### PR TITLE
USB support for stm32f4 discovery board

### DIFF
--- a/src/bitbox.mk
+++ b/src/bitbox.mk
@@ -10,11 +10,15 @@
 #GAME_C_FILES = test_data.c object.c test_game.c
 #GAME_H_FILES = test_data.h kernel.h object.h test_object.h
 
+MCU  = cortex-m4
+FPU = -mfloat-abi=hard -mfpu=fpv4-sp-d16 -D__FPU_USED=1
+OPT = -O3 -falign-functions=16 -fno-inline -fomit-frame-pointer
+
 CC = arm-none-eabi-gcc
 LD = arm-none-eabi-gcc
 OBJCOPY = arm-none-eabi-objcopy
 
-DEFINES =	-DARM_MATH_CM4 -DOVERCLOCK -DAUDIO -DGAMEPAD
+DEFINES =	-DARM_MATH_CM4 -DOVERCLOCK  -DAUDIO  -DGAMEPAD -DUSE_USB_OTG_HS -DUSE_STDPERIPH_DRIVER -DUSE_EMBEDDED_PHY -DUSE_USB_OTG_FS
 #-DPLATFORM_BITBOX
 
 C_OPTS = -std=c99 \
@@ -24,10 +28,10 @@ C_OPTS = -std=c99 \
 		-I../lib/ \
 		-g \
 		-Werror \
-		-O3 \
-		-mlittle-endian \
-		-funroll-loops \
-		-fplan9-extensions
+                -O3 \
+                -mlittle-endian 
+#                 -funroll-loops \
+#                -fplan9-extensions
 
 LIBS =	-lm
 
@@ -36,7 +40,26 @@ LIB_SOURCE_DIR =../lib
 BUILD_DIR =build
 #LIB_FILES = ../lib/object.c
 
-KERNEL_FILES = startup.c system.c new_vga.c bitbox_main.c gamepad.c audio.c
+KERNEL_FILES = startup.c system.c new_vga.c bitbox_main.c gamepad.c audio.c \
+ stm32fxxx_it.c \
+ stm32f4xx_gpio.c \
+ stm32f4xx_rcc.c \
+ stm32f4xx_tim.c \
+ misc.c \
+ usb_bsp.c \
+ usbh_usr.c \
+ usb_core.c \
+ usb_hcd.c \
+ usb_hcd_int.c \
+ usbh_core.c \
+ usbh_hcs.c \
+ usbh_hid_core.c \
+ usbh_hid_keybd.c \
+ usbh_hid_mouse.c \
+ usbh_hid_gamepad.c \
+ usbh_ioreq.c \
+ usbh_stdreq.c 
+
 
 C_FILES = $(LIB_FILES) $(GAME_C_FILES) $(KERNEL_FILES)
 		

--- a/src/lib/bitbox_main.c
+++ b/src/lib/bitbox_main.c
@@ -1,45 +1,131 @@
 #include "../lib/system.h"
 #include "../lib/kernel.h"
 
+#ifdef GAMEPAD
 #include "gamepad.h"
+#include "usb_bsp.h"
+#include "usbh_core.h"
+#include "usbh_usr.h"
+#include "usbh_hid_core.h"
+#include "usbh_hid_gamepad.h"
+#endif
 
+#ifdef GAMEPAD
+/** @defgroup USBH_USR_MAIN_Private_Variables
+* @{
+*/
+#ifdef USB_OTG_HS_INTERNAL_DMA_ENABLED
+  #if defined ( __ICCARM__ ) /*!< IAR Compiler */
+    #pragma data_alignment=4   
+  #endif
+#endif /* USB_OTG_HS_INTERNAL_DMA_ENABLED */
+__ALIGN_BEGIN USB_OTG_CORE_HANDLE           USB_OTG_Core __ALIGN_END ;
+
+#ifdef USB_OTG_HS_INTERNAL_DMA_ENABLED
+  #if defined ( __ICCARM__ ) /*!< IAR Compiler */
+    #pragma data_alignment=4   
+  #endif
+#endif /* USB_OTG_HS_INTERNAL_DMA_ENABLED */
+__ALIGN_BEGIN USBH_HOST                     USB_Host __ALIGN_END ;
+
+#ifdef USB_OTG_HS_INTERNAL_DMA_ENABLED
+  #if defined ( __ICCARM__ ) /*!< IAR Compiler */
+    #pragma data_alignment=4   
+  #endif
+#endif /* USB_OTG_HS_INTERNAL_DMA_ENABLED */
+__ALIGN_BEGIN USB_OTG_CORE_HANDLE           USB_OTG_FS_Core __ALIGN_END ;
+
+#ifdef USB_OTG_HS_INTERNAL_DMA_ENABLED
+  #if defined ( __ICCARM__ ) /*!< IAR Compiler */
+    #pragma data_alignment=4   
+  #endif
+#endif /* USB_OTG_HS_INTERNAL_DMA_ENABLED */
+__ALIGN_BEGIN USBH_HOST                     USB_FS_Host __ALIGN_END ;
+/**
+* @}
+*/ 
+#endif
 
 void init_led()
 {
-	RCC->AHB1ENR |= RCC_AHB1ENR_GPIOAEN; // enable gpioA
-    GPIOA->MODER |= (1 << 16) ; // set pin 8 to be general purpose output
+//	RCC->AHB1ENR |= RCC_AHB1ENR_GPIODEN; // enable gpioA
+//    GPIOD->MODER |= (1 << 24) ; // set pin 8 to be general purpose output
 }
 
 void toggle_led()
 {
-	GPIOA->ODR ^= 1<<8; // led on/off
+//	GPIOD->ODR ^= 1<<12; // led on/off
 }
 
 
 void main()
 {
 	InitializeSystem();
-	vga640_setup();
 	init_led();
 
 	#ifdef GAMEPAD
-	gamepad_init();
+  /* Init Host Library */
+#ifdef USE_USB_OTG_HS
+  USBH_Init(&USB_OTG_Core, 
+            USB_OTG_HS_CORE_ID,
+            &USB_Host,
+            &HID_cb, 
+            &USR_Callbacks);
+#endif
+
+  /* Init FS Core */
+#ifdef USE_USB_OTG_FS
+  USBH_Init(&USB_OTG_FS_Core, 
+            USB_OTG_FS_CORE_ID,
+            &USB_FS_Host,
+            &HID_cb, 
+            &USR_Callbacks);
+#endif
+	// gamepad_init();
 	#endif
+
+        /*
+        #ifdef USE_USB_OTG_HS
+        do { // while (frame < 1000) {
+           USBH_Process(&USB_OTG_Core, &USB_Host);
+	   USBH_Process(&USB_OTG_FS_Core, &USB_FS_Host);
+	 } while (USBH_Usr_InputDone == 0);
+        #endif
+        */
 
 	#ifdef AUDIO
 	audio_init();
 	#endif
 	
+	vga640_setup();
+
 	uint32_t oframe;
+	__IO uint32_t oline;
 
 	game_init();
+
 	while (1)
 	{
 		game_frame();
 		
 		// wait next frame
+                gamepad1 = 0;
 		oframe=frame;
-		while (oframe==frame);
+                #ifdef GAMEPAD
+		do {
+                 oline = line;
+	         #ifdef USE_USB_OTG_HS
+                 USBH_Process(&USB_OTG_Core, &USB_Host);
+                 gamepad1 |= HID_GAMEPAD_Data[0].button;
+                 #endif
+                 #ifdef USE_USB_OTG_FS
+                 USBH_Process(&USB_OTG_FS_Core, &USB_FS_Host);
+                 gamepad1 |= HID_GAMEPAD_Data[1].button;
+                 #endif
+		 // while (oline == line); 
+                // } while (line < 450);
+                #endif
+		} while (oframe==frame);
 
 		if (frame%32 == 0) toggle_led(); // each second
 

--- a/src/lib/misc.c
+++ b/src/lib/misc.c
@@ -1,0 +1,249 @@
+/**
+  ******************************************************************************
+  * @file    misc.c
+  * @author  MCD Application Team
+  * @version V1.0.2
+  * @date    05-March-2012
+  * @brief   This file provides all the miscellaneous firmware functions (add-on
+  *          to CMSIS functions).
+  *          
+  *  @verbatim   
+  *                               
+  *          ===================================================================      
+  *                        How to configure Interrupts using driver 
+  *          ===================================================================      
+  * 
+  *            This section provide functions allowing to configure the NVIC interrupts (IRQ).
+  *            The Cortex-M4 exceptions are managed by CMSIS functions.
+  *
+  *            1. Configure the NVIC Priority Grouping using NVIC_PriorityGroupConfig()
+  *                function according to the following table.
+ 
+  *  The table below gives the allowed values of the pre-emption priority and subpriority according
+  *  to the Priority Grouping configuration performed by NVIC_PriorityGroupConfig function
+  *    ==========================================================================================================================
+  *      NVIC_PriorityGroup   | NVIC_IRQChannelPreemptionPriority | NVIC_IRQChannelSubPriority  |       Description
+  *    ==========================================================================================================================
+  *     NVIC_PriorityGroup_0  |                0                  |            0-15             | 0 bits for pre-emption priority
+  *                           |                                   |                             | 4 bits for subpriority
+  *    --------------------------------------------------------------------------------------------------------------------------
+  *     NVIC_PriorityGroup_1  |                0-1                |            0-7              | 1 bits for pre-emption priority
+  *                           |                                   |                             | 3 bits for subpriority
+  *    --------------------------------------------------------------------------------------------------------------------------    
+  *     NVIC_PriorityGroup_2  |                0-3                |            0-3              | 2 bits for pre-emption priority
+  *                           |                                   |                             | 2 bits for subpriority
+  *    --------------------------------------------------------------------------------------------------------------------------    
+  *     NVIC_PriorityGroup_3  |                0-7                |            0-1              | 3 bits for pre-emption priority
+  *                           |                                   |                             | 1 bits for subpriority
+  *    --------------------------------------------------------------------------------------------------------------------------    
+  *     NVIC_PriorityGroup_4  |                0-15               |            0                | 4 bits for pre-emption priority
+  *                           |                                   |                             | 0 bits for subpriority                       
+  *    ==========================================================================================================================     
+  *
+  *            2. Enable and Configure the priority of the selected IRQ Channels using NVIC_Init()  
+  *
+  * @note  When the NVIC_PriorityGroup_0 is selected, IRQ pre-emption is no more possible. 
+  *        The pending IRQ priority will be managed only by the subpriority.
+  *
+  * @note  IRQ priority order (sorted by highest to lowest priority):
+  *         - Lowest pre-emption priority
+  *         - Lowest subpriority
+  *         - Lowest hardware priority (IRQ number)
+  *
+  *  @endverbatim
+  *
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT 2012 STMicroelectronics</center></h2>
+  *
+  * Licensed under MCD-ST Liberty SW License Agreement V2, (the "License");
+  * You may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at:
+  *
+  *        http://www.st.com/software_license_agreement_liberty_v2
+  *
+  * Unless required by applicable law or agreed to in writing, software 
+  * distributed under the License is distributed on an "AS IS" BASIS, 
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "misc.h"
+
+/** @addtogroup STM32F4xx_StdPeriph_Driver
+  * @{
+  */
+
+/** @defgroup MISC 
+  * @brief MISC driver modules
+  * @{
+  */
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+#define AIRCR_VECTKEY_MASK    ((uint32_t)0x05FA0000)
+
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/* Private functions ---------------------------------------------------------*/
+
+/** @defgroup MISC_Private_Functions
+  * @{
+  */
+
+/**
+  * @brief  Configures the priority grouping: pre-emption priority and subpriority.
+  * @param  NVIC_PriorityGroup: specifies the priority grouping bits length. 
+  *   This parameter can be one of the following values:
+  *     @arg NVIC_PriorityGroup_0: 0 bits for pre-emption priority
+  *                                4 bits for subpriority
+  *     @arg NVIC_PriorityGroup_1: 1 bits for pre-emption priority
+  *                                3 bits for subpriority
+  *     @arg NVIC_PriorityGroup_2: 2 bits for pre-emption priority
+  *                                2 bits for subpriority
+  *     @arg NVIC_PriorityGroup_3: 3 bits for pre-emption priority
+  *                                1 bits for subpriority
+  *     @arg NVIC_PriorityGroup_4: 4 bits for pre-emption priority
+  *                                0 bits for subpriority
+  * @note   When the NVIC_PriorityGroup_0 is selected, IRQ pre-emption is no more possible. 
+  *         The pending IRQ priority will be managed only by the subpriority. 
+  * @retval None
+  */
+void NVIC_PriorityGroupConfig(uint32_t NVIC_PriorityGroup)
+{
+  /* Check the parameters */
+  assert_param(IS_NVIC_PRIORITY_GROUP(NVIC_PriorityGroup));
+  
+  /* Set the PRIGROUP[10:8] bits according to NVIC_PriorityGroup value */
+  SCB->AIRCR = AIRCR_VECTKEY_MASK | NVIC_PriorityGroup;
+}
+
+/**
+  * @brief  Initializes the NVIC peripheral according to the specified
+  *         parameters in the NVIC_InitStruct.
+  * @note   To configure interrupts priority correctly, the NVIC_PriorityGroupConfig()
+  *         function should be called before. 
+  * @param  NVIC_InitStruct: pointer to a NVIC_InitTypeDef structure that contains
+  *         the configuration information for the specified NVIC peripheral.
+  * @retval None
+  */
+void NVIC_Init(NVIC_InitTypeDef* NVIC_InitStruct)
+{
+  uint8_t tmppriority = 0x00, tmppre = 0x00, tmpsub = 0x0F;
+  
+  /* Check the parameters */
+  assert_param(IS_FUNCTIONAL_STATE(NVIC_InitStruct->NVIC_IRQChannelCmd));
+  assert_param(IS_NVIC_PREEMPTION_PRIORITY(NVIC_InitStruct->NVIC_IRQChannelPreemptionPriority));  
+  assert_param(IS_NVIC_SUB_PRIORITY(NVIC_InitStruct->NVIC_IRQChannelSubPriority));
+    
+  if (NVIC_InitStruct->NVIC_IRQChannelCmd != DISABLE)
+  {
+    /* Compute the Corresponding IRQ Priority --------------------------------*/    
+    tmppriority = (0x700 - ((SCB->AIRCR) & (uint32_t)0x700))>> 0x08;
+    tmppre = (0x4 - tmppriority);
+    tmpsub = tmpsub >> tmppriority;
+
+    tmppriority = NVIC_InitStruct->NVIC_IRQChannelPreemptionPriority << tmppre;
+    tmppriority |=  (uint8_t)(NVIC_InitStruct->NVIC_IRQChannelSubPriority & tmpsub);
+        
+    tmppriority = tmppriority << 0x04;
+        
+    NVIC->IP[NVIC_InitStruct->NVIC_IRQChannel] = tmppriority;
+    
+    /* Enable the Selected IRQ Channels --------------------------------------*/
+    NVIC->ISER[NVIC_InitStruct->NVIC_IRQChannel >> 0x05] =
+      (uint32_t)0x01 << (NVIC_InitStruct->NVIC_IRQChannel & (uint8_t)0x1F);
+  }
+  else
+  {
+    /* Disable the Selected IRQ Channels -------------------------------------*/
+    NVIC->ICER[NVIC_InitStruct->NVIC_IRQChannel >> 0x05] =
+      (uint32_t)0x01 << (NVIC_InitStruct->NVIC_IRQChannel & (uint8_t)0x1F);
+  }
+}
+
+/**
+  * @brief  Sets the vector table location and Offset.
+  * @param  NVIC_VectTab: specifies if the vector table is in RAM or FLASH memory.
+  *   This parameter can be one of the following values:
+  *     @arg NVIC_VectTab_RAM: Vector Table in internal SRAM.
+  *     @arg NVIC_VectTab_FLASH: Vector Table in internal FLASH.
+  * @param  Offset: Vector Table base offset field. This value must be a multiple of 0x200.
+  * @retval None
+  */
+void NVIC_SetVectorTable(uint32_t NVIC_VectTab, uint32_t Offset)
+{ 
+  /* Check the parameters */
+  assert_param(IS_NVIC_VECTTAB(NVIC_VectTab));
+  assert_param(IS_NVIC_OFFSET(Offset));  
+   
+  SCB->VTOR = NVIC_VectTab | (Offset & (uint32_t)0x1FFFFF80);
+}
+
+/**
+  * @brief  Selects the condition for the system to enter low power mode.
+  * @param  LowPowerMode: Specifies the new mode for the system to enter low power mode.
+  *   This parameter can be one of the following values:
+  *     @arg NVIC_LP_SEVONPEND: Low Power SEV on Pend.
+  *     @arg NVIC_LP_SLEEPDEEP: Low Power DEEPSLEEP request.
+  *     @arg NVIC_LP_SLEEPONEXIT: Low Power Sleep on Exit.
+  * @param  NewState: new state of LP condition. This parameter can be: ENABLE or DISABLE.
+  * @retval None
+  */
+void NVIC_SystemLPConfig(uint8_t LowPowerMode, FunctionalState NewState)
+{
+  /* Check the parameters */
+  assert_param(IS_NVIC_LP(LowPowerMode));
+  assert_param(IS_FUNCTIONAL_STATE(NewState));  
+  
+  if (NewState != DISABLE)
+  {
+    SCB->SCR |= LowPowerMode;
+  }
+  else
+  {
+    SCB->SCR &= (uint32_t)(~(uint32_t)LowPowerMode);
+  }
+}
+
+/**
+  * @brief  Configures the SysTick clock source.
+  * @param  SysTick_CLKSource: specifies the SysTick clock source.
+  *   This parameter can be one of the following values:
+  *     @arg SysTick_CLKSource_HCLK_Div8: AHB clock divided by 8 selected as SysTick clock source.
+  *     @arg SysTick_CLKSource_HCLK: AHB clock selected as SysTick clock source.
+  * @retval None
+  */
+void SysTick_CLKSourceConfig(uint32_t SysTick_CLKSource)
+{
+  /* Check the parameters */
+  assert_param(IS_SYSTICK_CLK_SOURCE(SysTick_CLKSource));
+  if (SysTick_CLKSource == SysTick_CLKSource_HCLK)
+  {
+    SysTick->CTRL |= SysTick_CLKSource_HCLK;
+  }
+  else
+  {
+    SysTick->CTRL &= SysTick_CLKSource_HCLK_Div8;
+  }
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/src/lib/misc.h
+++ b/src/lib/misc.h
@@ -1,0 +1,178 @@
+/**
+  ******************************************************************************
+  * @file    misc.h
+  * @author  MCD Application Team
+  * @version V1.0.2
+  * @date    05-March-2012
+  * @brief   This file contains all the functions prototypes for the miscellaneous
+  *          firmware library functions (add-on to CMSIS functions).
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT 2012 STMicroelectronics</center></h2>
+  *
+  * Licensed under MCD-ST Liberty SW License Agreement V2, (the "License");
+  * You may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at:
+  *
+  *        http://www.st.com/software_license_agreement_liberty_v2
+  *
+  * Unless required by applicable law or agreed to in writing, software 
+  * distributed under the License is distributed on an "AS IS" BASIS, 
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __MISC_H
+#define __MISC_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f4xx.h"
+
+/** @addtogroup STM32F4xx_StdPeriph_Driver
+  * @{
+  */
+
+/** @addtogroup MISC
+  * @{
+  */
+
+/* Exported types ------------------------------------------------------------*/
+
+/** 
+  * @brief  NVIC Init Structure definition  
+  */
+
+typedef struct
+{
+  uint8_t NVIC_IRQChannel;                    /*!< Specifies the IRQ channel to be enabled or disabled.
+                                                   This parameter can be an enumerator of @ref IRQn_Type 
+                                                   enumeration (For the complete STM32 Devices IRQ Channels
+                                                   list, please refer to stm32f4xx.h file) */
+
+  uint8_t NVIC_IRQChannelPreemptionPriority;  /*!< Specifies the pre-emption priority for the IRQ channel
+                                                   specified in NVIC_IRQChannel. This parameter can be a value
+                                                   between 0 and 15 as described in the table @ref MISC_NVIC_Priority_Table
+                                                   A lower priority value indicates a higher priority */
+
+  uint8_t NVIC_IRQChannelSubPriority;         /*!< Specifies the subpriority level for the IRQ channel specified
+                                                   in NVIC_IRQChannel. This parameter can be a value
+                                                   between 0 and 15 as described in the table @ref MISC_NVIC_Priority_Table
+                                                   A lower priority value indicates a higher priority */
+
+  FunctionalState NVIC_IRQChannelCmd;         /*!< Specifies whether the IRQ channel defined in NVIC_IRQChannel
+                                                   will be enabled or disabled. 
+                                                   This parameter can be set either to ENABLE or DISABLE */   
+} NVIC_InitTypeDef;
+ 
+/* Exported constants --------------------------------------------------------*/
+
+/** @defgroup MISC_Exported_Constants
+  * @{
+  */
+
+/** @defgroup MISC_Vector_Table_Base 
+  * @{
+  */
+
+#define NVIC_VectTab_RAM             ((uint32_t)0x20000000)
+#define NVIC_VectTab_FLASH           ((uint32_t)0x08000000)
+#define IS_NVIC_VECTTAB(VECTTAB) (((VECTTAB) == NVIC_VectTab_RAM) || \
+                                  ((VECTTAB) == NVIC_VectTab_FLASH))
+/**
+  * @}
+  */
+
+/** @defgroup MISC_System_Low_Power 
+  * @{
+  */
+
+#define NVIC_LP_SEVONPEND            ((uint8_t)0x10)
+#define NVIC_LP_SLEEPDEEP            ((uint8_t)0x04)
+#define NVIC_LP_SLEEPONEXIT          ((uint8_t)0x02)
+#define IS_NVIC_LP(LP) (((LP) == NVIC_LP_SEVONPEND) || \
+                        ((LP) == NVIC_LP_SLEEPDEEP) || \
+                        ((LP) == NVIC_LP_SLEEPONEXIT))
+/**
+  * @}
+  */
+
+/** @defgroup MISC_Preemption_Priority_Group 
+  * @{
+  */
+
+#define NVIC_PriorityGroup_0         ((uint32_t)0x700) /*!< 0 bits for pre-emption priority
+                                                            4 bits for subpriority */
+#define NVIC_PriorityGroup_1         ((uint32_t)0x600) /*!< 1 bits for pre-emption priority
+                                                            3 bits for subpriority */
+#define NVIC_PriorityGroup_2         ((uint32_t)0x500) /*!< 2 bits for pre-emption priority
+                                                            2 bits for subpriority */
+#define NVIC_PriorityGroup_3         ((uint32_t)0x400) /*!< 3 bits for pre-emption priority
+                                                            1 bits for subpriority */
+#define NVIC_PriorityGroup_4         ((uint32_t)0x300) /*!< 4 bits for pre-emption priority
+                                                            0 bits for subpriority */
+
+#define IS_NVIC_PRIORITY_GROUP(GROUP) (((GROUP) == NVIC_PriorityGroup_0) || \
+                                       ((GROUP) == NVIC_PriorityGroup_1) || \
+                                       ((GROUP) == NVIC_PriorityGroup_2) || \
+                                       ((GROUP) == NVIC_PriorityGroup_3) || \
+                                       ((GROUP) == NVIC_PriorityGroup_4))
+
+#define IS_NVIC_PREEMPTION_PRIORITY(PRIORITY)  ((PRIORITY) < 0x10)
+
+#define IS_NVIC_SUB_PRIORITY(PRIORITY)  ((PRIORITY) < 0x10)
+
+#define IS_NVIC_OFFSET(OFFSET)  ((OFFSET) < 0x000FFFFF)
+
+/**
+  * @}
+  */
+
+/** @defgroup MISC_SysTick_clock_source 
+  * @{
+  */
+
+#define SysTick_CLKSource_HCLK_Div8    ((uint32_t)0xFFFFFFFB)
+#define SysTick_CLKSource_HCLK         ((uint32_t)0x00000004)
+#define IS_SYSTICK_CLK_SOURCE(SOURCE) (((SOURCE) == SysTick_CLKSource_HCLK) || \
+                                       ((SOURCE) == SysTick_CLKSource_HCLK_Div8))
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Exported macro ------------------------------------------------------------*/
+/* Exported functions --------------------------------------------------------*/
+
+void NVIC_PriorityGroupConfig(uint32_t NVIC_PriorityGroup);
+void NVIC_Init(NVIC_InitTypeDef* NVIC_InitStruct);
+void NVIC_SetVectorTable(uint32_t NVIC_VectTab, uint32_t Offset);
+void NVIC_SystemLPConfig(uint8_t LowPowerMode, FunctionalState NewState);
+void SysTick_CLKSourceConfig(uint32_t SysTick_CLKSource);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __MISC_H */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/src/lib/stm32f4xx_conf.h
+++ b/src/lib/stm32f4xx_conf.h
@@ -1,0 +1,94 @@
+/**
+  ******************************************************************************
+  * @file    stm32f4xx_conf.h  
+  * @author  MCD Application Team
+  * @version V2.1.0
+  * @date    19-March-2012
+  * @brief   Library configuration file.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT 2012 STMicroelectronics</center></h2>
+  *
+  * Licensed under MCD-ST Liberty SW License Agreement V2, (the "License");
+  * You may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at:
+  *
+  *        http://www.st.com/software_license_agreement_liberty_v2
+  *
+  * Unless required by applicable law or agreed to in writing, software 
+  * distributed under the License is distributed on an "AS IS" BASIS, 
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  *
+  ******************************************************************************
+  */  
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32F4xx_CONF_H
+#define __STM32F4xx_CONF_H
+
+/* Includes ------------------------------------------------------------------*/
+/* Uncomment the line below to enable peripheral header file inclusion */
+// #include "stm32f4xx_adc.h"
+// #include "stm32f4xx_can.h"
+// #include "stm32f4xx_crc.h"
+// #include "stm32f4xx_cryp.h"
+// #include "stm32f4xx_dac.h"
+// #include "stm32f4xx_dbgmcu.h"
+// #include "stm32f4xx_dcmi.h"
+// #include "stm32f4xx_dma.h"
+// #include "stm32f4xx_exti.h"
+// #include "stm32f4xx_flash.h"
+// #include "stm32f4xx_fsmc.h"
+// #include "stm32f4xx_hash.h"
+#include "stm32f4xx_gpio.h"
+// #include "stm32f4xx_i2c.h"
+// #include "stm32f4xx_iwdg.h"
+// #include "stm32f4xx_pwr.h"
+#include "stm32f4xx_rcc.h"
+// #include "stm32f4xx_rng.h"
+// #include "stm32f4xx_rtc.h"
+// #include "stm32f4xx_sdio.h"
+// #include "stm32f4xx_spi.h"
+// #include "stm32f4xx_syscfg.h"
+#include "stm32f4xx_tim.h"
+// #include "stm32f4xx_usart.h"
+// #include "stm32f4xx_wwdg.h"
+#include "misc.h" /* High level functions for NVIC and SysTick (add-on to CMSIS functions) */
+
+/* Exported types ------------------------------------------------------------*/
+/* Exported constants --------------------------------------------------------*/
+
+/* If an external clock source is used, then the value of the following define 
+   should be set to the value of the external clock source, else, if no external 
+   clock is used, keep this define commented */
+/*#define I2S_EXTERNAL_CLOCK_VAL   12288000 */ /* Value of the external clock in Hz */
+
+
+/* Uncomment the line below to expanse the "assert_param" macro in the 
+   Standard Peripheral Library drivers code */
+/* #define USE_FULL_ASSERT    1 */
+
+/* Exported macro ------------------------------------------------------------*/
+#ifdef  USE_FULL_ASSERT
+
+/**
+  * @brief  The assert_param macro is used for function's parameters check.
+  * @param  expr: If expr is false, it calls assert_failed function
+  *   which reports the name of the source file and the source
+  *   line number of the call that failed. 
+  *   If expr is true, it returns no value.
+  * @retval None
+  */
+  #define assert_param(expr) ((expr) ? (void)0 : assert_failed((uint8_t *)__FILE__, __LINE__))
+/* Exported functions ------------------------------------------------------- */
+  void assert_failed(uint8_t* file, uint32_t line);
+#else
+  #define assert_param(expr) ((void)0)
+#endif /* USE_FULL_ASSERT */
+
+#endif /* __STM32F4xx_CONF_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/src/lib/stm32f4xx_gpio.c
+++ b/src/lib/stm32f4xx_gpio.c
@@ -1,0 +1,567 @@
+/**
+  ******************************************************************************
+  * @file    stm32f4xx_gpio.c
+  * @author  MCD Application Team
+  * @version V1.0.2
+  * @date    05-March-2012
+  * @brief   This file provides firmware functions to manage the following 
+  *          functionalities of the GPIO peripheral:           
+  *           - Initialization and Configuration
+  *           - GPIO Read and Write
+  *           - GPIO Alternate functions configuration
+  * 
+  *  @verbatim
+  *
+  *          ===================================================================
+  *                                 How to use this driver
+  *          ===================================================================       
+  *           1. Enable the GPIO AHB clock using the following function
+  *                RCC_AHB1PeriphClockCmd(RCC_AHB1Periph_GPIOx, ENABLE);
+  *             
+  *           2. Configure the GPIO pin(s) using GPIO_Init()
+  *              Four possible configuration are available for each pin:
+  *                - Input: Floating, Pull-up, Pull-down.
+  *                - Output: Push-Pull (Pull-up, Pull-down or no Pull)
+  *                          Open Drain (Pull-up, Pull-down or no Pull).
+  *                  In output mode, the speed is configurable: 2 MHz, 25 MHz,
+  *                  50 MHz or 100 MHz.
+  *                - Alternate Function: Push-Pull (Pull-up, Pull-down or no Pull)
+  *                                      Open Drain (Pull-up, Pull-down or no Pull).
+  *                - Analog: required mode when a pin is to be used as ADC channel
+  *                          or DAC output.
+  * 
+  *          3- Peripherals alternate function:
+  *              - For ADC and DAC, configure the desired pin in analog mode using 
+  *                  GPIO_InitStruct->GPIO_Mode = GPIO_Mode_AN;
+  *              - For other peripherals (TIM, USART...):
+  *                 - Connect the pin to the desired peripherals' Alternate 
+  *                   Function (AF) using GPIO_PinAFConfig() function
+  *                 - Configure the desired pin in alternate function mode using
+  *                   GPIO_InitStruct->GPIO_Mode = GPIO_Mode_AF
+  *                 - Select the type, pull-up/pull-down and output speed via 
+  *                   GPIO_PuPd, GPIO_OType and GPIO_Speed members
+  *                 - Call GPIO_Init() function
+  *        
+  *          4. To get the level of a pin configured in input mode use GPIO_ReadInputDataBit()
+  *          
+  *          5. To set/reset the level of a pin configured in output mode use
+  *             GPIO_SetBits()/GPIO_ResetBits()
+  *               
+  *          6. During and just after reset, the alternate functions are not 
+  *             active and the GPIO pins are configured in input floating mode
+  *             (except JTAG pins).
+  *
+  *          7. The LSE oscillator pins OSC32_IN and OSC32_OUT can be used as 
+  *             general-purpose (PC14 and PC15, respectively) when the LSE
+  *             oscillator is off. The LSE has priority over the GPIO function.
+  *
+  *          8. The HSE oscillator pins OSC_IN/OSC_OUT can be used as 
+  *             general-purpose PH0 and PH1, respectively, when the HSE 
+  *             oscillator is off. The HSE has priority over the GPIO function.
+  *             
+  *  @endverbatim        
+  *
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT 2012 STMicroelectronics</center></h2>
+  *
+  * Licensed under MCD-ST Liberty SW License Agreement V2, (the "License");
+  * You may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at:
+  *
+  *        http://www.st.com/software_license_agreement_liberty_v2
+  *
+  * Unless required by applicable law or agreed to in writing, software 
+  * distributed under the License is distributed on an "AS IS" BASIS, 
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f4xx_gpio.h"
+#include "stm32f4xx_rcc.h"
+
+/** @addtogroup STM32F4xx_StdPeriph_Driver
+  * @{
+  */
+
+/** @defgroup GPIO 
+  * @brief GPIO driver modules
+  * @{
+  */ 
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/* Private functions ---------------------------------------------------------*/
+
+/** @defgroup GPIO_Private_Functions
+  * @{
+  */ 
+
+/** @defgroup GPIO_Group1 Initialization and Configuration
+ *  @brief   Initialization and Configuration
+ *
+@verbatim   
+ ===============================================================================
+                        Initialization and Configuration
+ ===============================================================================  
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Deinitializes the GPIOx peripheral registers to their default reset values.
+  * @note   By default, The GPIO pins are configured in input floating mode (except JTAG pins).
+  * @param  GPIOx: where x can be (A..I) to select the GPIO peripheral.
+  * @retval None
+  */
+void GPIO_DeInit(GPIO_TypeDef* GPIOx)
+{
+  /* Check the parameters */
+  assert_param(IS_GPIO_ALL_PERIPH(GPIOx));
+
+  if (GPIOx == GPIOA)
+  {
+    RCC_AHB1PeriphResetCmd(RCC_AHB1Periph_GPIOA, ENABLE);
+    RCC_AHB1PeriphResetCmd(RCC_AHB1Periph_GPIOA, DISABLE);
+  }
+  else if (GPIOx == GPIOB)
+  {
+    RCC_AHB1PeriphResetCmd(RCC_AHB1Periph_GPIOB, ENABLE);
+    RCC_AHB1PeriphResetCmd(RCC_AHB1Periph_GPIOB, DISABLE);
+  }
+  else if (GPIOx == GPIOC)
+  {
+    RCC_AHB1PeriphResetCmd(RCC_AHB1Periph_GPIOC, ENABLE);
+    RCC_AHB1PeriphResetCmd(RCC_AHB1Periph_GPIOC, DISABLE);
+  }
+  else if (GPIOx == GPIOD)
+  {
+    RCC_AHB1PeriphResetCmd(RCC_AHB1Periph_GPIOD, ENABLE);
+    RCC_AHB1PeriphResetCmd(RCC_AHB1Periph_GPIOD, DISABLE);
+  }
+  else if (GPIOx == GPIOE)
+  {
+    RCC_AHB1PeriphResetCmd(RCC_AHB1Periph_GPIOE, ENABLE);
+    RCC_AHB1PeriphResetCmd(RCC_AHB1Periph_GPIOE, DISABLE);
+  }
+  else if (GPIOx == GPIOF)
+  {
+    RCC_AHB1PeriphResetCmd(RCC_AHB1Periph_GPIOF, ENABLE);
+    RCC_AHB1PeriphResetCmd(RCC_AHB1Periph_GPIOF, DISABLE);
+  }
+  else if (GPIOx == GPIOG)
+  {
+    RCC_AHB1PeriphResetCmd(RCC_AHB1Periph_GPIOG, ENABLE);
+    RCC_AHB1PeriphResetCmd(RCC_AHB1Periph_GPIOG, DISABLE);
+  }
+  else if (GPIOx == GPIOH)
+  {
+    RCC_AHB1PeriphResetCmd(RCC_AHB1Periph_GPIOH, ENABLE);
+    RCC_AHB1PeriphResetCmd(RCC_AHB1Periph_GPIOH, DISABLE);
+  }
+  else
+  {
+    if (GPIOx == GPIOI)
+    {
+      RCC_AHB1PeriphResetCmd(RCC_AHB1Periph_GPIOI, ENABLE);
+      RCC_AHB1PeriphResetCmd(RCC_AHB1Periph_GPIOI, DISABLE);
+    }
+  }
+}
+
+/**
+  * @brief  Initializes the GPIOx peripheral according to the specified parameters in the GPIO_InitStruct.
+  * @param  GPIOx: where x can be (A..I) to select the GPIO peripheral.
+  * @param  GPIO_InitStruct: pointer to a GPIO_InitTypeDef structure that contains
+  *         the configuration information for the specified GPIO peripheral.
+  * @retval None
+  */
+void GPIO_Init(GPIO_TypeDef* GPIOx, GPIO_InitTypeDef* GPIO_InitStruct)
+{
+  uint32_t pinpos = 0x00, pos = 0x00 , currentpin = 0x00;
+
+  /* Check the parameters */
+  assert_param(IS_GPIO_ALL_PERIPH(GPIOx));
+  assert_param(IS_GPIO_PIN(GPIO_InitStruct->GPIO_Pin));
+  assert_param(IS_GPIO_MODE(GPIO_InitStruct->GPIO_Mode));
+  assert_param(IS_GPIO_PUPD(GPIO_InitStruct->GPIO_PuPd));
+
+  /* -------------------------Configure the port pins---------------- */
+  /*-- GPIO Mode Configuration --*/
+  for (pinpos = 0x00; pinpos < 0x10; pinpos++)
+  {
+    pos = ((uint32_t)0x01) << pinpos;
+    /* Get the port pins position */
+    currentpin = (GPIO_InitStruct->GPIO_Pin) & pos;
+
+    if (currentpin == pos)
+    {
+      GPIOx->MODER  &= ~(GPIO_MODER_MODER0 << (pinpos * 2));
+      GPIOx->MODER |= (((uint32_t)GPIO_InitStruct->GPIO_Mode) << (pinpos * 2));
+
+      if ((GPIO_InitStruct->GPIO_Mode == GPIO_Mode_OUT) || (GPIO_InitStruct->GPIO_Mode == GPIO_Mode_AF))
+      {
+        /* Check Speed mode parameters */
+        assert_param(IS_GPIO_SPEED(GPIO_InitStruct->GPIO_Speed));
+
+        /* Speed mode configuration */
+        GPIOx->OSPEEDR &= ~(GPIO_OSPEEDER_OSPEEDR0 << (pinpos * 2));
+        GPIOx->OSPEEDR |= ((uint32_t)(GPIO_InitStruct->GPIO_Speed) << (pinpos * 2));
+
+        /* Check Output mode parameters */
+        assert_param(IS_GPIO_OTYPE(GPIO_InitStruct->GPIO_OType));
+
+        /* Output mode configuration*/
+        GPIOx->OTYPER  &= ~((GPIO_OTYPER_OT_0) << ((uint16_t)pinpos)) ;
+        GPIOx->OTYPER |= (uint16_t)(((uint16_t)GPIO_InitStruct->GPIO_OType) << ((uint16_t)pinpos));
+      }
+
+      /* Pull-up Pull down resistor configuration*/
+      GPIOx->PUPDR &= ~(GPIO_PUPDR_PUPDR0 << ((uint16_t)pinpos * 2));
+      GPIOx->PUPDR |= (((uint32_t)GPIO_InitStruct->GPIO_PuPd) << (pinpos * 2));
+    }
+  }
+}
+
+/**
+  * @brief  Fills each GPIO_InitStruct member with its default value.
+  * @param  GPIO_InitStruct : pointer to a GPIO_InitTypeDef structure which will be initialized.
+  * @retval None
+  */
+void GPIO_StructInit(GPIO_InitTypeDef* GPIO_InitStruct)
+{
+  /* Reset GPIO init structure parameters values */
+  GPIO_InitStruct->GPIO_Pin  = GPIO_Pin_All;
+  GPIO_InitStruct->GPIO_Mode = GPIO_Mode_IN;
+  GPIO_InitStruct->GPIO_Speed = GPIO_Speed_2MHz;
+  GPIO_InitStruct->GPIO_OType = GPIO_OType_PP;
+  GPIO_InitStruct->GPIO_PuPd = GPIO_PuPd_NOPULL;
+}
+
+/**
+  * @brief  Locks GPIO Pins configuration registers.
+  * @note   The locked registers are GPIOx_MODER, GPIOx_OTYPER, GPIOx_OSPEEDR,
+  *         GPIOx_PUPDR, GPIOx_AFRL and GPIOx_AFRH.
+  * @note   The configuration of the locked GPIO pins can no longer be modified
+  *         until the next reset.
+  * @param  GPIOx: where x can be (A..I) to select the GPIO peripheral.
+  * @param  GPIO_Pin: specifies the port bit to be locked.
+  *          This parameter can be any combination of GPIO_Pin_x where x can be (0..15).
+  * @retval None
+  */
+void GPIO_PinLockConfig(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin)
+{
+  __IO uint32_t tmp = 0x00010000;
+
+  /* Check the parameters */
+  assert_param(IS_GPIO_ALL_PERIPH(GPIOx));
+  assert_param(IS_GPIO_PIN(GPIO_Pin));
+
+  tmp |= GPIO_Pin;
+  /* Set LCKK bit */
+  GPIOx->LCKR = tmp;
+  /* Reset LCKK bit */
+  GPIOx->LCKR =  GPIO_Pin;
+  /* Set LCKK bit */
+  GPIOx->LCKR = tmp;
+  /* Read LCKK bit*/
+  tmp = GPIOx->LCKR;
+  /* Read LCKK bit*/
+  tmp = GPIOx->LCKR;
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup GPIO_Group2 GPIO Read and Write
+ *  @brief   GPIO Read and Write
+ *
+@verbatim   
+ ===============================================================================
+                              GPIO Read and Write
+ ===============================================================================  
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Reads the specified input port pin.
+  * @param  GPIOx: where x can be (A..I) to select the GPIO peripheral.
+  * @param  GPIO_Pin: specifies the port bit to read.
+  *         This parameter can be GPIO_Pin_x where x can be (0..15).
+  * @retval The input port pin value.
+  */
+uint8_t GPIO_ReadInputDataBit(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin)
+{
+  uint8_t bitstatus = 0x00;
+
+  /* Check the parameters */
+  assert_param(IS_GPIO_ALL_PERIPH(GPIOx));
+  assert_param(IS_GET_GPIO_PIN(GPIO_Pin));
+
+  if ((GPIOx->IDR & GPIO_Pin) != (uint32_t)Bit_RESET)
+  {
+    bitstatus = (uint8_t)Bit_SET;
+  }
+  else
+  {
+    bitstatus = (uint8_t)Bit_RESET;
+  }
+  return bitstatus;
+}
+
+/**
+  * @brief  Reads the specified GPIO input data port.
+  * @param  GPIOx: where x can be (A..I) to select the GPIO peripheral.
+  * @retval GPIO input data port value.
+  */
+uint16_t GPIO_ReadInputData(GPIO_TypeDef* GPIOx)
+{
+  /* Check the parameters */
+  assert_param(IS_GPIO_ALL_PERIPH(GPIOx));
+
+  return ((uint16_t)GPIOx->IDR);
+}
+
+/**
+  * @brief  Reads the specified output data port bit.
+  * @param  GPIOx: where x can be (A..I) to select the GPIO peripheral.
+  * @param  GPIO_Pin: specifies the port bit to read.
+  *          This parameter can be GPIO_Pin_x where x can be (0..15).
+  * @retval The output port pin value.
+  */
+uint8_t GPIO_ReadOutputDataBit(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin)
+{
+  uint8_t bitstatus = 0x00;
+
+  /* Check the parameters */
+  assert_param(IS_GPIO_ALL_PERIPH(GPIOx));
+  assert_param(IS_GET_GPIO_PIN(GPIO_Pin));
+
+  if ((GPIOx->ODR & GPIO_Pin) != (uint32_t)Bit_RESET)
+  {
+    bitstatus = (uint8_t)Bit_SET;
+  }
+  else
+  {
+    bitstatus = (uint8_t)Bit_RESET;
+  }
+  return bitstatus;
+}
+
+/**
+  * @brief  Reads the specified GPIO output data port.
+  * @param  GPIOx: where x can be (A..I) to select the GPIO peripheral.
+  * @retval GPIO output data port value.
+  */
+uint16_t GPIO_ReadOutputData(GPIO_TypeDef* GPIOx)
+{
+  /* Check the parameters */
+  assert_param(IS_GPIO_ALL_PERIPH(GPIOx));
+
+  return ((uint16_t)GPIOx->ODR);
+}
+
+/**
+  * @brief  Sets the selected data port bits.
+  * @note   This functions uses GPIOx_BSRR register to allow atomic read/modify 
+  *         accesses. In this way, there is no risk of an IRQ occurring between
+  *         the read and the modify access.
+  * @param  GPIOx: where x can be (A..I) to select the GPIO peripheral.
+  * @param  GPIO_Pin: specifies the port bits to be written.
+  *          This parameter can be any combination of GPIO_Pin_x where x can be (0..15).
+  * @retval None
+  */
+void GPIO_SetBits(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin)
+{
+  /* Check the parameters */
+  assert_param(IS_GPIO_ALL_PERIPH(GPIOx));
+  assert_param(IS_GPIO_PIN(GPIO_Pin));
+
+  GPIOx->BSRRL = GPIO_Pin;
+}
+
+/**
+  * @brief  Clears the selected data port bits.
+  * @note   This functions uses GPIOx_BSRR register to allow atomic read/modify 
+  *         accesses. In this way, there is no risk of an IRQ occurring between
+  *         the read and the modify access.
+  * @param  GPIOx: where x can be (A..I) to select the GPIO peripheral.
+  * @param  GPIO_Pin: specifies the port bits to be written.
+  *          This parameter can be any combination of GPIO_Pin_x where x can be (0..15).
+  * @retval None
+  */
+void GPIO_ResetBits(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin)
+{
+  /* Check the parameters */
+  assert_param(IS_GPIO_ALL_PERIPH(GPIOx));
+  assert_param(IS_GPIO_PIN(GPIO_Pin));
+
+  GPIOx->BSRRH = GPIO_Pin;
+}
+
+/**
+  * @brief  Sets or clears the selected data port bit.
+  * @param  GPIOx: where x can be (A..I) to select the GPIO peripheral.
+  * @param  GPIO_Pin: specifies the port bit to be written.
+  *          This parameter can be one of GPIO_Pin_x where x can be (0..15).
+  * @param  BitVal: specifies the value to be written to the selected bit.
+  *          This parameter can be one of the BitAction enum values:
+  *            @arg Bit_RESET: to clear the port pin
+  *            @arg Bit_SET: to set the port pin
+  * @retval None
+  */
+void GPIO_WriteBit(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin, BitAction BitVal)
+{
+  /* Check the parameters */
+  assert_param(IS_GPIO_ALL_PERIPH(GPIOx));
+  assert_param(IS_GET_GPIO_PIN(GPIO_Pin));
+  assert_param(IS_GPIO_BIT_ACTION(BitVal));
+
+  if (BitVal != Bit_RESET)
+  {
+    GPIOx->BSRRL = GPIO_Pin;
+  }
+  else
+  {
+    GPIOx->BSRRH = GPIO_Pin ;
+  }
+}
+
+/**
+  * @brief  Writes data to the specified GPIO data port.
+  * @param  GPIOx: where x can be (A..I) to select the GPIO peripheral.
+  * @param  PortVal: specifies the value to be written to the port output data register.
+  * @retval None
+  */
+void GPIO_Write(GPIO_TypeDef* GPIOx, uint16_t PortVal)
+{
+  /* Check the parameters */
+  assert_param(IS_GPIO_ALL_PERIPH(GPIOx));
+
+  GPIOx->ODR = PortVal;
+}
+
+/**
+  * @brief  Toggles the specified GPIO pins..
+  * @param  GPIOx: where x can be (A..I) to select the GPIO peripheral.
+  * @param  GPIO_Pin: Specifies the pins to be toggled.
+  * @retval None
+  */
+void GPIO_ToggleBits(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin)
+{
+  /* Check the parameters */
+  assert_param(IS_GPIO_ALL_PERIPH(GPIOx));
+
+  GPIOx->ODR ^= GPIO_Pin;
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup GPIO_Group3 GPIO Alternate functions configuration function
+ *  @brief   GPIO Alternate functions configuration function
+ *
+@verbatim   
+ ===============================================================================
+               GPIO Alternate functions configuration function
+ ===============================================================================  
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Changes the mapping of the specified pin.
+  * @param  GPIOx: where x can be (A..I) to select the GPIO peripheral.
+  * @param  GPIO_PinSource: specifies the pin for the Alternate function.
+  *         This parameter can be GPIO_PinSourcex where x can be (0..15).
+  * @param  GPIO_AFSelection: selects the pin to used as Alternate function.
+  *          This parameter can be one of the following values:
+  *            @arg GPIO_AF_RTC_50Hz: Connect RTC_50Hz pin to AF0 (default after reset) 
+  *            @arg GPIO_AF_MCO: Connect MCO pin (MCO1 and MCO2) to AF0 (default after reset) 
+  *            @arg GPIO_AF_TAMPER: Connect TAMPER pins (TAMPER_1 and TAMPER_2) to AF0 (default after reset) 
+  *            @arg GPIO_AF_SWJ: Connect SWJ pins (SWD and JTAG)to AF0 (default after reset) 
+  *            @arg GPIO_AF_TRACE: Connect TRACE pins to AF0 (default after reset)
+  *            @arg GPIO_AF_TIM1: Connect TIM1 pins to AF1
+  *            @arg GPIO_AF_TIM2: Connect TIM2 pins to AF1
+  *            @arg GPIO_AF_TIM3: Connect TIM3 pins to AF2
+  *            @arg GPIO_AF_TIM4: Connect TIM4 pins to AF2
+  *            @arg GPIO_AF_TIM5: Connect TIM5 pins to AF2
+  *            @arg GPIO_AF_TIM8: Connect TIM8 pins to AF3
+  *            @arg GPIO_AF_TIM9: Connect TIM9 pins to AF3
+  *            @arg GPIO_AF_TIM10: Connect TIM10 pins to AF3
+  *            @arg GPIO_AF_TIM11: Connect TIM11 pins to AF3
+  *            @arg GPIO_AF_I2C1: Connect I2C1 pins to AF4
+  *            @arg GPIO_AF_I2C2: Connect I2C2 pins to AF4
+  *            @arg GPIO_AF_I2C3: Connect I2C3 pins to AF4
+  *            @arg GPIO_AF_SPI1: Connect SPI1 pins to AF5
+  *            @arg GPIO_AF_SPI2: Connect SPI2/I2S2 pins to AF5
+  *            @arg GPIO_AF_SPI3: Connect SPI3/I2S3 pins to AF6
+  *            @arg GPIO_AF_I2S3ext: Connect I2S3ext pins to AF7
+  *            @arg GPIO_AF_USART1: Connect USART1 pins to AF7
+  *            @arg GPIO_AF_USART2: Connect USART2 pins to AF7
+  *            @arg GPIO_AF_USART3: Connect USART3 pins to AF7
+  *            @arg GPIO_AF_UART4: Connect UART4 pins to AF8
+  *            @arg GPIO_AF_UART5: Connect UART5 pins to AF8
+  *            @arg GPIO_AF_USART6: Connect USART6 pins to AF8
+  *            @arg GPIO_AF_CAN1: Connect CAN1 pins to AF9
+  *            @arg GPIO_AF_CAN2: Connect CAN2 pins to AF9
+  *            @arg GPIO_AF_TIM12: Connect TIM12 pins to AF9
+  *            @arg GPIO_AF_TIM13: Connect TIM13 pins to AF9
+  *            @arg GPIO_AF_TIM14: Connect TIM14 pins to AF9
+  *            @arg GPIO_AF_OTG_FS: Connect OTG_FS pins to AF10
+  *            @arg GPIO_AF_OTG_HS: Connect OTG_HS pins to AF10
+  *            @arg GPIO_AF_ETH: Connect ETHERNET pins to AF11
+  *            @arg GPIO_AF_FSMC: Connect FSMC pins to AF12
+  *            @arg GPIO_AF_OTG_HS_FS: Connect OTG HS (configured in FS) pins to AF12
+  *            @arg GPIO_AF_SDIO: Connect SDIO pins to AF12
+  *            @arg GPIO_AF_DCMI: Connect DCMI pins to AF13
+  *            @arg GPIO_AF_EVENTOUT: Connect EVENTOUT pins to AF15
+  * @retval None
+  */
+void GPIO_PinAFConfig(GPIO_TypeDef* GPIOx, uint16_t GPIO_PinSource, uint8_t GPIO_AF)
+{
+  uint32_t temp = 0x00;
+  uint32_t temp_2 = 0x00;
+  
+  /* Check the parameters */
+  assert_param(IS_GPIO_ALL_PERIPH(GPIOx));
+  assert_param(IS_GPIO_PIN_SOURCE(GPIO_PinSource));
+  assert_param(IS_GPIO_AF(GPIO_AF));
+  
+  temp = ((uint32_t)(GPIO_AF) << ((uint32_t)((uint32_t)GPIO_PinSource & (uint32_t)0x07) * 4)) ;
+  GPIOx->AFR[GPIO_PinSource >> 0x03] &= ~((uint32_t)0xF << ((uint32_t)((uint32_t)GPIO_PinSource & (uint32_t)0x07) * 4)) ;
+  temp_2 = GPIOx->AFR[GPIO_PinSource >> 0x03] | temp;
+  GPIOx->AFR[GPIO_PinSource >> 0x03] = temp_2;
+}
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/src/lib/stm32f4xx_gpio.h
+++ b/src/lib/stm32f4xx_gpio.h
@@ -1,0 +1,412 @@
+/**
+  ******************************************************************************
+  * @file    stm32f4xx_gpio.h
+  * @author  MCD Application Team
+  * @version V1.0.2
+  * @date    05-March-2012
+  * @brief   This file contains all the functions prototypes for the GPIO firmware
+  *          library.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT 2012 STMicroelectronics</center></h2>
+  *
+  * Licensed under MCD-ST Liberty SW License Agreement V2, (the "License");
+  * You may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at:
+  *
+  *        http://www.st.com/software_license_agreement_liberty_v2
+  *
+  * Unless required by applicable law or agreed to in writing, software 
+  * distributed under the License is distributed on an "AS IS" BASIS, 
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32F4xx_GPIO_H
+#define __STM32F4xx_GPIO_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f4xx.h"
+
+/** @addtogroup STM32F4xx_StdPeriph_Driver
+  * @{
+  */
+
+/** @addtogroup GPIO
+  * @{
+  */ 
+
+/* Exported types ------------------------------------------------------------*/
+
+#define IS_GPIO_ALL_PERIPH(PERIPH) (((PERIPH) == GPIOA) || \
+                                    ((PERIPH) == GPIOB) || \
+                                    ((PERIPH) == GPIOC) || \
+                                    ((PERIPH) == GPIOD) || \
+                                    ((PERIPH) == GPIOE) || \
+                                    ((PERIPH) == GPIOF) || \
+                                    ((PERIPH) == GPIOG) || \
+                                    ((PERIPH) == GPIOH) || \
+                                    ((PERIPH) == GPIOI))
+                                                                
+/** 
+  * @brief  GPIO Configuration Mode enumeration 
+  */   
+typedef enum
+{ 
+  GPIO_Mode_IN   = 0x00, /*!< GPIO Input Mode */
+  GPIO_Mode_OUT  = 0x01, /*!< GPIO Output Mode */
+  GPIO_Mode_AF   = 0x02, /*!< GPIO Alternate function Mode */
+  GPIO_Mode_AN   = 0x03  /*!< GPIO Analog Mode */
+}GPIOMode_TypeDef;
+#define IS_GPIO_MODE(MODE) (((MODE) == GPIO_Mode_IN)  || ((MODE) == GPIO_Mode_OUT) || \
+                            ((MODE) == GPIO_Mode_AF)|| ((MODE) == GPIO_Mode_AN))
+
+/** 
+  * @brief  GPIO Output type enumeration 
+  */  
+typedef enum
+{ 
+  GPIO_OType_PP = 0x00,
+  GPIO_OType_OD = 0x01
+}GPIOOType_TypeDef;
+#define IS_GPIO_OTYPE(OTYPE) (((OTYPE) == GPIO_OType_PP) || ((OTYPE) == GPIO_OType_OD))
+
+
+/** 
+  * @brief  GPIO Output Maximum frequency enumeration 
+  */  
+typedef enum
+{ 
+  GPIO_Speed_2MHz   = 0x00, /*!< Low speed */
+  GPIO_Speed_25MHz  = 0x01, /*!< Medium speed */
+  GPIO_Speed_50MHz  = 0x02, /*!< Fast speed */
+  GPIO_Speed_100MHz = 0x03  /*!< High speed on 30 pF (80 MHz Output max speed on 15 pF) */
+}GPIOSpeed_TypeDef;
+#define IS_GPIO_SPEED(SPEED) (((SPEED) == GPIO_Speed_2MHz) || ((SPEED) == GPIO_Speed_25MHz) || \
+                              ((SPEED) == GPIO_Speed_50MHz)||  ((SPEED) == GPIO_Speed_100MHz)) 
+
+/** 
+  * @brief  GPIO Configuration PullUp PullDown enumeration 
+  */ 
+typedef enum
+{ 
+  GPIO_PuPd_NOPULL = 0x00,
+  GPIO_PuPd_UP     = 0x01,
+  GPIO_PuPd_DOWN   = 0x02
+}GPIOPuPd_TypeDef;
+#define IS_GPIO_PUPD(PUPD) (((PUPD) == GPIO_PuPd_NOPULL) || ((PUPD) == GPIO_PuPd_UP) || \
+                            ((PUPD) == GPIO_PuPd_DOWN))
+
+/** 
+  * @brief  GPIO Bit SET and Bit RESET enumeration 
+  */ 
+typedef enum
+{ 
+  Bit_RESET = 0,
+  Bit_SET
+}BitAction;
+#define IS_GPIO_BIT_ACTION(ACTION) (((ACTION) == Bit_RESET) || ((ACTION) == Bit_SET))
+
+
+/** 
+  * @brief   GPIO Init structure definition  
+  */ 
+typedef struct
+{
+  uint32_t GPIO_Pin;              /*!< Specifies the GPIO pins to be configured.
+                                       This parameter can be any value of @ref GPIO_pins_define */
+
+  GPIOMode_TypeDef GPIO_Mode;     /*!< Specifies the operating mode for the selected pins.
+                                       This parameter can be a value of @ref GPIOMode_TypeDef */
+
+  GPIOSpeed_TypeDef GPIO_Speed;   /*!< Specifies the speed for the selected pins.
+                                       This parameter can be a value of @ref GPIOSpeed_TypeDef */
+
+  GPIOOType_TypeDef GPIO_OType;   /*!< Specifies the operating output type for the selected pins.
+                                       This parameter can be a value of @ref GPIOOType_TypeDef */
+
+  GPIOPuPd_TypeDef GPIO_PuPd;     /*!< Specifies the operating Pull-up/Pull down for the selected pins.
+                                       This parameter can be a value of @ref GPIOPuPd_TypeDef */
+}GPIO_InitTypeDef;
+
+/* Exported constants --------------------------------------------------------*/
+
+/** @defgroup GPIO_Exported_Constants
+  * @{
+  */ 
+
+/** @defgroup GPIO_pins_define 
+  * @{
+  */ 
+#define GPIO_Pin_0                 ((uint16_t)0x0001)  /* Pin 0 selected */
+#define GPIO_Pin_1                 ((uint16_t)0x0002)  /* Pin 1 selected */
+#define GPIO_Pin_2                 ((uint16_t)0x0004)  /* Pin 2 selected */
+#define GPIO_Pin_3                 ((uint16_t)0x0008)  /* Pin 3 selected */
+#define GPIO_Pin_4                 ((uint16_t)0x0010)  /* Pin 4 selected */
+#define GPIO_Pin_5                 ((uint16_t)0x0020)  /* Pin 5 selected */
+#define GPIO_Pin_6                 ((uint16_t)0x0040)  /* Pin 6 selected */
+#define GPIO_Pin_7                 ((uint16_t)0x0080)  /* Pin 7 selected */
+#define GPIO_Pin_8                 ((uint16_t)0x0100)  /* Pin 8 selected */
+#define GPIO_Pin_9                 ((uint16_t)0x0200)  /* Pin 9 selected */
+#define GPIO_Pin_10                ((uint16_t)0x0400)  /* Pin 10 selected */
+#define GPIO_Pin_11                ((uint16_t)0x0800)  /* Pin 11 selected */
+#define GPIO_Pin_12                ((uint16_t)0x1000)  /* Pin 12 selected */
+#define GPIO_Pin_13                ((uint16_t)0x2000)  /* Pin 13 selected */
+#define GPIO_Pin_14                ((uint16_t)0x4000)  /* Pin 14 selected */
+#define GPIO_Pin_15                ((uint16_t)0x8000)  /* Pin 15 selected */
+#define GPIO_Pin_All               ((uint16_t)0xFFFF)  /* All pins selected */
+
+#define IS_GPIO_PIN(PIN) ((((PIN) & (uint16_t)0x00) == 0x00) && ((PIN) != (uint16_t)0x00))
+#define IS_GET_GPIO_PIN(PIN) (((PIN) == GPIO_Pin_0) || \
+                              ((PIN) == GPIO_Pin_1) || \
+                              ((PIN) == GPIO_Pin_2) || \
+                              ((PIN) == GPIO_Pin_3) || \
+                              ((PIN) == GPIO_Pin_4) || \
+                              ((PIN) == GPIO_Pin_5) || \
+                              ((PIN) == GPIO_Pin_6) || \
+                              ((PIN) == GPIO_Pin_7) || \
+                              ((PIN) == GPIO_Pin_8) || \
+                              ((PIN) == GPIO_Pin_9) || \
+                              ((PIN) == GPIO_Pin_10) || \
+                              ((PIN) == GPIO_Pin_11) || \
+                              ((PIN) == GPIO_Pin_12) || \
+                              ((PIN) == GPIO_Pin_13) || \
+                              ((PIN) == GPIO_Pin_14) || \
+                              ((PIN) == GPIO_Pin_15))
+/**
+  * @}
+  */ 
+
+
+/** @defgroup GPIO_Pin_sources 
+  * @{
+  */ 
+#define GPIO_PinSource0            ((uint8_t)0x00)
+#define GPIO_PinSource1            ((uint8_t)0x01)
+#define GPIO_PinSource2            ((uint8_t)0x02)
+#define GPIO_PinSource3            ((uint8_t)0x03)
+#define GPIO_PinSource4            ((uint8_t)0x04)
+#define GPIO_PinSource5            ((uint8_t)0x05)
+#define GPIO_PinSource6            ((uint8_t)0x06)
+#define GPIO_PinSource7            ((uint8_t)0x07)
+#define GPIO_PinSource8            ((uint8_t)0x08)
+#define GPIO_PinSource9            ((uint8_t)0x09)
+#define GPIO_PinSource10           ((uint8_t)0x0A)
+#define GPIO_PinSource11           ((uint8_t)0x0B)
+#define GPIO_PinSource12           ((uint8_t)0x0C)
+#define GPIO_PinSource13           ((uint8_t)0x0D)
+#define GPIO_PinSource14           ((uint8_t)0x0E)
+#define GPIO_PinSource15           ((uint8_t)0x0F)
+
+#define IS_GPIO_PIN_SOURCE(PINSOURCE) (((PINSOURCE) == GPIO_PinSource0) || \
+                                       ((PINSOURCE) == GPIO_PinSource1) || \
+                                       ((PINSOURCE) == GPIO_PinSource2) || \
+                                       ((PINSOURCE) == GPIO_PinSource3) || \
+                                       ((PINSOURCE) == GPIO_PinSource4) || \
+                                       ((PINSOURCE) == GPIO_PinSource5) || \
+                                       ((PINSOURCE) == GPIO_PinSource6) || \
+                                       ((PINSOURCE) == GPIO_PinSource7) || \
+                                       ((PINSOURCE) == GPIO_PinSource8) || \
+                                       ((PINSOURCE) == GPIO_PinSource9) || \
+                                       ((PINSOURCE) == GPIO_PinSource10) || \
+                                       ((PINSOURCE) == GPIO_PinSource11) || \
+                                       ((PINSOURCE) == GPIO_PinSource12) || \
+                                       ((PINSOURCE) == GPIO_PinSource13) || \
+                                       ((PINSOURCE) == GPIO_PinSource14) || \
+                                       ((PINSOURCE) == GPIO_PinSource15))
+/**
+  * @}
+  */ 
+
+/** @defgroup GPIO_Alternat_function_selection_define 
+  * @{
+  */ 
+/** 
+  * @brief   AF 0 selection  
+  */ 
+#define GPIO_AF_RTC_50Hz      ((uint8_t)0x00)  /* RTC_50Hz Alternate Function mapping */
+#define GPIO_AF_MCO           ((uint8_t)0x00)  /* MCO (MCO1 and MCO2) Alternate Function mapping */
+#define GPIO_AF_TAMPER        ((uint8_t)0x00)  /* TAMPER (TAMPER_1 and TAMPER_2) Alternate Function mapping */
+#define GPIO_AF_SWJ           ((uint8_t)0x00)  /* SWJ (SWD and JTAG) Alternate Function mapping */
+#define GPIO_AF_TRACE         ((uint8_t)0x00)  /* TRACE Alternate Function mapping */
+
+/** 
+  * @brief   AF 1 selection  
+  */ 
+#define GPIO_AF_TIM1          ((uint8_t)0x01)  /* TIM1 Alternate Function mapping */
+#define GPIO_AF_TIM2          ((uint8_t)0x01)  /* TIM2 Alternate Function mapping */
+
+/** 
+  * @brief   AF 2 selection  
+  */ 
+#define GPIO_AF_TIM3          ((uint8_t)0x02)  /* TIM3 Alternate Function mapping */
+#define GPIO_AF_TIM4          ((uint8_t)0x02)  /* TIM4 Alternate Function mapping */
+#define GPIO_AF_TIM5          ((uint8_t)0x02)  /* TIM5 Alternate Function mapping */
+
+/** 
+  * @brief   AF 3 selection  
+  */ 
+#define GPIO_AF_TIM8          ((uint8_t)0x03)  /* TIM8 Alternate Function mapping */
+#define GPIO_AF_TIM9          ((uint8_t)0x03)  /* TIM9 Alternate Function mapping */
+#define GPIO_AF_TIM10         ((uint8_t)0x03)  /* TIM10 Alternate Function mapping */
+#define GPIO_AF_TIM11         ((uint8_t)0x03)  /* TIM11 Alternate Function mapping */
+
+/** 
+  * @brief   AF 4 selection  
+  */ 
+#define GPIO_AF_I2C1          ((uint8_t)0x04)  /* I2C1 Alternate Function mapping */
+#define GPIO_AF_I2C2          ((uint8_t)0x04)  /* I2C2 Alternate Function mapping */
+#define GPIO_AF_I2C3          ((uint8_t)0x04)  /* I2C3 Alternate Function mapping */
+
+/** 
+  * @brief   AF 5 selection  
+  */ 
+#define GPIO_AF_SPI1          ((uint8_t)0x05)  /* SPI1 Alternate Function mapping */
+#define GPIO_AF_SPI2          ((uint8_t)0x05)  /* SPI2/I2S2 Alternate Function mapping */
+
+/** 
+  * @brief   AF 6 selection  
+  */ 
+#define GPIO_AF_SPI3          ((uint8_t)0x06)  /* SPI3/I2S3 Alternate Function mapping */
+
+/** 
+  * @brief   AF 7 selection  
+  */ 
+#define GPIO_AF_USART1        ((uint8_t)0x07)  /* USART1 Alternate Function mapping */
+#define GPIO_AF_USART2        ((uint8_t)0x07)  /* USART2 Alternate Function mapping */
+#define GPIO_AF_USART3        ((uint8_t)0x07)  /* USART3 Alternate Function mapping */
+#define GPIO_AF_I2S3ext       ((uint8_t)0x07)  /* I2S3ext Alternate Function mapping */
+
+/** 
+  * @brief   AF 8 selection  
+  */ 
+#define GPIO_AF_UART4         ((uint8_t)0x08)  /* UART4 Alternate Function mapping */
+#define GPIO_AF_UART5         ((uint8_t)0x08)  /* UART5 Alternate Function mapping */
+#define GPIO_AF_USART6        ((uint8_t)0x08)  /* USART6 Alternate Function mapping */
+
+/** 
+  * @brief   AF 9 selection 
+  */ 
+#define GPIO_AF_CAN1          ((uint8_t)0x09)  /* CAN1 Alternate Function mapping */
+#define GPIO_AF_CAN2          ((uint8_t)0x09)  /* CAN2 Alternate Function mapping */
+#define GPIO_AF_TIM12         ((uint8_t)0x09)  /* TIM12 Alternate Function mapping */
+#define GPIO_AF_TIM13         ((uint8_t)0x09)  /* TIM13 Alternate Function mapping */
+#define GPIO_AF_TIM14         ((uint8_t)0x09)  /* TIM14 Alternate Function mapping */
+
+/** 
+  * @brief   AF 10 selection  
+  */ 
+#define GPIO_AF_OTG_FS         ((uint8_t)0xA)  /* OTG_FS Alternate Function mapping */
+#define GPIO_AF_OTG_HS         ((uint8_t)0xA)  /* OTG_HS Alternate Function mapping */
+
+/** 
+  * @brief   AF 11 selection  
+  */ 
+#define GPIO_AF_ETH             ((uint8_t)0x0B)  /* ETHERNET Alternate Function mapping */
+
+/** 
+  * @brief   AF 12 selection  
+  */ 
+#define GPIO_AF_FSMC            ((uint8_t)0xC)  /* FSMC Alternate Function mapping */
+#define GPIO_AF_OTG_HS_FS       ((uint8_t)0xC)  /* OTG HS configured in FS, Alternate Function mapping */
+#define GPIO_AF_SDIO            ((uint8_t)0xC)  /* SDIO Alternate Function mapping */
+
+/** 
+  * @brief   AF 13 selection  
+  */ 
+#define GPIO_AF_DCMI          ((uint8_t)0x0D)  /* DCMI Alternate Function mapping */
+
+/** 
+  * @brief   AF 15 selection  
+  */ 
+#define GPIO_AF_EVENTOUT      ((uint8_t)0x0F)  /* EVENTOUT Alternate Function mapping */
+
+#define IS_GPIO_AF(AF)   (((AF) == GPIO_AF_RTC_50Hz)  || ((AF) == GPIO_AF_TIM14)  || \
+                          ((AF) == GPIO_AF_MCO)       || ((AF) == GPIO_AF_TAMPER) || \
+                          ((AF) == GPIO_AF_SWJ)       || ((AF) == GPIO_AF_TRACE)  || \
+                          ((AF) == GPIO_AF_TIM1)      || ((AF) == GPIO_AF_TIM2)   || \
+                          ((AF) == GPIO_AF_TIM3)      || ((AF) == GPIO_AF_TIM4)   || \
+                          ((AF) == GPIO_AF_TIM5)      || ((AF) == GPIO_AF_TIM8)   || \
+                          ((AF) == GPIO_AF_I2C1)      || ((AF) == GPIO_AF_I2C2)   || \
+                          ((AF) == GPIO_AF_I2C3)      || ((AF) == GPIO_AF_SPI1)   || \
+                          ((AF) == GPIO_AF_SPI2)      || ((AF) == GPIO_AF_TIM13)  || \
+                          ((AF) == GPIO_AF_SPI3)      || ((AF) == GPIO_AF_TIM14)  || \
+                          ((AF) == GPIO_AF_USART1)    || ((AF) == GPIO_AF_USART2) || \
+                          ((AF) == GPIO_AF_USART3)    || ((AF) == GPIO_AF_UART4)  || \
+                          ((AF) == GPIO_AF_UART5)     || ((AF) == GPIO_AF_USART6) || \
+                          ((AF) == GPIO_AF_CAN1)      || ((AF) == GPIO_AF_CAN2)   || \
+                          ((AF) == GPIO_AF_OTG_FS)    || ((AF) == GPIO_AF_OTG_HS) || \
+                          ((AF) == GPIO_AF_ETH)       || ((AF) == GPIO_AF_FSMC)   || \
+                          ((AF) == GPIO_AF_OTG_HS_FS) || ((AF) == GPIO_AF_SDIO)   || \
+                          ((AF) == GPIO_AF_DCMI)      || ((AF) == GPIO_AF_EVENTOUT))
+/**
+  * @}
+  */ 
+
+/** @defgroup GPIO_Legacy 
+  * @{
+  */
+    
+#define GPIO_Mode_AIN           GPIO_Mode_AN
+
+#define GPIO_AF_OTG1_FS         GPIO_AF_OTG_FS
+#define GPIO_AF_OTG2_HS         GPIO_AF_OTG_HS
+#define GPIO_AF_OTG2_FS         GPIO_AF_OTG_HS_FS
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Exported macro ------------------------------------------------------------*/
+/* Exported functions --------------------------------------------------------*/ 
+
+/*  Function used to set the GPIO configuration to the default reset state ****/
+void GPIO_DeInit(GPIO_TypeDef* GPIOx);
+
+/* Initialization and Configuration functions *********************************/
+void GPIO_Init(GPIO_TypeDef* GPIOx, GPIO_InitTypeDef* GPIO_InitStruct);
+void GPIO_StructInit(GPIO_InitTypeDef* GPIO_InitStruct);
+void GPIO_PinLockConfig(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin);
+
+/* GPIO Read and Write functions **********************************************/
+uint8_t GPIO_ReadInputDataBit(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin);
+uint16_t GPIO_ReadInputData(GPIO_TypeDef* GPIOx);
+uint8_t GPIO_ReadOutputDataBit(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin);
+uint16_t GPIO_ReadOutputData(GPIO_TypeDef* GPIOx);
+void GPIO_SetBits(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin);
+void GPIO_ResetBits(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin);
+void GPIO_WriteBit(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin, BitAction BitVal);
+void GPIO_Write(GPIO_TypeDef* GPIOx, uint16_t PortVal);
+void GPIO_ToggleBits(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin);
+
+/* GPIO Alternate functions configuration function ****************************/
+void GPIO_PinAFConfig(GPIO_TypeDef* GPIOx, uint16_t GPIO_PinSource, uint8_t GPIO_AF);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /*__STM32F4xx_GPIO_H */
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/src/lib/stm32f4xx_rcc.c
+++ b/src/lib/stm32f4xx_rcc.c
@@ -1,0 +1,1814 @@
+/**
+  ******************************************************************************
+  * @file    stm32f4xx_rcc.c
+  * @author  MCD Application Team
+  * @version V1.0.2
+  * @date    05-March-2012
+  * @brief   This file provides firmware functions to manage the following 
+  *          functionalities of the Reset and clock control (RCC) peripheral:
+  *           - Internal/external clocks, PLL, CSS and MCO configuration
+  *           - System, AHB and APB busses clocks configuration
+  *           - Peripheral clocks configuration
+  *           - Interrupts and flags management
+  *
+  *  @verbatim
+  *               
+  *          ===================================================================
+  *                               RCC specific features
+  *          ===================================================================
+  *    
+  *          After reset the device is running from Internal High Speed oscillator 
+  *          (HSI 16MHz) with Flash 0 wait state, Flash prefetch buffer, D-Cache 
+  *          and I-Cache are disabled, and all peripherals are off except internal
+  *          SRAM, Flash and JTAG.
+  *           - There is no prescaler on High speed (AHB) and Low speed (APB) busses;
+  *             all peripherals mapped on these busses are running at HSI speed.
+  *       	  - The clock for all peripherals is switched off, except the SRAM and FLASH.
+  *           - All GPIOs are in input floating state, except the JTAG pins which
+  *             are assigned to be used for debug purpose.
+  *        
+  *          Once the device started from reset, the user application has to:        
+  *           - Configure the clock source to be used to drive the System clock
+  *             (if the application needs higher frequency/performance)
+  *           - Configure the System clock frequency and Flash settings  
+  *           - Configure the AHB and APB busses prescalers
+  *           - Enable the clock for the peripheral(s) to be used
+  *           - Configure the clock source(s) for peripherals which clocks are not
+  *             derived from the System clock (I2S, RTC, ADC, USB OTG FS/SDIO/RNG)      
+  *                        
+  *  @endverbatim
+  *    
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT 2012 STMicroelectronics</center></h2>
+  *
+  * Licensed under MCD-ST Liberty SW License Agreement V2, (the "License");
+  * You may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at:
+  *
+  *        http://www.st.com/software_license_agreement_liberty_v2
+  *
+  * Unless required by applicable law or agreed to in writing, software 
+  * distributed under the License is distributed on an "AS IS" BASIS, 
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f4xx_rcc.h"
+
+/** @addtogroup STM32F4xx_StdPeriph_Driver
+  * @{
+  */
+
+/** @defgroup RCC 
+  * @brief RCC driver modules
+  * @{
+  */ 
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* ------------ RCC registers bit address in the alias region ----------- */
+#define RCC_OFFSET                (RCC_BASE - PERIPH_BASE)
+/* --- CR Register ---*/
+/* Alias word address of HSION bit */
+#define CR_OFFSET                 (RCC_OFFSET + 0x00)
+#define HSION_BitNumber           0x00
+#define CR_HSION_BB               (PERIPH_BB_BASE + (CR_OFFSET * 32) + (HSION_BitNumber * 4))
+/* Alias word address of CSSON bit */
+#define CSSON_BitNumber           0x13
+#define CR_CSSON_BB               (PERIPH_BB_BASE + (CR_OFFSET * 32) + (CSSON_BitNumber * 4))
+/* Alias word address of PLLON bit */
+#define PLLON_BitNumber           0x18
+#define CR_PLLON_BB               (PERIPH_BB_BASE + (CR_OFFSET * 32) + (PLLON_BitNumber * 4))
+/* Alias word address of PLLI2SON bit */
+#define PLLI2SON_BitNumber        0x1A
+#define CR_PLLI2SON_BB            (PERIPH_BB_BASE + (CR_OFFSET * 32) + (PLLI2SON_BitNumber * 4))
+
+/* --- CFGR Register ---*/
+/* Alias word address of I2SSRC bit */
+#define CFGR_OFFSET               (RCC_OFFSET + 0x08)
+#define I2SSRC_BitNumber          0x17
+#define CFGR_I2SSRC_BB            (PERIPH_BB_BASE + (CFGR_OFFSET * 32) + (I2SSRC_BitNumber * 4))
+
+/* --- BDCR Register ---*/
+/* Alias word address of RTCEN bit */
+#define BDCR_OFFSET               (RCC_OFFSET + 0x70)
+#define RTCEN_BitNumber           0x0F
+#define BDCR_RTCEN_BB             (PERIPH_BB_BASE + (BDCR_OFFSET * 32) + (RTCEN_BitNumber * 4))
+/* Alias word address of BDRST bit */
+#define BDRST_BitNumber           0x10
+#define BDCR_BDRST_BB             (PERIPH_BB_BASE + (BDCR_OFFSET * 32) + (BDRST_BitNumber * 4))
+/* --- CSR Register ---*/
+/* Alias word address of LSION bit */
+#define CSR_OFFSET                (RCC_OFFSET + 0x74)
+#define LSION_BitNumber           0x00
+#define CSR_LSION_BB              (PERIPH_BB_BASE + (CSR_OFFSET * 32) + (LSION_BitNumber * 4))
+/* ---------------------- RCC registers bit mask ------------------------ */
+/* CFGR register bit mask */
+#define CFGR_MCO2_RESET_MASK      ((uint32_t)0x07FFFFFF)
+#define CFGR_MCO1_RESET_MASK      ((uint32_t)0xF89FFFFF)
+
+/* RCC Flag Mask */
+#define FLAG_MASK                 ((uint8_t)0x1F)
+
+/* CR register byte 3 (Bits[23:16]) base address */
+#define CR_BYTE3_ADDRESS          ((uint32_t)0x40023802)
+
+/* CIR register byte 2 (Bits[15:8]) base address */
+#define CIR_BYTE2_ADDRESS         ((uint32_t)(RCC_BASE + 0x0C + 0x01))
+
+/* CIR register byte 3 (Bits[23:16]) base address */
+#define CIR_BYTE3_ADDRESS         ((uint32_t)(RCC_BASE + 0x0C + 0x02))
+
+/* BDCR register base address */
+#define BDCR_ADDRESS              (PERIPH_BASE + BDCR_OFFSET)
+
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+static __I uint8_t APBAHBPrescTable[16] = {0, 0, 0, 0, 1, 2, 3, 4, 1, 2, 3, 4, 6, 7, 8, 9};
+
+/* Private function prototypes -----------------------------------------------*/
+/* Private functions ---------------------------------------------------------*/
+
+/** @defgroup RCC_Private_Functions
+  * @{
+  */ 
+
+/** @defgroup RCC_Group1 Internal and external clocks, PLL, CSS and MCO configuration functions
+ *  @brief   Internal and external clocks, PLL, CSS and MCO configuration functions 
+ *
+@verbatim   
+ ===============================================================================
+      Internal/external clocks, PLL, CSS and MCO configuration functions
+ ===============================================================================  
+
+  This section provide functions allowing to configure the internal/external clocks,
+  PLLs, CSS and MCO pins.
+  
+  1. HSI (high-speed internal), 16 MHz factory-trimmed RC used directly or through
+     the PLL as System clock source.
+
+  2. LSI (low-speed internal), 32 KHz low consumption RC used as IWDG and/or RTC
+     clock source.
+
+  3. HSE (high-speed external), 4 to 26 MHz crystal oscillator used directly or
+     through the PLL as System clock source. Can be used also as RTC clock source.
+
+  4. LSE (low-speed external), 32 KHz oscillator used as RTC clock source.   
+
+  5. PLL (clocked by HSI or HSE), featuring two different output clocks:
+      - The first output is used to generate the high speed system clock (up to 168 MHz)
+      - The second output is used to generate the clock for the USB OTG FS (48 MHz),
+        the random analog generator (<=48 MHz) and the SDIO (<= 48 MHz).
+
+  6. PLLI2S (clocked by HSI or HSE), used to generate an accurate clock to achieve 
+     high-quality audio performance on the I2S interface.
+  
+  7. CSS (Clock security system), once enable and if a HSE clock failure occurs 
+     (HSE used directly or through PLL as System clock source), the System clock
+     is automatically switched to HSI and an interrupt is generated if enabled. 
+     The interrupt is linked to the Cortex-M4 NMI (Non-Maskable Interrupt) 
+     exception vector.   
+
+  8. MCO1 (microcontroller clock output), used to output HSI, LSE, HSE or PLL
+     clock (through a configurable prescaler) on PA8 pin.
+
+  9. MCO2 (microcontroller clock output), used to output HSE, PLL, SYSCLK or PLLI2S
+     clock (through a configurable prescaler) on PC9 pin.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Resets the RCC clock configuration to the default reset state.
+  * @note   The default reset state of the clock configuration is given below:
+  *            - HSI ON and used as system clock source
+  *            - HSE, PLL and PLLI2S OFF
+  *            - AHB, APB1 and APB2 prescaler set to 1.
+  *            - CSS, MCO1 and MCO2 OFF
+  *            - All interrupts disabled
+  * @note   This function doesn't modify the configuration of the
+  *            - Peripheral clocks
+  *            - LSI, LSE and RTC clocks 
+  * @param  None
+  * @retval None
+  */
+void RCC_DeInit(void)
+{
+  /* Set HSION bit */
+  RCC->CR |= (uint32_t)0x00000001;
+
+  /* Reset CFGR register */
+  RCC->CFGR = 0x00000000;
+
+  /* Reset HSEON, CSSON and PLLON bits */
+  RCC->CR &= (uint32_t)0xFEF6FFFF;
+
+  /* Reset PLLCFGR register */
+  RCC->PLLCFGR = 0x24003010;
+
+  /* Reset HSEBYP bit */
+  RCC->CR &= (uint32_t)0xFFFBFFFF;
+
+  /* Disable all interrupts */
+  RCC->CIR = 0x00000000;
+}
+
+/**
+  * @brief  Configures the External High Speed oscillator (HSE).
+  * @note   After enabling the HSE (RCC_HSE_ON or RCC_HSE_Bypass), the application
+  *         software should wait on HSERDY flag to be set indicating that HSE clock
+  *         is stable and can be used to clock the PLL and/or system clock.
+  * @note   HSE state can not be changed if it is used directly or through the
+  *         PLL as system clock. In this case, you have to select another source
+  *         of the system clock then change the HSE state (ex. disable it).
+  * @note   The HSE is stopped by hardware when entering STOP and STANDBY modes.  
+  * @note   This function reset the CSSON bit, so if the Clock security system(CSS)
+  *         was previously enabled you have to enable it again after calling this
+  *         function.    
+  * @param  RCC_HSE: specifies the new state of the HSE.
+  *          This parameter can be one of the following values:
+  *            @arg RCC_HSE_OFF: turn OFF the HSE oscillator, HSERDY flag goes low after
+  *                              6 HSE oscillator clock cycles.
+  *            @arg RCC_HSE_ON: turn ON the HSE oscillator
+  *            @arg RCC_HSE_Bypass: HSE oscillator bypassed with external clock
+  * @retval None
+  */
+void RCC_HSEConfig(uint8_t RCC_HSE)
+{
+  /* Check the parameters */
+  assert_param(IS_RCC_HSE(RCC_HSE));
+
+  /* Reset HSEON and HSEBYP bits before configuring the HSE ------------------*/
+  *(__IO uint8_t *) CR_BYTE3_ADDRESS = RCC_HSE_OFF;
+
+  /* Set the new HSE configuration -------------------------------------------*/
+  *(__IO uint8_t *) CR_BYTE3_ADDRESS = RCC_HSE;
+}
+
+/**
+  * @brief  Waits for HSE start-up.
+  * @note   This functions waits on HSERDY flag to be set and return SUCCESS if 
+  *         this flag is set, otherwise returns ERROR if the timeout is reached 
+  *         and this flag is not set. The timeout value is defined by the constant
+  *         HSE_STARTUP_TIMEOUT in stm32f4xx.h file. You can tailor it depending
+  *         on the HSE crystal used in your application. 
+  * @param  None
+  * @retval An ErrorStatus enumeration value:
+  *          - SUCCESS: HSE oscillator is stable and ready to use
+  *          - ERROR: HSE oscillator not yet ready
+  */
+ErrorStatus RCC_WaitForHSEStartUp(void)
+{
+  __IO uint32_t startupcounter = 0;
+  ErrorStatus status = ERROR;
+  FlagStatus hsestatus = RESET;
+  /* Wait till HSE is ready and if Time out is reached exit */
+  do
+  {
+    hsestatus = RCC_GetFlagStatus(RCC_FLAG_HSERDY);
+    startupcounter++;
+  } while((startupcounter != HSE_STARTUP_TIMEOUT) && (hsestatus == RESET));
+
+  if (RCC_GetFlagStatus(RCC_FLAG_HSERDY) != RESET)
+  {
+    status = SUCCESS;
+  }
+  else
+  {
+    status = ERROR;
+  }
+  return (status);
+}
+
+/**
+  * @brief  Adjusts the Internal High Speed oscillator (HSI) calibration value.
+  * @note   The calibration is used to compensate for the variations in voltage
+  *         and temperature that influence the frequency of the internal HSI RC.
+  * @param  HSICalibrationValue: specifies the calibration trimming value.
+  *         This parameter must be a number between 0 and 0x1F.
+  * @retval None
+  */
+void RCC_AdjustHSICalibrationValue(uint8_t HSICalibrationValue)
+{
+  uint32_t tmpreg = 0;
+  /* Check the parameters */
+  assert_param(IS_RCC_CALIBRATION_VALUE(HSICalibrationValue));
+
+  tmpreg = RCC->CR;
+
+  /* Clear HSITRIM[4:0] bits */
+  tmpreg &= ~RCC_CR_HSITRIM;
+
+  /* Set the HSITRIM[4:0] bits according to HSICalibrationValue value */
+  tmpreg |= (uint32_t)HSICalibrationValue << 3;
+
+  /* Store the new value */
+  RCC->CR = tmpreg;
+}
+
+/**
+  * @brief  Enables or disables the Internal High Speed oscillator (HSI).
+  * @note   The HSI is stopped by hardware when entering STOP and STANDBY modes.
+  *         It is used (enabled by hardware) as system clock source after startup
+  *         from Reset, wakeup from STOP and STANDBY mode, or in case of failure
+  *         of the HSE used directly or indirectly as system clock (if the Clock
+  *         Security System CSS is enabled).             
+  * @note   HSI can not be stopped if it is used as system clock source. In this case,
+  *         you have to select another source of the system clock then stop the HSI.  
+  * @note   After enabling the HSI, the application software should wait on HSIRDY
+  *         flag to be set indicating that HSI clock is stable and can be used as
+  *         system clock source.  
+  * @param  NewState: new state of the HSI.
+  *          This parameter can be: ENABLE or DISABLE.
+  * @note   When the HSI is stopped, HSIRDY flag goes low after 6 HSI oscillator
+  *         clock cycles.  
+  * @retval None
+  */
+void RCC_HSICmd(FunctionalState NewState)
+{
+  /* Check the parameters */
+  assert_param(IS_FUNCTIONAL_STATE(NewState));
+
+  *(__IO uint32_t *) CR_HSION_BB = (uint32_t)NewState;
+}
+
+/**
+  * @brief  Configures the External Low Speed oscillator (LSE).
+  * @note   As the LSE is in the Backup domain and write access is denied to
+  *         this domain after reset, you have to enable write access using 
+  *         PWR_BackupAccessCmd(ENABLE) function before to configure the LSE
+  *         (to be done once after reset).  
+  * @note   After enabling the LSE (RCC_LSE_ON or RCC_LSE_Bypass), the application
+  *         software should wait on LSERDY flag to be set indicating that LSE clock
+  *         is stable and can be used to clock the RTC.
+  * @param  RCC_LSE: specifies the new state of the LSE.
+  *          This parameter can be one of the following values:
+  *            @arg RCC_LSE_OFF: turn OFF the LSE oscillator, LSERDY flag goes low after
+  *                              6 LSE oscillator clock cycles.
+  *            @arg RCC_LSE_ON: turn ON the LSE oscillator
+  *            @arg RCC_LSE_Bypass: LSE oscillator bypassed with external clock
+  * @retval None
+  */
+void RCC_LSEConfig(uint8_t RCC_LSE)
+{
+  /* Check the parameters */
+  assert_param(IS_RCC_LSE(RCC_LSE));
+
+  /* Reset LSEON and LSEBYP bits before configuring the LSE ------------------*/
+  /* Reset LSEON bit */
+  *(__IO uint8_t *) BDCR_ADDRESS = RCC_LSE_OFF;
+
+  /* Reset LSEBYP bit */
+  *(__IO uint8_t *) BDCR_ADDRESS = RCC_LSE_OFF;
+
+  /* Configure LSE (RCC_LSE_OFF is already covered by the code section above) */
+  switch (RCC_LSE)
+  {
+    case RCC_LSE_ON:
+      /* Set LSEON bit */
+      *(__IO uint8_t *) BDCR_ADDRESS = RCC_LSE_ON;
+      break;
+    case RCC_LSE_Bypass:
+      /* Set LSEBYP and LSEON bits */
+      *(__IO uint8_t *) BDCR_ADDRESS = RCC_LSE_Bypass | RCC_LSE_ON;
+      break;
+    default:
+      break;
+  }
+}
+
+/**
+  * @brief  Enables or disables the Internal Low Speed oscillator (LSI).
+  * @note   After enabling the LSI, the application software should wait on 
+  *         LSIRDY flag to be set indicating that LSI clock is stable and can
+  *         be used to clock the IWDG and/or the RTC.
+  * @note   LSI can not be disabled if the IWDG is running.  
+  * @param  NewState: new state of the LSI.
+  *          This parameter can be: ENABLE or DISABLE.
+  * @note   When the LSI is stopped, LSIRDY flag goes low after 6 LSI oscillator
+  *         clock cycles. 
+  * @retval None
+  */
+void RCC_LSICmd(FunctionalState NewState)
+{
+  /* Check the parameters */
+  assert_param(IS_FUNCTIONAL_STATE(NewState));
+
+  *(__IO uint32_t *) CSR_LSION_BB = (uint32_t)NewState;
+}
+
+/**
+  * @brief  Configures the main PLL clock source, multiplication and division factors.
+  * @note   This function must be used only when the main PLL is disabled.
+  *  
+  * @param  RCC_PLLSource: specifies the PLL entry clock source.
+  *          This parameter can be one of the following values:
+  *            @arg RCC_PLLSource_HSI: HSI oscillator clock selected as PLL clock entry
+  *            @arg RCC_PLLSource_HSE: HSE oscillator clock selected as PLL clock entry
+  * @note   This clock source (RCC_PLLSource) is common for the main PLL and PLLI2S.  
+  *  
+  * @param  PLLM: specifies the division factor for PLL VCO input clock
+  *          This parameter must be a number between 0 and 63.
+  * @note   You have to set the PLLM parameter correctly to ensure that the VCO input
+  *         frequency ranges from 1 to 2 MHz. It is recommended to select a frequency
+  *         of 2 MHz to limit PLL jitter.
+  *  
+  * @param  PLLN: specifies the multiplication factor for PLL VCO output clock
+  *          This parameter must be a number between 192 and 432.
+  * @note   You have to set the PLLN parameter correctly to ensure that the VCO
+  *         output frequency is between 192 and 432 MHz.
+  *   
+  * @param  PLLP: specifies the division factor for main system clock (SYSCLK)
+  *          This parameter must be a number in the range {2, 4, 6, or 8}.
+  * @note   You have to set the PLLP parameter correctly to not exceed 168 MHz on
+  *         the System clock frequency.
+  *  
+  * @param  PLLQ: specifies the division factor for OTG FS, SDIO and RNG clocks
+  *          This parameter must be a number between 4 and 15.
+  * @note   If the USB OTG FS is used in your application, you have to set the
+  *         PLLQ parameter correctly to have 48 MHz clock for the USB. However,
+  *         the SDIO and RNG need a frequency lower than or equal to 48 MHz to work
+  *         correctly.
+  *   
+  * @retval None
+  */
+void RCC_PLLConfig(uint32_t RCC_PLLSource, uint32_t PLLM, uint32_t PLLN, uint32_t PLLP, uint32_t PLLQ)
+{
+  /* Check the parameters */
+  assert_param(IS_RCC_PLL_SOURCE(RCC_PLLSource));
+  assert_param(IS_RCC_PLLM_VALUE(PLLM));
+  assert_param(IS_RCC_PLLN_VALUE(PLLN));
+  assert_param(IS_RCC_PLLP_VALUE(PLLP));
+  assert_param(IS_RCC_PLLQ_VALUE(PLLQ));
+
+  RCC->PLLCFGR = PLLM | (PLLN << 6) | (((PLLP >> 1) -1) << 16) | (RCC_PLLSource) |
+                 (PLLQ << 24);
+}
+
+/**
+  * @brief  Enables or disables the main PLL.
+  * @note   After enabling the main PLL, the application software should wait on 
+  *         PLLRDY flag to be set indicating that PLL clock is stable and can
+  *         be used as system clock source.
+  * @note   The main PLL can not be disabled if it is used as system clock source
+  * @note   The main PLL is disabled by hardware when entering STOP and STANDBY modes.
+  * @param  NewState: new state of the main PLL. This parameter can be: ENABLE or DISABLE.
+  * @retval None
+  */
+void RCC_PLLCmd(FunctionalState NewState)
+{
+  /* Check the parameters */
+  assert_param(IS_FUNCTIONAL_STATE(NewState));
+  *(__IO uint32_t *) CR_PLLON_BB = (uint32_t)NewState;
+}
+
+/**
+  * @brief  Configures the PLLI2S clock multiplication and division factors.
+  *  
+  * @note   This function must be used only when the PLLI2S is disabled.
+  * @note   PLLI2S clock source is common with the main PLL (configured in 
+  *         RCC_PLLConfig function )  
+  *             
+  * @param  PLLI2SN: specifies the multiplication factor for PLLI2S VCO output clock
+  *          This parameter must be a number between 192 and 432.
+  * @note   You have to set the PLLI2SN parameter correctly to ensure that the VCO 
+  *         output frequency is between 192 and 432 MHz.
+  *    
+  * @param  PLLI2SR: specifies the division factor for I2S clock
+  *          This parameter must be a number between 2 and 7.
+  * @note   You have to set the PLLI2SR parameter correctly to not exceed 192 MHz
+  *         on the I2S clock frequency.
+  *   
+  * @retval None
+  */
+void RCC_PLLI2SConfig(uint32_t PLLI2SN, uint32_t PLLI2SR)
+{
+  /* Check the parameters */
+  assert_param(IS_RCC_PLLI2SN_VALUE(PLLI2SN));
+  assert_param(IS_RCC_PLLI2SR_VALUE(PLLI2SR));
+
+  RCC->PLLI2SCFGR = (PLLI2SN << 6) | (PLLI2SR << 28);
+}
+
+/**
+  * @brief  Enables or disables the PLLI2S. 
+  * @note   The PLLI2S is disabled by hardware when entering STOP and STANDBY modes.  
+  * @param  NewState: new state of the PLLI2S. This parameter can be: ENABLE or DISABLE.
+  * @retval None
+  */
+void RCC_PLLI2SCmd(FunctionalState NewState)
+{
+  /* Check the parameters */
+  assert_param(IS_FUNCTIONAL_STATE(NewState));
+  *(__IO uint32_t *) CR_PLLI2SON_BB = (uint32_t)NewState;
+}
+
+/**
+  * @brief  Enables or disables the Clock Security System.
+  * @note   If a failure is detected on the HSE oscillator clock, this oscillator
+  *         is automatically disabled and an interrupt is generated to inform the
+  *         software about the failure (Clock Security System Interrupt, CSSI),
+  *         allowing the MCU to perform rescue operations. The CSSI is linked to 
+  *         the Cortex-M4 NMI (Non-Maskable Interrupt) exception vector.  
+  * @param  NewState: new state of the Clock Security System.
+  *         This parameter can be: ENABLE or DISABLE.
+  * @retval None
+  */
+void RCC_ClockSecuritySystemCmd(FunctionalState NewState)
+{
+  /* Check the parameters */
+  assert_param(IS_FUNCTIONAL_STATE(NewState));
+  *(__IO uint32_t *) CR_CSSON_BB = (uint32_t)NewState;
+}
+
+/**
+  * @brief  Selects the clock source to output on MCO1 pin(PA8).
+  * @note   PA8 should be configured in alternate function mode.
+  * @param  RCC_MCO1Source: specifies the clock source to output.
+  *          This parameter can be one of the following values:
+  *            @arg RCC_MCO1Source_HSI: HSI clock selected as MCO1 source
+  *            @arg RCC_MCO1Source_LSE: LSE clock selected as MCO1 source
+  *            @arg RCC_MCO1Source_HSE: HSE clock selected as MCO1 source
+  *            @arg RCC_MCO1Source_PLLCLK: main PLL clock selected as MCO1 source
+  * @param  RCC_MCO1Div: specifies the MCO1 prescaler.
+  *          This parameter can be one of the following values:
+  *            @arg RCC_MCO1Div_1: no division applied to MCO1 clock
+  *            @arg RCC_MCO1Div_2: division by 2 applied to MCO1 clock
+  *            @arg RCC_MCO1Div_3: division by 3 applied to MCO1 clock
+  *            @arg RCC_MCO1Div_4: division by 4 applied to MCO1 clock
+  *            @arg RCC_MCO1Div_5: division by 5 applied to MCO1 clock
+  * @retval None
+  */
+void RCC_MCO1Config(uint32_t RCC_MCO1Source, uint32_t RCC_MCO1Div)
+{
+  uint32_t tmpreg = 0;
+  
+  /* Check the parameters */
+  assert_param(IS_RCC_MCO1SOURCE(RCC_MCO1Source));
+  assert_param(IS_RCC_MCO1DIV(RCC_MCO1Div));  
+
+  tmpreg = RCC->CFGR;
+
+  /* Clear MCO1[1:0] and MCO1PRE[2:0] bits */
+  tmpreg &= CFGR_MCO1_RESET_MASK;
+
+  /* Select MCO1 clock source and prescaler */
+  tmpreg |= RCC_MCO1Source | RCC_MCO1Div;
+
+  /* Store the new value */
+  RCC->CFGR = tmpreg;  
+}
+
+/**
+  * @brief  Selects the clock source to output on MCO2 pin(PC9).
+  * @note   PC9 should be configured in alternate function mode.
+  * @param  RCC_MCO2Source: specifies the clock source to output.
+  *          This parameter can be one of the following values:
+  *            @arg RCC_MCO2Source_SYSCLK: System clock (SYSCLK) selected as MCO2 source
+  *            @arg RCC_MCO2Source_PLLI2SCLK: PLLI2S clock selected as MCO2 source
+  *            @arg RCC_MCO2Source_HSE: HSE clock selected as MCO2 source
+  *            @arg RCC_MCO2Source_PLLCLK: main PLL clock selected as MCO2 source
+  * @param  RCC_MCO2Div: specifies the MCO2 prescaler.
+  *          This parameter can be one of the following values:
+  *            @arg RCC_MCO2Div_1: no division applied to MCO2 clock
+  *            @arg RCC_MCO2Div_2: division by 2 applied to MCO2 clock
+  *            @arg RCC_MCO2Div_3: division by 3 applied to MCO2 clock
+  *            @arg RCC_MCO2Div_4: division by 4 applied to MCO2 clock
+  *            @arg RCC_MCO2Div_5: division by 5 applied to MCO2 clock
+  * @retval None
+  */
+void RCC_MCO2Config(uint32_t RCC_MCO2Source, uint32_t RCC_MCO2Div)
+{
+  uint32_t tmpreg = 0;
+  
+  /* Check the parameters */
+  assert_param(IS_RCC_MCO2SOURCE(RCC_MCO2Source));
+  assert_param(IS_RCC_MCO2DIV(RCC_MCO2Div));
+  
+  tmpreg = RCC->CFGR;
+  
+  /* Clear MCO2 and MCO2PRE[2:0] bits */
+  tmpreg &= CFGR_MCO2_RESET_MASK;
+
+  /* Select MCO2 clock source and prescaler */
+  tmpreg |= RCC_MCO2Source | RCC_MCO2Div;
+
+  /* Store the new value */
+  RCC->CFGR = tmpreg;  
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup RCC_Group2 System AHB and APB busses clocks configuration functions
+ *  @brief   System, AHB and APB busses clocks configuration functions
+ *
+@verbatim   
+ ===============================================================================
+             System, AHB and APB busses clocks configuration functions
+ ===============================================================================  
+
+  This section provide functions allowing to configure the System, AHB, APB1 and 
+  APB2 busses clocks.
+  
+  1. Several clock sources can be used to drive the System clock (SYSCLK): HSI,
+     HSE and PLL.
+     The AHB clock (HCLK) is derived from System clock through configurable prescaler
+     and used to clock the CPU, memory and peripherals mapped on AHB bus (DMA, GPIO...).
+     APB1 (PCLK1) and APB2 (PCLK2) clocks are derived from AHB clock through 
+     configurable prescalers and used to clock the peripherals mapped on these busses.
+     You can use "RCC_GetClocksFreq()" function to retrieve the frequencies of these clocks.  
+
+@note All the peripheral clocks are derived from the System clock (SYSCLK) except:
+       - I2S: the I2S clock can be derived either from a specific PLL (PLLI2S) or
+          from an external clock mapped on the I2S_CKIN pin. 
+          You have to use RCC_I2SCLKConfig() function to configure this clock. 
+       - RTC: the RTC clock can be derived either from the LSI, LSE or HSE clock
+          divided by 2 to 31. You have to use RCC_RTCCLKConfig() and RCC_RTCCLKCmd()
+          functions to configure this clock. 
+       - USB OTG FS, SDIO and RTC: USB OTG FS require a frequency equal to 48 MHz
+          to work correctly, while the SDIO require a frequency equal or lower than
+          to 48. This clock is derived of the main PLL through PLLQ divider.
+       - IWDG clock which is always the LSI clock.
+       
+  2. The maximum frequency of the SYSCLK and HCLK is 168 MHz, PCLK2 82 MHz and PCLK1 42 MHz.
+     Depending on the device voltage range, the maximum frequency should be 
+     adapted accordingly:
+ +-------------------------------------------------------------------------------------+     
+ | Latency       |                HCLK clock frequency (MHz)                           |
+ |               |---------------------------------------------------------------------|     
+ |               | voltage range  | voltage range  | voltage range   | voltage range   |
+ |               | 2.7 V - 3.6 V  | 2.4 V - 2.7 V  | 2.1 V - 2.4 V   | 1.8 V - 2.1 V   |
+ |---------------|----------------|----------------|-----------------|-----------------|              
+ |0WS(1CPU cycle)|0 < HCLK <= 30  |0 < HCLK <= 24  |0 < HCLK <= 18   |0 < HCLK <= 16   |
+ |---------------|----------------|----------------|-----------------|-----------------|   
+ |1WS(2CPU cycle)|30 < HCLK <= 60 |24 < HCLK <= 48 |18 < HCLK <= 36  |16 < HCLK <= 32  | 
+ |---------------|----------------|----------------|-----------------|-----------------|   
+ |2WS(3CPU cycle)|60 < HCLK <= 90 |48 < HCLK <= 72 |36 < HCLK <= 54  |32 < HCLK <= 48  |
+ |---------------|----------------|----------------|-----------------|-----------------| 
+ |3WS(4CPU cycle)|90 < HCLK <= 120|72 < HCLK <= 96 |54 < HCLK <= 72  |48 < HCLK <= 64  |
+ |---------------|----------------|----------------|-----------------|-----------------| 
+ |4WS(5CPU cycle)|120< HCLK <= 150|96 < HCLK <= 120|72 < HCLK <= 90  |64 < HCLK <= 80  |
+ |---------------|----------------|----------------|-----------------|-----------------| 
+ |5WS(6CPU cycle)|120< HCLK <= 168|120< HCLK <= 144|90 < HCLK <= 108 |80 < HCLK <= 96  | 
+ |---------------|----------------|----------------|-----------------|-----------------| 
+ |6WS(7CPU cycle)|      NA        |144< HCLK <= 168|108 < HCLK <= 120|96 < HCLK <= 112 | 
+ |---------------|----------------|----------------|-----------------|-----------------| 
+ |7WS(8CPU cycle)|      NA        |      NA        |120 < HCLK <= 138|112 < HCLK <= 120| 
+ +-------------------------------------------------------------------------------------+    
+   @note When VOS bit (in PWR_CR register) is reset to '0’, the maximum value of HCLK is 144 MHz.
+         You can use PWR_MainRegulatorModeConfig() function to set or reset this bit.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Configures the system clock (SYSCLK).
+  * @note   The HSI is used (enabled by hardware) as system clock source after
+  *         startup from Reset, wake-up from STOP and STANDBY mode, or in case
+  *         of failure of the HSE used directly or indirectly as system clock
+  *         (if the Clock Security System CSS is enabled).
+  * @note   A switch from one clock source to another occurs only if the target
+  *         clock source is ready (clock stable after startup delay or PLL locked). 
+  *         If a clock source which is not yet ready is selected, the switch will
+  *         occur when the clock source will be ready. 
+  *         You can use RCC_GetSYSCLKSource() function to know which clock is
+  *         currently used as system clock source. 
+  * @param  RCC_SYSCLKSource: specifies the clock source used as system clock.
+  *          This parameter can be one of the following values:
+  *            @arg RCC_SYSCLKSource_HSI:    HSI selected as system clock source
+  *            @arg RCC_SYSCLKSource_HSE:    HSE selected as system clock source
+  *            @arg RCC_SYSCLKSource_PLLCLK: PLL selected as system clock source
+  * @retval None
+  */
+void RCC_SYSCLKConfig(uint32_t RCC_SYSCLKSource)
+{
+  uint32_t tmpreg = 0;
+
+  /* Check the parameters */
+  assert_param(IS_RCC_SYSCLK_SOURCE(RCC_SYSCLKSource));
+
+  tmpreg = RCC->CFGR;
+
+  /* Clear SW[1:0] bits */
+  tmpreg &= ~RCC_CFGR_SW;
+
+  /* Set SW[1:0] bits according to RCC_SYSCLKSource value */
+  tmpreg |= RCC_SYSCLKSource;
+
+  /* Store the new value */
+  RCC->CFGR = tmpreg;
+}
+
+/**
+  * @brief  Returns the clock source used as system clock.
+  * @param  None
+  * @retval The clock source used as system clock. The returned value can be one
+  *         of the following:
+  *              - 0x00: HSI used as system clock
+  *              - 0x04: HSE used as system clock
+  *              - 0x08: PLL used as system clock
+  */
+uint8_t RCC_GetSYSCLKSource(void)
+{
+  return ((uint8_t)(RCC->CFGR & RCC_CFGR_SWS));
+}
+
+/**
+  * @brief  Configures the AHB clock (HCLK).
+  * @note   Depending on the device voltage range, the software has to set correctly
+  *         these bits to ensure that HCLK not exceed the maximum allowed frequency
+  *         (for more details refer to section above
+  *           "CPU, AHB and APB busses clocks configuration functions")
+  * @param  RCC_SYSCLK: defines the AHB clock divider. This clock is derived from 
+  *         the system clock (SYSCLK).
+  *          This parameter can be one of the following values:
+  *            @arg RCC_SYSCLK_Div1: AHB clock = SYSCLK
+  *            @arg RCC_SYSCLK_Div2: AHB clock = SYSCLK/2
+  *            @arg RCC_SYSCLK_Div4: AHB clock = SYSCLK/4
+  *            @arg RCC_SYSCLK_Div8: AHB clock = SYSCLK/8
+  *            @arg RCC_SYSCLK_Div16: AHB clock = SYSCLK/16
+  *            @arg RCC_SYSCLK_Div64: AHB clock = SYSCLK/64
+  *            @arg RCC_SYSCLK_Div128: AHB clock = SYSCLK/128
+  *            @arg RCC_SYSCLK_Div256: AHB clock = SYSCLK/256
+  *            @arg RCC_SYSCLK_Div512: AHB clock = SYSCLK/512
+  * @retval None
+  */
+void RCC_HCLKConfig(uint32_t RCC_SYSCLK)
+{
+  uint32_t tmpreg = 0;
+  
+  /* Check the parameters */
+  assert_param(IS_RCC_HCLK(RCC_SYSCLK));
+
+  tmpreg = RCC->CFGR;
+
+  /* Clear HPRE[3:0] bits */
+  tmpreg &= ~RCC_CFGR_HPRE;
+
+  /* Set HPRE[3:0] bits according to RCC_SYSCLK value */
+  tmpreg |= RCC_SYSCLK;
+
+  /* Store the new value */
+  RCC->CFGR = tmpreg;
+}
+
+
+/**
+  * @brief  Configures the Low Speed APB clock (PCLK1).
+  * @param  RCC_HCLK: defines the APB1 clock divider. This clock is derived from 
+  *         the AHB clock (HCLK).
+  *          This parameter can be one of the following values:
+  *            @arg RCC_HCLK_Div1:  APB1 clock = HCLK
+  *            @arg RCC_HCLK_Div2:  APB1 clock = HCLK/2
+  *            @arg RCC_HCLK_Div4:  APB1 clock = HCLK/4
+  *            @arg RCC_HCLK_Div8:  APB1 clock = HCLK/8
+  *            @arg RCC_HCLK_Div16: APB1 clock = HCLK/16
+  * @retval None
+  */
+void RCC_PCLK1Config(uint32_t RCC_HCLK)
+{
+  uint32_t tmpreg = 0;
+
+  /* Check the parameters */
+  assert_param(IS_RCC_PCLK(RCC_HCLK));
+
+  tmpreg = RCC->CFGR;
+
+  /* Clear PPRE1[2:0] bits */
+  tmpreg &= ~RCC_CFGR_PPRE1;
+
+  /* Set PPRE1[2:0] bits according to RCC_HCLK value */
+  tmpreg |= RCC_HCLK;
+
+  /* Store the new value */
+  RCC->CFGR = tmpreg;
+}
+
+/**
+  * @brief  Configures the High Speed APB clock (PCLK2).
+  * @param  RCC_HCLK: defines the APB2 clock divider. This clock is derived from 
+  *         the AHB clock (HCLK).
+  *          This parameter can be one of the following values:
+  *            @arg RCC_HCLK_Div1:  APB2 clock = HCLK
+  *            @arg RCC_HCLK_Div2:  APB2 clock = HCLK/2
+  *            @arg RCC_HCLK_Div4:  APB2 clock = HCLK/4
+  *            @arg RCC_HCLK_Div8:  APB2 clock = HCLK/8
+  *            @arg RCC_HCLK_Div16: APB2 clock = HCLK/16
+  * @retval None
+  */
+void RCC_PCLK2Config(uint32_t RCC_HCLK)
+{
+  uint32_t tmpreg = 0;
+
+  /* Check the parameters */
+  assert_param(IS_RCC_PCLK(RCC_HCLK));
+
+  tmpreg = RCC->CFGR;
+
+  /* Clear PPRE2[2:0] bits */
+  tmpreg &= ~RCC_CFGR_PPRE2;
+
+  /* Set PPRE2[2:0] bits according to RCC_HCLK value */
+  tmpreg |= RCC_HCLK << 3;
+
+  /* Store the new value */
+  RCC->CFGR = tmpreg;
+}
+
+/**
+  * @brief  Returns the frequencies of different on chip clocks; SYSCLK, HCLK, 
+  *         PCLK1 and PCLK2.       
+  * 
+  * @note   The system frequency computed by this function is not the real 
+  *         frequency in the chip. It is calculated based on the predefined 
+  *         constant and the selected clock source:
+  * @note     If SYSCLK source is HSI, function returns values based on HSI_VALUE(*)
+  * @note     If SYSCLK source is HSE, function returns values based on HSE_VALUE(**)
+  * @note     If SYSCLK source is PLL, function returns values based on HSE_VALUE(**) 
+  *           or HSI_VALUE(*) multiplied/divided by the PLL factors.         
+  * @note     (*) HSI_VALUE is a constant defined in stm32f4xx.h file (default value
+  *               16 MHz) but the real value may vary depending on the variations
+  *               in voltage and temperature.
+  * @note     (**) HSE_VALUE is a constant defined in stm32f4xx.h file (default value
+  *                25 MHz), user has to ensure that HSE_VALUE is same as the real
+  *                frequency of the crystal used. Otherwise, this function may
+  *                have wrong result.
+  *                
+  * @note   The result of this function could be not correct when using fractional
+  *         value for HSE crystal.
+  *   
+  * @param  RCC_Clocks: pointer to a RCC_ClocksTypeDef structure which will hold
+  *          the clocks frequencies.
+  *     
+  * @note   This function can be used by the user application to compute the 
+  *         baudrate for the communication peripherals or configure other parameters.
+  * @note   Each time SYSCLK, HCLK, PCLK1 and/or PCLK2 clock changes, this function
+  *         must be called to update the structure's field. Otherwise, any
+  *         configuration based on this function will be incorrect.
+  *    
+  * @retval None
+  */
+void RCC_GetClocksFreq(RCC_ClocksTypeDef* RCC_Clocks)
+{
+  uint32_t tmp = 0, presc = 0, pllvco = 0, pllp = 2, pllsource = 0, pllm = 2;
+
+  /* Get SYSCLK source -------------------------------------------------------*/
+  tmp = RCC->CFGR & RCC_CFGR_SWS;
+
+  switch (tmp)
+  {
+    case 0x00:  /* HSI used as system clock source */
+      RCC_Clocks->SYSCLK_Frequency = HSI_VALUE;
+      break;
+    case 0x04:  /* HSE used as system clock  source */
+      RCC_Clocks->SYSCLK_Frequency = HSE_VALUE;
+      break;
+    case 0x08:  /* PLL used as system clock  source */
+
+      /* PLL_VCO = (HSE_VALUE or HSI_VALUE / PLLM) * PLLN
+         SYSCLK = PLL_VCO / PLLP
+         */    
+      pllsource = (RCC->PLLCFGR & RCC_PLLCFGR_PLLSRC) >> 22;
+      pllm = RCC->PLLCFGR & RCC_PLLCFGR_PLLM;
+      
+      if (pllsource != 0)
+      {
+        /* HSE used as PLL clock source */
+        pllvco = (HSE_VALUE / pllm) * ((RCC->PLLCFGR & RCC_PLLCFGR_PLLN) >> 6);
+      }
+      else
+      {
+        /* HSI used as PLL clock source */
+        pllvco = (HSI_VALUE / pllm) * ((RCC->PLLCFGR & RCC_PLLCFGR_PLLN) >> 6);      
+      }
+
+      pllp = (((RCC->PLLCFGR & RCC_PLLCFGR_PLLP) >>16) + 1 ) *2;
+      RCC_Clocks->SYSCLK_Frequency = pllvco/pllp;
+      break;
+    default:
+      RCC_Clocks->SYSCLK_Frequency = HSI_VALUE;
+      break;
+  }
+  /* Compute HCLK, PCLK1 and PCLK2 clocks frequencies ------------------------*/
+
+  /* Get HCLK prescaler */
+  tmp = RCC->CFGR & RCC_CFGR_HPRE;
+  tmp = tmp >> 4;
+  presc = APBAHBPrescTable[tmp];
+  /* HCLK clock frequency */
+  RCC_Clocks->HCLK_Frequency = RCC_Clocks->SYSCLK_Frequency >> presc;
+
+  /* Get PCLK1 prescaler */
+  tmp = RCC->CFGR & RCC_CFGR_PPRE1;
+  tmp = tmp >> 10;
+  presc = APBAHBPrescTable[tmp];
+  /* PCLK1 clock frequency */
+  RCC_Clocks->PCLK1_Frequency = RCC_Clocks->HCLK_Frequency >> presc;
+
+  /* Get PCLK2 prescaler */
+  tmp = RCC->CFGR & RCC_CFGR_PPRE2;
+  tmp = tmp >> 13;
+  presc = APBAHBPrescTable[tmp];
+  /* PCLK2 clock frequency */
+  RCC_Clocks->PCLK2_Frequency = RCC_Clocks->HCLK_Frequency >> presc;
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup RCC_Group3 Peripheral clocks configuration functions
+ *  @brief   Peripheral clocks configuration functions 
+ *
+@verbatim   
+ ===============================================================================
+                   Peripheral clocks configuration functions
+ ===============================================================================  
+
+  This section provide functions allowing to configure the Peripheral clocks. 
+  
+  1. The RTC clock which is derived from the LSI, LSE or HSE clock divided by 2 to 31.
+     
+  2. After restart from Reset or wakeup from STANDBY, all peripherals are off
+     except internal SRAM, Flash and JTAG. Before to start using a peripheral you
+     have to enable its interface clock. You can do this using RCC_AHBPeriphClockCmd()
+     , RCC_APB2PeriphClockCmd() and RCC_APB1PeriphClockCmd() functions.
+
+  3. To reset the peripherals configuration (to the default state after device reset)
+     you can use RCC_AHBPeriphResetCmd(), RCC_APB2PeriphResetCmd() and 
+     RCC_APB1PeriphResetCmd() functions.
+     
+  4. To further reduce power consumption in SLEEP mode the peripheral clocks can
+     be disabled prior to executing the WFI or WFE instructions. You can do this
+     using RCC_AHBPeriphClockLPModeCmd(), RCC_APB2PeriphClockLPModeCmd() and
+     RCC_APB1PeriphClockLPModeCmd() functions.  
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Configures the RTC clock (RTCCLK).
+  * @note   As the RTC clock configuration bits are in the Backup domain and write
+  *         access is denied to this domain after reset, you have to enable write
+  *         access using PWR_BackupAccessCmd(ENABLE) function before to configure
+  *         the RTC clock source (to be done once after reset).    
+  * @note   Once the RTC clock is configured it can't be changed unless the  
+  *         Backup domain is reset using RCC_BackupResetCmd() function, or by
+  *         a Power On Reset (POR).
+  *    
+  * @param  RCC_RTCCLKSource: specifies the RTC clock source.
+  *          This parameter can be one of the following values:
+  *            @arg RCC_RTCCLKSource_LSE: LSE selected as RTC clock
+  *            @arg RCC_RTCCLKSource_LSI: LSI selected as RTC clock
+  *            @arg RCC_RTCCLKSource_HSE_Divx: HSE clock divided by x selected
+  *                                            as RTC clock, where x:[2,31]
+  *  
+  * @note   If the LSE or LSI is used as RTC clock source, the RTC continues to
+  *         work in STOP and STANDBY modes, and can be used as wakeup source.
+  *         However, when the HSE clock is used as RTC clock source, the RTC
+  *         cannot be used in STOP and STANDBY modes.    
+  * @note   The maximum input clock frequency for RTC is 1MHz (when using HSE as
+  *         RTC clock source).
+  *  
+  * @retval None
+  */
+void RCC_RTCCLKConfig(uint32_t RCC_RTCCLKSource)
+{
+  uint32_t tmpreg = 0;
+
+  /* Check the parameters */
+  assert_param(IS_RCC_RTCCLK_SOURCE(RCC_RTCCLKSource));
+
+  if ((RCC_RTCCLKSource & 0x00000300) == 0x00000300)
+  { /* If HSE is selected as RTC clock source, configure HSE division factor for RTC clock */
+    tmpreg = RCC->CFGR;
+
+    /* Clear RTCPRE[4:0] bits */
+    tmpreg &= ~RCC_CFGR_RTCPRE;
+
+    /* Configure HSE division factor for RTC clock */
+    tmpreg |= (RCC_RTCCLKSource & 0xFFFFCFF);
+
+    /* Store the new value */
+    RCC->CFGR = tmpreg;
+  }
+    
+  /* Select the RTC clock source */
+  RCC->BDCR |= (RCC_RTCCLKSource & 0x00000FFF);
+}
+
+/**
+  * @brief  Enables or disables the RTC clock.
+  * @note   This function must be used only after the RTC clock source was selected
+  *         using the RCC_RTCCLKConfig function.
+  * @param  NewState: new state of the RTC clock. This parameter can be: ENABLE or DISABLE.
+  * @retval None
+  */
+void RCC_RTCCLKCmd(FunctionalState NewState)
+{
+  /* Check the parameters */
+  assert_param(IS_FUNCTIONAL_STATE(NewState));
+
+  *(__IO uint32_t *) BDCR_RTCEN_BB = (uint32_t)NewState;
+}
+
+/**
+  * @brief  Forces or releases the Backup domain reset.
+  * @note   This function resets the RTC peripheral (including the backup registers)
+  *         and the RTC clock source selection in RCC_CSR register.
+  * @note   The BKPSRAM is not affected by this reset.    
+  * @param  NewState: new state of the Backup domain reset.
+  *          This parameter can be: ENABLE or DISABLE.
+  * @retval None
+  */
+void RCC_BackupResetCmd(FunctionalState NewState)
+{
+  /* Check the parameters */
+  assert_param(IS_FUNCTIONAL_STATE(NewState));
+  *(__IO uint32_t *) BDCR_BDRST_BB = (uint32_t)NewState;
+}
+
+/**
+  * @brief  Configures the I2S clock source (I2SCLK).
+  * @note   This function must be called before enabling the I2S APB clock.
+  * @param  RCC_I2SCLKSource: specifies the I2S clock source.
+  *          This parameter can be one of the following values:
+  *            @arg RCC_I2S2CLKSource_PLLI2S: PLLI2S clock used as I2S clock source
+  *            @arg RCC_I2S2CLKSource_Ext: External clock mapped on the I2S_CKIN pin
+  *                                        used as I2S clock source
+  * @retval None
+  */
+void RCC_I2SCLKConfig(uint32_t RCC_I2SCLKSource)
+{
+  /* Check the parameters */
+  assert_param(IS_RCC_I2SCLK_SOURCE(RCC_I2SCLKSource));
+
+  *(__IO uint32_t *) CFGR_I2SSRC_BB = RCC_I2SCLKSource;
+}
+
+/**
+  * @brief  Enables or disables the AHB1 peripheral clock.
+  * @note   After reset, the peripheral clock (used for registers read/write access)
+  *         is disabled and the application software has to enable this clock before 
+  *         using it.   
+  * @param  RCC_AHBPeriph: specifies the AHB1 peripheral to gates its clock.
+  *          This parameter can be any combination of the following values:
+  *            @arg RCC_AHB1Periph_GPIOA:       GPIOA clock
+  *            @arg RCC_AHB1Periph_GPIOB:       GPIOB clock 
+  *            @arg RCC_AHB1Periph_GPIOC:       GPIOC clock
+  *            @arg RCC_AHB1Periph_GPIOD:       GPIOD clock
+  *            @arg RCC_AHB1Periph_GPIOE:       GPIOE clock
+  *            @arg RCC_AHB1Periph_GPIOF:       GPIOF clock
+  *            @arg RCC_AHB1Periph_GPIOG:       GPIOG clock
+  *            @arg RCC_AHB1Periph_GPIOG:       GPIOG clock
+  *            @arg RCC_AHB1Periph_GPIOI:       GPIOI clock
+  *            @arg RCC_AHB1Periph_CRC:         CRC clock
+  *            @arg RCC_AHB1Periph_BKPSRAM:     BKPSRAM interface clock
+  *            @arg RCC_AHB1Periph_CCMDATARAMEN CCM data RAM interface clock
+  *            @arg RCC_AHB1Periph_DMA1:        DMA1 clock
+  *            @arg RCC_AHB1Periph_DMA2:        DMA2 clock
+  *            @arg RCC_AHB1Periph_ETH_MAC:     Ethernet MAC clock
+  *            @arg RCC_AHB1Periph_ETH_MAC_Tx:  Ethernet Transmission clock
+  *            @arg RCC_AHB1Periph_ETH_MAC_Rx:  Ethernet Reception clock
+  *            @arg RCC_AHB1Periph_ETH_MAC_PTP: Ethernet PTP clock
+  *            @arg RCC_AHB1Periph_OTG_HS:      USB OTG HS clock
+  *            @arg RCC_AHB1Periph_OTG_HS_ULPI: USB OTG HS ULPI clock
+  * @param  NewState: new state of the specified peripheral clock.
+  *          This parameter can be: ENABLE or DISABLE.
+  * @retval None
+  */
+void RCC_AHB1PeriphClockCmd(uint32_t RCC_AHB1Periph, FunctionalState NewState)
+{
+  /* Check the parameters */
+  assert_param(IS_RCC_AHB1_CLOCK_PERIPH(RCC_AHB1Periph));
+
+  assert_param(IS_FUNCTIONAL_STATE(NewState));
+  if (NewState != DISABLE)
+  {
+    RCC->AHB1ENR |= RCC_AHB1Periph;
+  }
+  else
+  {
+    RCC->AHB1ENR &= ~RCC_AHB1Periph;
+  }
+}
+
+/**
+  * @brief  Enables or disables the AHB2 peripheral clock.
+  * @note   After reset, the peripheral clock (used for registers read/write access)
+  *         is disabled and the application software has to enable this clock before 
+  *         using it. 
+  * @param  RCC_AHBPeriph: specifies the AHB2 peripheral to gates its clock.
+  *          This parameter can be any combination of the following values:
+  *            @arg RCC_AHB2Periph_DCMI:   DCMI clock
+  *            @arg RCC_AHB2Periph_CRYP:   CRYP clock
+  *            @arg RCC_AHB2Periph_HASH:   HASH clock
+  *            @arg RCC_AHB2Periph_RNG:    RNG clock
+  *            @arg RCC_AHB2Periph_OTG_FS: USB OTG FS clock
+  * @param  NewState: new state of the specified peripheral clock.
+  *          This parameter can be: ENABLE or DISABLE.
+  * @retval None
+  */
+void RCC_AHB2PeriphClockCmd(uint32_t RCC_AHB2Periph, FunctionalState NewState)
+{
+  /* Check the parameters */
+  assert_param(IS_RCC_AHB2_PERIPH(RCC_AHB2Periph));
+  assert_param(IS_FUNCTIONAL_STATE(NewState));
+
+  if (NewState != DISABLE)
+  {
+    RCC->AHB2ENR |= RCC_AHB2Periph;
+  }
+  else
+  {
+    RCC->AHB2ENR &= ~RCC_AHB2Periph;
+  }
+}
+
+/**
+  * @brief  Enables or disables the AHB3 peripheral clock.
+  * @note   After reset, the peripheral clock (used for registers read/write access)
+  *         is disabled and the application software has to enable this clock before 
+  *         using it. 
+  * @param  RCC_AHBPeriph: specifies the AHB3 peripheral to gates its clock.
+  *          This parameter must be: RCC_AHB3Periph_FSMC
+  * @param  NewState: new state of the specified peripheral clock.
+  *          This parameter can be: ENABLE or DISABLE.
+  * @retval None
+  */
+void RCC_AHB3PeriphClockCmd(uint32_t RCC_AHB3Periph, FunctionalState NewState)
+{
+  /* Check the parameters */
+  assert_param(IS_RCC_AHB3_PERIPH(RCC_AHB3Periph));  
+  assert_param(IS_FUNCTIONAL_STATE(NewState));
+
+  if (NewState != DISABLE)
+  {
+    RCC->AHB3ENR |= RCC_AHB3Periph;
+  }
+  else
+  {
+    RCC->AHB3ENR &= ~RCC_AHB3Periph;
+  }
+}
+
+/**
+  * @brief  Enables or disables the Low Speed APB (APB1) peripheral clock.
+  * @note   After reset, the peripheral clock (used for registers read/write access)
+  *         is disabled and the application software has to enable this clock before 
+  *         using it. 
+  * @param  RCC_APB1Periph: specifies the APB1 peripheral to gates its clock.
+  *          This parameter can be any combination of the following values:
+  *            @arg RCC_APB1Periph_TIM2:   TIM2 clock
+  *            @arg RCC_APB1Periph_TIM3:   TIM3 clock
+  *            @arg RCC_APB1Periph_TIM4:   TIM4 clock
+  *            @arg RCC_APB1Periph_TIM5:   TIM5 clock
+  *            @arg RCC_APB1Periph_TIM6:   TIM6 clock
+  *            @arg RCC_APB1Periph_TIM7:   TIM7 clock
+  *            @arg RCC_APB1Periph_TIM12:  TIM12 clock
+  *            @arg RCC_APB1Periph_TIM13:  TIM13 clock
+  *            @arg RCC_APB1Periph_TIM14:  TIM14 clock
+  *            @arg RCC_APB1Periph_WWDG:   WWDG clock
+  *            @arg RCC_APB1Periph_SPI2:   SPI2 clock
+  *            @arg RCC_APB1Periph_SPI3:   SPI3 clock
+  *            @arg RCC_APB1Periph_USART2: USART2 clock
+  *            @arg RCC_APB1Periph_USART3: USART3 clock
+  *            @arg RCC_APB1Periph_UART4:  UART4 clock
+  *            @arg RCC_APB1Periph_UART5:  UART5 clock
+  *            @arg RCC_APB1Periph_I2C1:   I2C1 clock
+  *            @arg RCC_APB1Periph_I2C2:   I2C2 clock
+  *            @arg RCC_APB1Periph_I2C3:   I2C3 clock
+  *            @arg RCC_APB1Periph_CAN1:   CAN1 clock
+  *            @arg RCC_APB1Periph_CAN2:   CAN2 clock
+  *            @arg RCC_APB1Periph_PWR:    PWR clock
+  *            @arg RCC_APB1Periph_DAC:    DAC clock
+  * @param  NewState: new state of the specified peripheral clock.
+  *          This parameter can be: ENABLE or DISABLE.
+  * @retval None
+  */
+void RCC_APB1PeriphClockCmd(uint32_t RCC_APB1Periph, FunctionalState NewState)
+{
+  /* Check the parameters */
+  assert_param(IS_RCC_APB1_PERIPH(RCC_APB1Periph));  
+  assert_param(IS_FUNCTIONAL_STATE(NewState));
+
+  if (NewState != DISABLE)
+  {
+    RCC->APB1ENR |= RCC_APB1Periph;
+  }
+  else
+  {
+    RCC->APB1ENR &= ~RCC_APB1Periph;
+  }
+}
+
+/**
+  * @brief  Enables or disables the High Speed APB (APB2) peripheral clock.
+  * @note   After reset, the peripheral clock (used for registers read/write access)
+  *         is disabled and the application software has to enable this clock before 
+  *         using it.
+  * @param  RCC_APB2Periph: specifies the APB2 peripheral to gates its clock.
+  *          This parameter can be any combination of the following values:
+  *            @arg RCC_APB2Periph_TIM1:   TIM1 clock
+  *            @arg RCC_APB2Periph_TIM8:   TIM8 clock
+  *            @arg RCC_APB2Periph_USART1: USART1 clock
+  *            @arg RCC_APB2Periph_USART6: USART6 clock
+  *            @arg RCC_APB2Periph_ADC1:   ADC1 clock
+  *            @arg RCC_APB2Periph_ADC2:   ADC2 clock
+  *            @arg RCC_APB2Periph_ADC3:   ADC3 clock
+  *            @arg RCC_APB2Periph_SDIO:   SDIO clock
+  *            @arg RCC_APB2Periph_SPI1:   SPI1 clock
+  *            @arg RCC_APB2Periph_SYSCFG: SYSCFG clock
+  *            @arg RCC_APB2Periph_TIM9:   TIM9 clock
+  *            @arg RCC_APB2Periph_TIM10:  TIM10 clock
+  *            @arg RCC_APB2Periph_TIM11:  TIM11 clock
+  * @param  NewState: new state of the specified peripheral clock.
+  *          This parameter can be: ENABLE or DISABLE.
+  * @retval None
+  */
+void RCC_APB2PeriphClockCmd(uint32_t RCC_APB2Periph, FunctionalState NewState)
+{
+  /* Check the parameters */
+  assert_param(IS_RCC_APB2_PERIPH(RCC_APB2Periph));
+  assert_param(IS_FUNCTIONAL_STATE(NewState));
+
+  if (NewState != DISABLE)
+  {
+    RCC->APB2ENR |= RCC_APB2Periph;
+  }
+  else
+  {
+    RCC->APB2ENR &= ~RCC_APB2Periph;
+  }
+}
+
+/**
+  * @brief  Forces or releases AHB1 peripheral reset.
+  * @param  RCC_AHB1Periph: specifies the AHB1 peripheral to reset.
+  *          This parameter can be any combination of the following values:
+  *            @arg RCC_AHB1Periph_GPIOA:   GPIOA clock
+  *            @arg RCC_AHB1Periph_GPIOB:   GPIOB clock 
+  *            @arg RCC_AHB1Periph_GPIOC:   GPIOC clock
+  *            @arg RCC_AHB1Periph_GPIOD:   GPIOD clock
+  *            @arg RCC_AHB1Periph_GPIOE:   GPIOE clock
+  *            @arg RCC_AHB1Periph_GPIOF:   GPIOF clock
+  *            @arg RCC_AHB1Periph_GPIOG:   GPIOG clock
+  *            @arg RCC_AHB1Periph_GPIOG:   GPIOG clock
+  *            @arg RCC_AHB1Periph_GPIOI:   GPIOI clock
+  *            @arg RCC_AHB1Periph_CRC:     CRC clock
+  *            @arg RCC_AHB1Periph_DMA1:    DMA1 clock
+  *            @arg RCC_AHB1Periph_DMA2:    DMA2 clock
+  *            @arg RCC_AHB1Periph_ETH_MAC: Ethernet MAC clock
+  *            @arg RCC_AHB1Periph_OTG_HS:  USB OTG HS clock
+  *                  
+  * @param  NewState: new state of the specified peripheral reset.
+  *          This parameter can be: ENABLE or DISABLE.
+  * @retval None
+  */
+void RCC_AHB1PeriphResetCmd(uint32_t RCC_AHB1Periph, FunctionalState NewState)
+{
+  /* Check the parameters */
+  assert_param(IS_RCC_AHB1_RESET_PERIPH(RCC_AHB1Periph));
+  assert_param(IS_FUNCTIONAL_STATE(NewState));
+
+  if (NewState != DISABLE)
+  {
+    RCC->AHB1RSTR |= RCC_AHB1Periph;
+  }
+  else
+  {
+    RCC->AHB1RSTR &= ~RCC_AHB1Periph;
+  }
+}
+
+/**
+  * @brief  Forces or releases AHB2 peripheral reset.
+  * @param  RCC_AHB2Periph: specifies the AHB2 peripheral to reset.
+  *          This parameter can be any combination of the following values:
+  *            @arg RCC_AHB2Periph_DCMI:   DCMI clock
+  *            @arg RCC_AHB2Periph_CRYP:   CRYP clock
+  *            @arg RCC_AHB2Periph_HASH:   HASH clock
+  *            @arg RCC_AHB2Periph_RNG:    RNG clock
+  *            @arg RCC_AHB2Periph_OTG_FS: USB OTG FS clock
+  * @param  NewState: new state of the specified peripheral reset.
+  *          This parameter can be: ENABLE or DISABLE.
+  * @retval None
+  */
+void RCC_AHB2PeriphResetCmd(uint32_t RCC_AHB2Periph, FunctionalState NewState)
+{
+  /* Check the parameters */
+  assert_param(IS_RCC_AHB2_PERIPH(RCC_AHB2Periph));
+  assert_param(IS_FUNCTIONAL_STATE(NewState));
+
+  if (NewState != DISABLE)
+  {
+    RCC->AHB2RSTR |= RCC_AHB2Periph;
+  }
+  else
+  {
+    RCC->AHB2RSTR &= ~RCC_AHB2Periph;
+  }
+}
+
+/**
+  * @brief  Forces or releases AHB3 peripheral reset.
+  * @param  RCC_AHB3Periph: specifies the AHB3 peripheral to reset.
+  *          This parameter must be: RCC_AHB3Periph_FSMC
+  * @param  NewState: new state of the specified peripheral reset.
+  *          This parameter can be: ENABLE or DISABLE.
+  * @retval None
+  */
+void RCC_AHB3PeriphResetCmd(uint32_t RCC_AHB3Periph, FunctionalState NewState)
+{
+  /* Check the parameters */
+  assert_param(IS_RCC_AHB3_PERIPH(RCC_AHB3Periph));
+  assert_param(IS_FUNCTIONAL_STATE(NewState));
+
+  if (NewState != DISABLE)
+  {
+    RCC->AHB3RSTR |= RCC_AHB3Periph;
+  }
+  else
+  {
+    RCC->AHB3RSTR &= ~RCC_AHB3Periph;
+  }
+}
+
+/**
+  * @brief  Forces or releases Low Speed APB (APB1) peripheral reset.
+  * @param  RCC_APB1Periph: specifies the APB1 peripheral to reset.
+  *          This parameter can be any combination of the following values:
+  *            @arg RCC_APB1Periph_TIM2:   TIM2 clock
+  *            @arg RCC_APB1Periph_TIM3:   TIM3 clock
+  *            @arg RCC_APB1Periph_TIM4:   TIM4 clock
+  *            @arg RCC_APB1Periph_TIM5:   TIM5 clock
+  *            @arg RCC_APB1Periph_TIM6:   TIM6 clock
+  *            @arg RCC_APB1Periph_TIM7:   TIM7 clock
+  *            @arg RCC_APB1Periph_TIM12:  TIM12 clock
+  *            @arg RCC_APB1Periph_TIM13:  TIM13 clock
+  *            @arg RCC_APB1Periph_TIM14:  TIM14 clock
+  *            @arg RCC_APB1Periph_WWDG:   WWDG clock
+  *            @arg RCC_APB1Periph_SPI2:   SPI2 clock
+  *            @arg RCC_APB1Periph_SPI3:   SPI3 clock
+  *            @arg RCC_APB1Periph_USART2: USART2 clock
+  *            @arg RCC_APB1Periph_USART3: USART3 clock
+  *            @arg RCC_APB1Periph_UART4:  UART4 clock
+  *            @arg RCC_APB1Periph_UART5:  UART5 clock
+  *            @arg RCC_APB1Periph_I2C1:   I2C1 clock
+  *            @arg RCC_APB1Periph_I2C2:   I2C2 clock
+  *            @arg RCC_APB1Periph_I2C3:   I2C3 clock
+  *            @arg RCC_APB1Periph_CAN1:   CAN1 clock
+  *            @arg RCC_APB1Periph_CAN2:   CAN2 clock
+  *            @arg RCC_APB1Periph_PWR:    PWR clock
+  *            @arg RCC_APB1Periph_DAC:    DAC clock
+  * @param  NewState: new state of the specified peripheral reset.
+  *          This parameter can be: ENABLE or DISABLE.
+  * @retval None
+  */
+void RCC_APB1PeriphResetCmd(uint32_t RCC_APB1Periph, FunctionalState NewState)
+{
+  /* Check the parameters */
+  assert_param(IS_RCC_APB1_PERIPH(RCC_APB1Periph));
+  assert_param(IS_FUNCTIONAL_STATE(NewState));
+  if (NewState != DISABLE)
+  {
+    RCC->APB1RSTR |= RCC_APB1Periph;
+  }
+  else
+  {
+    RCC->APB1RSTR &= ~RCC_APB1Periph;
+  }
+}
+
+/**
+  * @brief  Forces or releases High Speed APB (APB2) peripheral reset.
+  * @param  RCC_APB2Periph: specifies the APB2 peripheral to reset.
+  *          This parameter can be any combination of the following values:
+  *            @arg RCC_APB2Periph_TIM1:   TIM1 clock
+  *            @arg RCC_APB2Periph_TIM8:   TIM8 clock
+  *            @arg RCC_APB2Periph_USART1: USART1 clock
+  *            @arg RCC_APB2Periph_USART6: USART6 clock
+  *            @arg RCC_APB2Periph_ADC1:   ADC1 clock
+  *            @arg RCC_APB2Periph_ADC2:   ADC2 clock
+  *            @arg RCC_APB2Periph_ADC3:   ADC3 clock
+  *            @arg RCC_APB2Periph_SDIO:   SDIO clock
+  *            @arg RCC_APB2Periph_SPI1:   SPI1 clock
+  *            @arg RCC_APB2Periph_SYSCFG: SYSCFG clock
+  *            @arg RCC_APB2Periph_TIM9:   TIM9 clock
+  *            @arg RCC_APB2Periph_TIM10:  TIM10 clock
+  *            @arg RCC_APB2Periph_TIM11:  TIM11 clock
+  * @param  NewState: new state of the specified peripheral reset.
+  *          This parameter can be: ENABLE or DISABLE.
+  * @retval None
+  */
+void RCC_APB2PeriphResetCmd(uint32_t RCC_APB2Periph, FunctionalState NewState)
+{
+  /* Check the parameters */
+  assert_param(IS_RCC_APB2_RESET_PERIPH(RCC_APB2Periph));
+  assert_param(IS_FUNCTIONAL_STATE(NewState));
+  if (NewState != DISABLE)
+  {
+    RCC->APB2RSTR |= RCC_APB2Periph;
+  }
+  else
+  {
+    RCC->APB2RSTR &= ~RCC_APB2Periph;
+  }
+}
+
+/**
+  * @brief  Enables or disables the AHB1 peripheral clock during Low Power (Sleep) mode.
+  * @note   Peripheral clock gating in SLEEP mode can be used to further reduce
+  *         power consumption.
+  * @note   After wakeup from SLEEP mode, the peripheral clock is enabled again.
+  * @note   By default, all peripheral clocks are enabled during SLEEP mode.
+  * @param  RCC_AHBPeriph: specifies the AHB1 peripheral to gates its clock.
+  *          This parameter can be any combination of the following values:
+  *            @arg RCC_AHB1Periph_GPIOA:       GPIOA clock
+  *            @arg RCC_AHB1Periph_GPIOB:       GPIOB clock 
+  *            @arg RCC_AHB1Periph_GPIOC:       GPIOC clock
+  *            @arg RCC_AHB1Periph_GPIOD:       GPIOD clock
+  *            @arg RCC_AHB1Periph_GPIOE:       GPIOE clock
+  *            @arg RCC_AHB1Periph_GPIOF:       GPIOF clock
+  *            @arg RCC_AHB1Periph_GPIOG:       GPIOG clock
+  *            @arg RCC_AHB1Periph_GPIOG:       GPIOG clock
+  *            @arg RCC_AHB1Periph_GPIOI:       GPIOI clock
+  *            @arg RCC_AHB1Periph_CRC:         CRC clock
+  *            @arg RCC_AHB1Periph_BKPSRAM:     BKPSRAM interface clock
+  *            @arg RCC_AHB1Periph_DMA1:        DMA1 clock
+  *            @arg RCC_AHB1Periph_DMA2:        DMA2 clock
+  *            @arg RCC_AHB1Periph_ETH_MAC:     Ethernet MAC clock
+  *            @arg RCC_AHB1Periph_ETH_MAC_Tx:  Ethernet Transmission clock
+  *            @arg RCC_AHB1Periph_ETH_MAC_Rx:  Ethernet Reception clock
+  *            @arg RCC_AHB1Periph_ETH_MAC_PTP: Ethernet PTP clock
+  *            @arg RCC_AHB1Periph_OTG_HS:      USB OTG HS clock
+  *            @arg RCC_AHB1Periph_OTG_HS_ULPI: USB OTG HS ULPI clock
+  * @param  NewState: new state of the specified peripheral clock.
+  *          This parameter can be: ENABLE or DISABLE.
+  * @retval None
+  */
+void RCC_AHB1PeriphClockLPModeCmd(uint32_t RCC_AHB1Periph, FunctionalState NewState)
+{
+  /* Check the parameters */
+  assert_param(IS_RCC_AHB1_LPMODE_PERIPH(RCC_AHB1Periph));
+  assert_param(IS_FUNCTIONAL_STATE(NewState));
+  if (NewState != DISABLE)
+  {
+    RCC->AHB1LPENR |= RCC_AHB1Periph;
+  }
+  else
+  {
+    RCC->AHB1LPENR &= ~RCC_AHB1Periph;
+  }
+}
+
+/**
+  * @brief  Enables or disables the AHB2 peripheral clock during Low Power (Sleep) mode.
+  * @note   Peripheral clock gating in SLEEP mode can be used to further reduce
+  *           power consumption.
+  * @note   After wakeup from SLEEP mode, the peripheral clock is enabled again.
+  * @note   By default, all peripheral clocks are enabled during SLEEP mode.
+  * @param  RCC_AHBPeriph: specifies the AHB2 peripheral to gates its clock.
+  *          This parameter can be any combination of the following values:
+  *            @arg RCC_AHB2Periph_DCMI:   DCMI clock
+  *            @arg RCC_AHB2Periph_CRYP:   CRYP clock
+  *            @arg RCC_AHB2Periph_HASH:   HASH clock
+  *            @arg RCC_AHB2Periph_RNG:    RNG clock
+  *            @arg RCC_AHB2Periph_OTG_FS: USB OTG FS clock  
+  * @param  NewState: new state of the specified peripheral clock.
+  *          This parameter can be: ENABLE or DISABLE.
+  * @retval None
+  */
+void RCC_AHB2PeriphClockLPModeCmd(uint32_t RCC_AHB2Periph, FunctionalState NewState)
+{
+  /* Check the parameters */
+  assert_param(IS_RCC_AHB2_PERIPH(RCC_AHB2Periph));
+  assert_param(IS_FUNCTIONAL_STATE(NewState));
+  if (NewState != DISABLE)
+  {
+    RCC->AHB2LPENR |= RCC_AHB2Periph;
+  }
+  else
+  {
+    RCC->AHB2LPENR &= ~RCC_AHB2Periph;
+  }
+}
+
+/**
+  * @brief  Enables or disables the AHB3 peripheral clock during Low Power (Sleep) mode.
+  * @note   Peripheral clock gating in SLEEP mode can be used to further reduce
+  *         power consumption.
+  * @note   After wakeup from SLEEP mode, the peripheral clock is enabled again.
+  * @note   By default, all peripheral clocks are enabled during SLEEP mode.
+  * @param  RCC_AHBPeriph: specifies the AHB3 peripheral to gates its clock.
+  *          This parameter must be: RCC_AHB3Periph_FSMC
+  * @param  NewState: new state of the specified peripheral clock.
+  *          This parameter can be: ENABLE or DISABLE.
+  * @retval None
+  */
+void RCC_AHB3PeriphClockLPModeCmd(uint32_t RCC_AHB3Periph, FunctionalState NewState)
+{
+  /* Check the parameters */
+  assert_param(IS_RCC_AHB3_PERIPH(RCC_AHB3Periph));
+  assert_param(IS_FUNCTIONAL_STATE(NewState));
+  if (NewState != DISABLE)
+  {
+    RCC->AHB3LPENR |= RCC_AHB3Periph;
+  }
+  else
+  {
+    RCC->AHB3LPENR &= ~RCC_AHB3Periph;
+  }
+}
+
+/**
+  * @brief  Enables or disables the APB1 peripheral clock during Low Power (Sleep) mode.
+  * @note   Peripheral clock gating in SLEEP mode can be used to further reduce
+  *         power consumption.
+  * @note   After wakeup from SLEEP mode, the peripheral clock is enabled again.
+  * @note   By default, all peripheral clocks are enabled during SLEEP mode.
+  * @param  RCC_APB1Periph: specifies the APB1 peripheral to gates its clock.
+  *          This parameter can be any combination of the following values:
+  *            @arg RCC_APB1Periph_TIM2:   TIM2 clock
+  *            @arg RCC_APB1Periph_TIM3:   TIM3 clock
+  *            @arg RCC_APB1Periph_TIM4:   TIM4 clock
+  *            @arg RCC_APB1Periph_TIM5:   TIM5 clock
+  *            @arg RCC_APB1Periph_TIM6:   TIM6 clock
+  *            @arg RCC_APB1Periph_TIM7:   TIM7 clock
+  *            @arg RCC_APB1Periph_TIM12:  TIM12 clock
+  *            @arg RCC_APB1Periph_TIM13:  TIM13 clock
+  *            @arg RCC_APB1Periph_TIM14:  TIM14 clock
+  *            @arg RCC_APB1Periph_WWDG:   WWDG clock
+  *            @arg RCC_APB1Periph_SPI2:   SPI2 clock
+  *            @arg RCC_APB1Periph_SPI3:   SPI3 clock
+  *            @arg RCC_APB1Periph_USART2: USART2 clock
+  *            @arg RCC_APB1Periph_USART3: USART3 clock
+  *            @arg RCC_APB1Periph_UART4:  UART4 clock
+  *            @arg RCC_APB1Periph_UART5:  UART5 clock
+  *            @arg RCC_APB1Periph_I2C1:   I2C1 clock
+  *            @arg RCC_APB1Periph_I2C2:   I2C2 clock
+  *            @arg RCC_APB1Periph_I2C3:   I2C3 clock
+  *            @arg RCC_APB1Periph_CAN1:   CAN1 clock
+  *            @arg RCC_APB1Periph_CAN2:   CAN2 clock
+  *            @arg RCC_APB1Periph_PWR:    PWR clock
+  *            @arg RCC_APB1Periph_DAC:    DAC clock
+  * @param  NewState: new state of the specified peripheral clock.
+  *          This parameter can be: ENABLE or DISABLE.
+  * @retval None
+  */
+void RCC_APB1PeriphClockLPModeCmd(uint32_t RCC_APB1Periph, FunctionalState NewState)
+{
+  /* Check the parameters */
+  assert_param(IS_RCC_APB1_PERIPH(RCC_APB1Periph));
+  assert_param(IS_FUNCTIONAL_STATE(NewState));
+  if (NewState != DISABLE)
+  {
+    RCC->APB1LPENR |= RCC_APB1Periph;
+  }
+  else
+  {
+    RCC->APB1LPENR &= ~RCC_APB1Periph;
+  }
+}
+
+/**
+  * @brief  Enables or disables the APB2 peripheral clock during Low Power (Sleep) mode.
+  * @note   Peripheral clock gating in SLEEP mode can be used to further reduce
+  *         power consumption.
+  * @note   After wakeup from SLEEP mode, the peripheral clock is enabled again.
+  * @note   By default, all peripheral clocks are enabled during SLEEP mode.
+  * @param  RCC_APB2Periph: specifies the APB2 peripheral to gates its clock.
+  *          This parameter can be any combination of the following values:
+  *            @arg RCC_APB2Periph_TIM1:   TIM1 clock
+  *            @arg RCC_APB2Periph_TIM8:   TIM8 clock
+  *            @arg RCC_APB2Periph_USART1: USART1 clock
+  *            @arg RCC_APB2Periph_USART6: USART6 clock
+  *            @arg RCC_APB2Periph_ADC1:   ADC1 clock
+  *            @arg RCC_APB2Periph_ADC2:   ADC2 clock
+  *            @arg RCC_APB2Periph_ADC3:   ADC3 clock
+  *            @arg RCC_APB2Periph_SDIO:   SDIO clock
+  *            @arg RCC_APB2Periph_SPI1:   SPI1 clock
+  *            @arg RCC_APB2Periph_SYSCFG: SYSCFG clock
+  *            @arg RCC_APB2Periph_TIM9:   TIM9 clock
+  *            @arg RCC_APB2Periph_TIM10:  TIM10 clock
+  *            @arg RCC_APB2Periph_TIM11:  TIM11 clock
+  * @param  NewState: new state of the specified peripheral clock.
+  *          This parameter can be: ENABLE or DISABLE.
+  * @retval None
+  */
+void RCC_APB2PeriphClockLPModeCmd(uint32_t RCC_APB2Periph, FunctionalState NewState)
+{
+  /* Check the parameters */
+  assert_param(IS_RCC_APB2_PERIPH(RCC_APB2Periph));
+  assert_param(IS_FUNCTIONAL_STATE(NewState));
+  if (NewState != DISABLE)
+  {
+    RCC->APB2LPENR |= RCC_APB2Periph;
+  }
+  else
+  {
+    RCC->APB2LPENR &= ~RCC_APB2Periph;
+  }
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup RCC_Group4 Interrupts and flags management functions
+ *  @brief   Interrupts and flags management functions 
+ *
+@verbatim   
+ ===============================================================================
+                   Interrupts and flags management functions
+ ===============================================================================  
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Enables or disables the specified RCC interrupts.
+  * @param  RCC_IT: specifies the RCC interrupt sources to be enabled or disabled.
+  *          This parameter can be any combination of the following values:
+  *            @arg RCC_IT_LSIRDY: LSI ready interrupt
+  *            @arg RCC_IT_LSERDY: LSE ready interrupt
+  *            @arg RCC_IT_HSIRDY: HSI ready interrupt
+  *            @arg RCC_IT_HSERDY: HSE ready interrupt
+  *            @arg RCC_IT_PLLRDY: main PLL ready interrupt
+  *            @arg RCC_IT_PLLI2SRDY: PLLI2S ready interrupt  
+  * @param  NewState: new state of the specified RCC interrupts.
+  *          This parameter can be: ENABLE or DISABLE.
+  * @retval None
+  */
+void RCC_ITConfig(uint8_t RCC_IT, FunctionalState NewState)
+{
+  /* Check the parameters */
+  assert_param(IS_RCC_IT(RCC_IT));
+  assert_param(IS_FUNCTIONAL_STATE(NewState));
+  if (NewState != DISABLE)
+  {
+    /* Perform Byte access to RCC_CIR[14:8] bits to enable the selected interrupts */
+    *(__IO uint8_t *) CIR_BYTE2_ADDRESS |= RCC_IT;
+  }
+  else
+  {
+    /* Perform Byte access to RCC_CIR[14:8] bits to disable the selected interrupts */
+    *(__IO uint8_t *) CIR_BYTE2_ADDRESS &= (uint8_t)~RCC_IT;
+  }
+}
+
+/**
+  * @brief  Checks whether the specified RCC flag is set or not.
+  * @param  RCC_FLAG: specifies the flag to check.
+  *          This parameter can be one of the following values:
+  *            @arg RCC_FLAG_HSIRDY: HSI oscillator clock ready
+  *            @arg RCC_FLAG_HSERDY: HSE oscillator clock ready
+  *            @arg RCC_FLAG_PLLRDY: main PLL clock ready
+  *            @arg RCC_FLAG_PLLI2SRDY: PLLI2S clock ready
+  *            @arg RCC_FLAG_LSERDY: LSE oscillator clock ready
+  *            @arg RCC_FLAG_LSIRDY: LSI oscillator clock ready
+  *            @arg RCC_FLAG_BORRST: POR/PDR or BOR reset
+  *            @arg RCC_FLAG_PINRST: Pin reset
+  *            @arg RCC_FLAG_PORRST: POR/PDR reset
+  *            @arg RCC_FLAG_SFTRST: Software reset
+  *            @arg RCC_FLAG_IWDGRST: Independent Watchdog reset
+  *            @arg RCC_FLAG_WWDGRST: Window Watchdog reset
+  *            @arg RCC_FLAG_LPWRRST: Low Power reset
+  * @retval The new state of RCC_FLAG (SET or RESET).
+  */
+FlagStatus RCC_GetFlagStatus(uint8_t RCC_FLAG)
+{
+  uint32_t tmp = 0;
+  uint32_t statusreg = 0;
+  FlagStatus bitstatus = RESET;
+
+  /* Check the parameters */
+  assert_param(IS_RCC_FLAG(RCC_FLAG));
+
+  /* Get the RCC register index */
+  tmp = RCC_FLAG >> 5;
+  if (tmp == 1)               /* The flag to check is in CR register */
+  {
+    statusreg = RCC->CR;
+  }
+  else if (tmp == 2)          /* The flag to check is in BDCR register */
+  {
+    statusreg = RCC->BDCR;
+  }
+  else                       /* The flag to check is in CSR register */
+  {
+    statusreg = RCC->CSR;
+  }
+
+  /* Get the flag position */
+  tmp = RCC_FLAG & FLAG_MASK;
+  if ((statusreg & ((uint32_t)1 << tmp)) != (uint32_t)RESET)
+  {
+    bitstatus = SET;
+  }
+  else
+  {
+    bitstatus = RESET;
+  }
+  /* Return the flag status */
+  return bitstatus;
+}
+
+/**
+  * @brief  Clears the RCC reset flags.
+  *         The reset flags are: RCC_FLAG_PINRST, RCC_FLAG_PORRST,  RCC_FLAG_SFTRST,
+  *         RCC_FLAG_IWDGRST, RCC_FLAG_WWDGRST, RCC_FLAG_LPWRRST
+  * @param  None
+  * @retval None
+  */
+void RCC_ClearFlag(void)
+{
+  /* Set RMVF bit to clear the reset flags */
+  RCC->CSR |= RCC_CSR_RMVF;
+}
+
+/**
+  * @brief  Checks whether the specified RCC interrupt has occurred or not.
+  * @param  RCC_IT: specifies the RCC interrupt source to check.
+  *          This parameter can be one of the following values:
+  *            @arg RCC_IT_LSIRDY: LSI ready interrupt
+  *            @arg RCC_IT_LSERDY: LSE ready interrupt
+  *            @arg RCC_IT_HSIRDY: HSI ready interrupt
+  *            @arg RCC_IT_HSERDY: HSE ready interrupt
+  *            @arg RCC_IT_PLLRDY: main PLL ready interrupt
+  *            @arg RCC_IT_PLLI2SRDY: PLLI2S ready interrupt  
+  *            @arg RCC_IT_CSS: Clock Security System interrupt
+  * @retval The new state of RCC_IT (SET or RESET).
+  */
+ITStatus RCC_GetITStatus(uint8_t RCC_IT)
+{
+  ITStatus bitstatus = RESET;
+
+  /* Check the parameters */
+  assert_param(IS_RCC_GET_IT(RCC_IT));
+
+  /* Check the status of the specified RCC interrupt */
+  if ((RCC->CIR & RCC_IT) != (uint32_t)RESET)
+  {
+    bitstatus = SET;
+  }
+  else
+  {
+    bitstatus = RESET;
+  }
+  /* Return the RCC_IT status */
+  return  bitstatus;
+}
+
+/**
+  * @brief  Clears the RCC's interrupt pending bits.
+  * @param  RCC_IT: specifies the interrupt pending bit to clear.
+  *          This parameter can be any combination of the following values:
+  *            @arg RCC_IT_LSIRDY: LSI ready interrupt
+  *            @arg RCC_IT_LSERDY: LSE ready interrupt
+  *            @arg RCC_IT_HSIRDY: HSI ready interrupt
+  *            @arg RCC_IT_HSERDY: HSE ready interrupt
+  *            @arg RCC_IT_PLLRDY: main PLL ready interrupt
+  *            @arg RCC_IT_PLLI2SRDY: PLLI2S ready interrupt  
+  *            @arg RCC_IT_CSS: Clock Security System interrupt
+  * @retval None
+  */
+void RCC_ClearITPendingBit(uint8_t RCC_IT)
+{
+  /* Check the parameters */
+  assert_param(IS_RCC_CLEAR_IT(RCC_IT));
+
+  /* Perform Byte access to RCC_CIR[23:16] bits to clear the selected interrupt
+     pending bits */
+  *(__IO uint8_t *) CIR_BYTE3_ADDRESS = RCC_IT;
+}
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/src/lib/stm32f4xx_rcc.h
+++ b/src/lib/stm32f4xx_rcc.h
@@ -1,0 +1,516 @@
+/**
+  ******************************************************************************
+  * @file    stm32f4xx_rcc.h
+  * @author  MCD Application Team
+  * @version V1.0.2
+  * @date    05-March-2012
+  * @brief   This file contains all the functions prototypes for the RCC firmware library.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT 2012 STMicroelectronics</center></h2>
+  *
+  * Licensed under MCD-ST Liberty SW License Agreement V2, (the "License");
+  * You may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at:
+  *
+  *        http://www.st.com/software_license_agreement_liberty_v2
+  *
+  * Unless required by applicable law or agreed to in writing, software 
+  * distributed under the License is distributed on an "AS IS" BASIS, 
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32F4xx_RCC_H
+#define __STM32F4xx_RCC_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f4xx.h"
+
+/** @addtogroup STM32F4xx_StdPeriph_Driver
+  * @{
+  */
+
+/** @addtogroup RCC
+  * @{
+  */ 
+
+/* Exported types ------------------------------------------------------------*/
+typedef struct
+{
+  uint32_t SYSCLK_Frequency; /*!<  SYSCLK clock frequency expressed in Hz */
+  uint32_t HCLK_Frequency;   /*!<  HCLK clock frequency expressed in Hz */
+  uint32_t PCLK1_Frequency;  /*!<  PCLK1 clock frequency expressed in Hz */
+  uint32_t PCLK2_Frequency;  /*!<  PCLK2 clock frequency expressed in Hz */
+}RCC_ClocksTypeDef;
+
+/* Exported constants --------------------------------------------------------*/
+
+/** @defgroup RCC_Exported_Constants
+  * @{
+  */
+  
+/** @defgroup RCC_HSE_configuration 
+  * @{
+  */
+#define RCC_HSE_OFF                      ((uint8_t)0x00)
+#define RCC_HSE_ON                       ((uint8_t)0x01)
+#define RCC_HSE_Bypass                   ((uint8_t)0x05)
+#define IS_RCC_HSE(HSE) (((HSE) == RCC_HSE_OFF) || ((HSE) == RCC_HSE_ON) || \
+                         ((HSE) == RCC_HSE_Bypass))
+/**
+  * @}
+  */ 
+  
+/** @defgroup RCC_PLL_Clock_Source 
+  * @{
+  */
+#define RCC_PLLSource_HSI                ((uint32_t)0x00000000)
+#define RCC_PLLSource_HSE                ((uint32_t)0x00400000)
+#define IS_RCC_PLL_SOURCE(SOURCE) (((SOURCE) == RCC_PLLSource_HSI) || \
+                                   ((SOURCE) == RCC_PLLSource_HSE))
+#define IS_RCC_PLLM_VALUE(VALUE) ((VALUE) <= 63)
+#define IS_RCC_PLLN_VALUE(VALUE) ((192 <= (VALUE)) && ((VALUE) <= 432))
+#define IS_RCC_PLLP_VALUE(VALUE) (((VALUE) == 2) || ((VALUE) == 4) || ((VALUE) == 6) || ((VALUE) == 8))
+#define IS_RCC_PLLQ_VALUE(VALUE) ((4 <= (VALUE)) && ((VALUE) <= 15))
+ 
+#define IS_RCC_PLLI2SN_VALUE(VALUE) ((192 <= (VALUE)) && ((VALUE) <= 432))
+#define IS_RCC_PLLI2SR_VALUE(VALUE) ((2 <= (VALUE)) && ((VALUE) <= 7))   
+/**
+  * @}
+  */ 
+  
+/** @defgroup RCC_System_Clock_Source 
+  * @{
+  */
+#define RCC_SYSCLKSource_HSI             ((uint32_t)0x00000000)
+#define RCC_SYSCLKSource_HSE             ((uint32_t)0x00000001)
+#define RCC_SYSCLKSource_PLLCLK          ((uint32_t)0x00000002)
+#define IS_RCC_SYSCLK_SOURCE(SOURCE) (((SOURCE) == RCC_SYSCLKSource_HSI) || \
+                                      ((SOURCE) == RCC_SYSCLKSource_HSE) || \
+                                      ((SOURCE) == RCC_SYSCLKSource_PLLCLK))
+/**
+  * @}
+  */ 
+  
+/** @defgroup RCC_AHB_Clock_Source
+  * @{
+  */
+#define RCC_SYSCLK_Div1                  ((uint32_t)0x00000000)
+#define RCC_SYSCLK_Div2                  ((uint32_t)0x00000080)
+#define RCC_SYSCLK_Div4                  ((uint32_t)0x00000090)
+#define RCC_SYSCLK_Div8                  ((uint32_t)0x000000A0)
+#define RCC_SYSCLK_Div16                 ((uint32_t)0x000000B0)
+#define RCC_SYSCLK_Div64                 ((uint32_t)0x000000C0)
+#define RCC_SYSCLK_Div128                ((uint32_t)0x000000D0)
+#define RCC_SYSCLK_Div256                ((uint32_t)0x000000E0)
+#define RCC_SYSCLK_Div512                ((uint32_t)0x000000F0)
+#define IS_RCC_HCLK(HCLK) (((HCLK) == RCC_SYSCLK_Div1) || ((HCLK) == RCC_SYSCLK_Div2) || \
+                           ((HCLK) == RCC_SYSCLK_Div4) || ((HCLK) == RCC_SYSCLK_Div8) || \
+                           ((HCLK) == RCC_SYSCLK_Div16) || ((HCLK) == RCC_SYSCLK_Div64) || \
+                           ((HCLK) == RCC_SYSCLK_Div128) || ((HCLK) == RCC_SYSCLK_Div256) || \
+                           ((HCLK) == RCC_SYSCLK_Div512))
+/**
+  * @}
+  */ 
+  
+/** @defgroup RCC_APB1_APB2_Clock_Source
+  * @{
+  */
+#define RCC_HCLK_Div1                    ((uint32_t)0x00000000)
+#define RCC_HCLK_Div2                    ((uint32_t)0x00001000)
+#define RCC_HCLK_Div4                    ((uint32_t)0x00001400)
+#define RCC_HCLK_Div8                    ((uint32_t)0x00001800)
+#define RCC_HCLK_Div16                   ((uint32_t)0x00001C00)
+#define IS_RCC_PCLK(PCLK) (((PCLK) == RCC_HCLK_Div1) || ((PCLK) == RCC_HCLK_Div2) || \
+                           ((PCLK) == RCC_HCLK_Div4) || ((PCLK) == RCC_HCLK_Div8) || \
+                           ((PCLK) == RCC_HCLK_Div16))
+/**
+  * @}
+  */ 
+  
+/** @defgroup RCC_Interrupt_Source 
+  * @{
+  */
+#define RCC_IT_LSIRDY                    ((uint8_t)0x01)
+#define RCC_IT_LSERDY                    ((uint8_t)0x02)
+#define RCC_IT_HSIRDY                    ((uint8_t)0x04)
+#define RCC_IT_HSERDY                    ((uint8_t)0x08)
+#define RCC_IT_PLLRDY                    ((uint8_t)0x10)
+#define RCC_IT_PLLI2SRDY                 ((uint8_t)0x20)
+#define RCC_IT_CSS                       ((uint8_t)0x80)
+#define IS_RCC_IT(IT) ((((IT) & (uint8_t)0xC0) == 0x00) && ((IT) != 0x00))
+#define IS_RCC_GET_IT(IT) (((IT) == RCC_IT_LSIRDY) || ((IT) == RCC_IT_LSERDY) || \
+                           ((IT) == RCC_IT_HSIRDY) || ((IT) == RCC_IT_HSERDY) || \
+                           ((IT) == RCC_IT_PLLRDY) || ((IT) == RCC_IT_CSS) || \
+                           ((IT) == RCC_IT_PLLI2SRDY))
+#define IS_RCC_CLEAR_IT(IT) ((((IT) & (uint8_t)0x40) == 0x00) && ((IT) != 0x00))
+/**
+  * @}
+  */ 
+  
+/** @defgroup RCC_LSE_Configuration 
+  * @{
+  */
+#define RCC_LSE_OFF                      ((uint8_t)0x00)
+#define RCC_LSE_ON                       ((uint8_t)0x01)
+#define RCC_LSE_Bypass                   ((uint8_t)0x04)
+#define IS_RCC_LSE(LSE) (((LSE) == RCC_LSE_OFF) || ((LSE) == RCC_LSE_ON) || \
+                         ((LSE) == RCC_LSE_Bypass))
+/**
+  * @}
+  */ 
+  
+/** @defgroup RCC_RTC_Clock_Source
+  * @{
+  */
+#define RCC_RTCCLKSource_LSE             ((uint32_t)0x00000100)
+#define RCC_RTCCLKSource_LSI             ((uint32_t)0x00000200)
+#define RCC_RTCCLKSource_HSE_Div2        ((uint32_t)0x00020300)
+#define RCC_RTCCLKSource_HSE_Div3        ((uint32_t)0x00030300)
+#define RCC_RTCCLKSource_HSE_Div4        ((uint32_t)0x00040300)
+#define RCC_RTCCLKSource_HSE_Div5        ((uint32_t)0x00050300)
+#define RCC_RTCCLKSource_HSE_Div6        ((uint32_t)0x00060300)
+#define RCC_RTCCLKSource_HSE_Div7        ((uint32_t)0x00070300)
+#define RCC_RTCCLKSource_HSE_Div8        ((uint32_t)0x00080300)
+#define RCC_RTCCLKSource_HSE_Div9        ((uint32_t)0x00090300)
+#define RCC_RTCCLKSource_HSE_Div10       ((uint32_t)0x000A0300)
+#define RCC_RTCCLKSource_HSE_Div11       ((uint32_t)0x000B0300)
+#define RCC_RTCCLKSource_HSE_Div12       ((uint32_t)0x000C0300)
+#define RCC_RTCCLKSource_HSE_Div13       ((uint32_t)0x000D0300)
+#define RCC_RTCCLKSource_HSE_Div14       ((uint32_t)0x000E0300)
+#define RCC_RTCCLKSource_HSE_Div15       ((uint32_t)0x000F0300)
+#define RCC_RTCCLKSource_HSE_Div16       ((uint32_t)0x00100300)
+#define RCC_RTCCLKSource_HSE_Div17       ((uint32_t)0x00110300)
+#define RCC_RTCCLKSource_HSE_Div18       ((uint32_t)0x00120300)
+#define RCC_RTCCLKSource_HSE_Div19       ((uint32_t)0x00130300)
+#define RCC_RTCCLKSource_HSE_Div20       ((uint32_t)0x00140300)
+#define RCC_RTCCLKSource_HSE_Div21       ((uint32_t)0x00150300)
+#define RCC_RTCCLKSource_HSE_Div22       ((uint32_t)0x00160300)
+#define RCC_RTCCLKSource_HSE_Div23       ((uint32_t)0x00170300)
+#define RCC_RTCCLKSource_HSE_Div24       ((uint32_t)0x00180300)
+#define RCC_RTCCLKSource_HSE_Div25       ((uint32_t)0x00190300)
+#define RCC_RTCCLKSource_HSE_Div26       ((uint32_t)0x001A0300)
+#define RCC_RTCCLKSource_HSE_Div27       ((uint32_t)0x001B0300)
+#define RCC_RTCCLKSource_HSE_Div28       ((uint32_t)0x001C0300)
+#define RCC_RTCCLKSource_HSE_Div29       ((uint32_t)0x001D0300)
+#define RCC_RTCCLKSource_HSE_Div30       ((uint32_t)0x001E0300)
+#define RCC_RTCCLKSource_HSE_Div31       ((uint32_t)0x001F0300)
+#define IS_RCC_RTCCLK_SOURCE(SOURCE) (((SOURCE) == RCC_RTCCLKSource_LSE) || \
+                                      ((SOURCE) == RCC_RTCCLKSource_LSI) || \
+                                      ((SOURCE) == RCC_RTCCLKSource_HSE_Div2) || \
+                                      ((SOURCE) == RCC_RTCCLKSource_HSE_Div3) || \
+                                      ((SOURCE) == RCC_RTCCLKSource_HSE_Div4) || \
+                                      ((SOURCE) == RCC_RTCCLKSource_HSE_Div5) || \
+                                      ((SOURCE) == RCC_RTCCLKSource_HSE_Div6) || \
+                                      ((SOURCE) == RCC_RTCCLKSource_HSE_Div7) || \
+                                      ((SOURCE) == RCC_RTCCLKSource_HSE_Div8) || \
+                                      ((SOURCE) == RCC_RTCCLKSource_HSE_Div9) || \
+                                      ((SOURCE) == RCC_RTCCLKSource_HSE_Div10) || \
+                                      ((SOURCE) == RCC_RTCCLKSource_HSE_Div11) || \
+                                      ((SOURCE) == RCC_RTCCLKSource_HSE_Div12) || \
+                                      ((SOURCE) == RCC_RTCCLKSource_HSE_Div13) || \
+                                      ((SOURCE) == RCC_RTCCLKSource_HSE_Div14) || \
+                                      ((SOURCE) == RCC_RTCCLKSource_HSE_Div15) || \
+                                      ((SOURCE) == RCC_RTCCLKSource_HSE_Div16) || \
+                                      ((SOURCE) == RCC_RTCCLKSource_HSE_Div17) || \
+                                      ((SOURCE) == RCC_RTCCLKSource_HSE_Div18) || \
+                                      ((SOURCE) == RCC_RTCCLKSource_HSE_Div19) || \
+                                      ((SOURCE) == RCC_RTCCLKSource_HSE_Div20) || \
+                                      ((SOURCE) == RCC_RTCCLKSource_HSE_Div21) || \
+                                      ((SOURCE) == RCC_RTCCLKSource_HSE_Div22) || \
+                                      ((SOURCE) == RCC_RTCCLKSource_HSE_Div23) || \
+                                      ((SOURCE) == RCC_RTCCLKSource_HSE_Div24) || \
+                                      ((SOURCE) == RCC_RTCCLKSource_HSE_Div25) || \
+                                      ((SOURCE) == RCC_RTCCLKSource_HSE_Div26) || \
+                                      ((SOURCE) == RCC_RTCCLKSource_HSE_Div27) || \
+                                      ((SOURCE) == RCC_RTCCLKSource_HSE_Div28) || \
+                                      ((SOURCE) == RCC_RTCCLKSource_HSE_Div29) || \
+                                      ((SOURCE) == RCC_RTCCLKSource_HSE_Div30) || \
+                                      ((SOURCE) == RCC_RTCCLKSource_HSE_Div31))
+/**
+  * @}
+  */ 
+  
+/** @defgroup RCC_I2S_Clock_Source
+  * @{
+  */
+#define RCC_I2S2CLKSource_PLLI2S             ((uint8_t)0x00)
+#define RCC_I2S2CLKSource_Ext                ((uint8_t)0x01)
+
+#define IS_RCC_I2SCLK_SOURCE(SOURCE) (((SOURCE) == RCC_I2S2CLKSource_PLLI2S) || ((SOURCE) == RCC_I2S2CLKSource_Ext))                                
+/**
+  * @}
+  */ 
+  
+/** @defgroup RCC_AHB1_Peripherals 
+  * @{
+  */ 
+#define RCC_AHB1Periph_GPIOA             ((uint32_t)0x00000001)
+#define RCC_AHB1Periph_GPIOB             ((uint32_t)0x00000002)
+#define RCC_AHB1Periph_GPIOC             ((uint32_t)0x00000004)
+#define RCC_AHB1Periph_GPIOD             ((uint32_t)0x00000008)
+#define RCC_AHB1Periph_GPIOE             ((uint32_t)0x00000010)
+#define RCC_AHB1Periph_GPIOF             ((uint32_t)0x00000020)
+#define RCC_AHB1Periph_GPIOG             ((uint32_t)0x00000040)
+#define RCC_AHB1Periph_GPIOH             ((uint32_t)0x00000080)
+#define RCC_AHB1Periph_GPIOI             ((uint32_t)0x00000100)
+#define RCC_AHB1Periph_CRC               ((uint32_t)0x00001000)
+#define RCC_AHB1Periph_FLITF             ((uint32_t)0x00008000)
+#define RCC_AHB1Periph_SRAM1             ((uint32_t)0x00010000)
+#define RCC_AHB1Periph_SRAM2             ((uint32_t)0x00020000)
+#define RCC_AHB1Periph_BKPSRAM           ((uint32_t)0x00040000)
+#define RCC_AHB1Periph_CCMDATARAMEN      ((uint32_t)0x00100000)
+#define RCC_AHB1Periph_DMA1              ((uint32_t)0x00200000)
+#define RCC_AHB1Periph_DMA2              ((uint32_t)0x00400000)
+#define RCC_AHB1Periph_ETH_MAC           ((uint32_t)0x02000000)
+#define RCC_AHB1Periph_ETH_MAC_Tx        ((uint32_t)0x04000000)
+#define RCC_AHB1Periph_ETH_MAC_Rx        ((uint32_t)0x08000000)
+#define RCC_AHB1Periph_ETH_MAC_PTP       ((uint32_t)0x10000000)
+#define RCC_AHB1Periph_OTG_HS            ((uint32_t)0x20000000)
+#define RCC_AHB1Periph_OTG_HS_ULPI       ((uint32_t)0x40000000)
+#define IS_RCC_AHB1_CLOCK_PERIPH(PERIPH) ((((PERIPH) & 0x818BEE00) == 0x00) && ((PERIPH) != 0x00))
+#define IS_RCC_AHB1_RESET_PERIPH(PERIPH) ((((PERIPH) & 0xDD9FEE00) == 0x00) && ((PERIPH) != 0x00))
+#define IS_RCC_AHB1_LPMODE_PERIPH(PERIPH) ((((PERIPH) & 0x81986E00) == 0x00) && ((PERIPH) != 0x00))
+/**
+  * @}
+  */ 
+  
+/** @defgroup RCC_AHB2_Peripherals 
+  * @{
+  */  
+#define RCC_AHB2Periph_DCMI              ((uint32_t)0x00000001)
+#define RCC_AHB2Periph_CRYP              ((uint32_t)0x00000010)
+#define RCC_AHB2Periph_HASH              ((uint32_t)0x00000020)
+#define RCC_AHB2Periph_RNG               ((uint32_t)0x00000040)
+#define RCC_AHB2Periph_OTG_FS            ((uint32_t)0x00000080)
+#define IS_RCC_AHB2_PERIPH(PERIPH) ((((PERIPH) & 0xFFFFFF0E) == 0x00) && ((PERIPH) != 0x00))
+/**
+  * @}
+  */ 
+  
+/** @defgroup RCC_AHB3_Peripherals 
+  * @{
+  */ 
+#define RCC_AHB3Periph_FSMC               ((uint32_t)0x00000001)
+#define IS_RCC_AHB3_PERIPH(PERIPH) ((((PERIPH) & 0xFFFFFFFE) == 0x00) && ((PERIPH) != 0x00))
+/**
+  * @}
+  */ 
+  
+/** @defgroup RCC_APB1_Peripherals 
+  * @{
+  */ 
+#define RCC_APB1Periph_TIM2              ((uint32_t)0x00000001)
+#define RCC_APB1Periph_TIM3              ((uint32_t)0x00000002)
+#define RCC_APB1Periph_TIM4              ((uint32_t)0x00000004)
+#define RCC_APB1Periph_TIM5              ((uint32_t)0x00000008)
+#define RCC_APB1Periph_TIM6              ((uint32_t)0x00000010)
+#define RCC_APB1Periph_TIM7              ((uint32_t)0x00000020)
+#define RCC_APB1Periph_TIM12             ((uint32_t)0x00000040)
+#define RCC_APB1Periph_TIM13             ((uint32_t)0x00000080)
+#define RCC_APB1Periph_TIM14             ((uint32_t)0x00000100)
+#define RCC_APB1Periph_WWDG              ((uint32_t)0x00000800)
+#define RCC_APB1Periph_SPI2              ((uint32_t)0x00004000)
+#define RCC_APB1Periph_SPI3              ((uint32_t)0x00008000)
+#define RCC_APB1Periph_USART2            ((uint32_t)0x00020000)
+#define RCC_APB1Periph_USART3            ((uint32_t)0x00040000)
+#define RCC_APB1Periph_UART4             ((uint32_t)0x00080000)
+#define RCC_APB1Periph_UART5             ((uint32_t)0x00100000)
+#define RCC_APB1Periph_I2C1              ((uint32_t)0x00200000)
+#define RCC_APB1Periph_I2C2              ((uint32_t)0x00400000)
+#define RCC_APB1Periph_I2C3              ((uint32_t)0x00800000)
+#define RCC_APB1Periph_CAN1              ((uint32_t)0x02000000)
+#define RCC_APB1Periph_CAN2              ((uint32_t)0x04000000)
+#define RCC_APB1Periph_PWR               ((uint32_t)0x10000000)
+#define RCC_APB1Periph_DAC               ((uint32_t)0x20000000)
+#define IS_RCC_APB1_PERIPH(PERIPH) ((((PERIPH) & 0xC9013600) == 0x00) && ((PERIPH) != 0x00))
+/**
+  * @}
+  */ 
+  
+/** @defgroup RCC_APB2_Peripherals 
+  * @{
+  */ 
+#define RCC_APB2Periph_TIM1              ((uint32_t)0x00000001)
+#define RCC_APB2Periph_TIM8              ((uint32_t)0x00000002)
+#define RCC_APB2Periph_USART1            ((uint32_t)0x00000010)
+#define RCC_APB2Periph_USART6            ((uint32_t)0x00000020)
+#define RCC_APB2Periph_ADC               ((uint32_t)0x00000100)
+#define RCC_APB2Periph_ADC1              ((uint32_t)0x00000100)
+#define RCC_APB2Periph_ADC2              ((uint32_t)0x00000200)
+#define RCC_APB2Periph_ADC3              ((uint32_t)0x00000400)
+#define RCC_APB2Periph_SDIO              ((uint32_t)0x00000800)
+#define RCC_APB2Periph_SPI1              ((uint32_t)0x00001000)
+#define RCC_APB2Periph_SYSCFG            ((uint32_t)0x00004000)
+#define RCC_APB2Periph_TIM9              ((uint32_t)0x00010000)
+#define RCC_APB2Periph_TIM10             ((uint32_t)0x00020000)
+#define RCC_APB2Periph_TIM11             ((uint32_t)0x00040000)
+#define IS_RCC_APB2_PERIPH(PERIPH) ((((PERIPH) & 0xFFF8A0CC) == 0x00) && ((PERIPH) != 0x00))
+#define IS_RCC_APB2_RESET_PERIPH(PERIPH) ((((PERIPH) & 0xFFF8A6CC) == 0x00) && ((PERIPH) != 0x00))
+/**
+  * @}
+  */ 
+  
+/** @defgroup RCC_MCO1_Clock_Source_Prescaler
+  * @{
+  */
+#define RCC_MCO1Source_HSI               ((uint32_t)0x00000000)
+#define RCC_MCO1Source_LSE               ((uint32_t)0x00200000)
+#define RCC_MCO1Source_HSE               ((uint32_t)0x00400000)
+#define RCC_MCO1Source_PLLCLK            ((uint32_t)0x00600000)
+#define RCC_MCO1Div_1                    ((uint32_t)0x00000000)
+#define RCC_MCO1Div_2                    ((uint32_t)0x04000000)
+#define RCC_MCO1Div_3                    ((uint32_t)0x05000000)
+#define RCC_MCO1Div_4                    ((uint32_t)0x06000000)
+#define RCC_MCO1Div_5                    ((uint32_t)0x07000000)
+#define IS_RCC_MCO1SOURCE(SOURCE) (((SOURCE) == RCC_MCO1Source_HSI) || ((SOURCE) == RCC_MCO1Source_LSE) || \
+                                   ((SOURCE) == RCC_MCO1Source_HSE) || ((SOURCE) == RCC_MCO1Source_PLLCLK))
+                                   
+#define IS_RCC_MCO1DIV(DIV) (((DIV) == RCC_MCO1Div_1) || ((DIV) == RCC_MCO1Div_2) || \
+                             ((DIV) == RCC_MCO1Div_3) || ((DIV) == RCC_MCO1Div_4) || \
+                             ((DIV) == RCC_MCO1Div_5)) 
+/**
+  * @}
+  */ 
+  
+/** @defgroup RCC_MCO2_Clock_Source_Prescaler
+  * @{
+  */
+#define RCC_MCO2Source_SYSCLK            ((uint32_t)0x00000000)
+#define RCC_MCO2Source_PLLI2SCLK         ((uint32_t)0x40000000)
+#define RCC_MCO2Source_HSE               ((uint32_t)0x80000000)
+#define RCC_MCO2Source_PLLCLK            ((uint32_t)0xC0000000)
+#define RCC_MCO2Div_1                    ((uint32_t)0x00000000)
+#define RCC_MCO2Div_2                    ((uint32_t)0x20000000)
+#define RCC_MCO2Div_3                    ((uint32_t)0x28000000)
+#define RCC_MCO2Div_4                    ((uint32_t)0x30000000)
+#define RCC_MCO2Div_5                    ((uint32_t)0x38000000)
+#define IS_RCC_MCO2SOURCE(SOURCE) (((SOURCE) == RCC_MCO2Source_SYSCLK) || ((SOURCE) == RCC_MCO2Source_PLLI2SCLK)|| \
+                                   ((SOURCE) == RCC_MCO2Source_HSE) || ((SOURCE) == RCC_MCO2Source_PLLCLK))
+                                   
+#define IS_RCC_MCO2DIV(DIV) (((DIV) == RCC_MCO2Div_1) || ((DIV) == RCC_MCO2Div_2) || \
+                             ((DIV) == RCC_MCO2Div_3) || ((DIV) == RCC_MCO2Div_4) || \
+                             ((DIV) == RCC_MCO2Div_5))                             
+/**
+  * @}
+  */ 
+  
+/** @defgroup RCC_Flag 
+  * @{
+  */
+#define RCC_FLAG_HSIRDY                  ((uint8_t)0x21)
+#define RCC_FLAG_HSERDY                  ((uint8_t)0x31)
+#define RCC_FLAG_PLLRDY                  ((uint8_t)0x39)
+#define RCC_FLAG_PLLI2SRDY               ((uint8_t)0x3B)
+#define RCC_FLAG_LSERDY                  ((uint8_t)0x41)
+#define RCC_FLAG_LSIRDY                  ((uint8_t)0x61)
+#define RCC_FLAG_BORRST                  ((uint8_t)0x79)
+#define RCC_FLAG_PINRST                  ((uint8_t)0x7A)
+#define RCC_FLAG_PORRST                  ((uint8_t)0x7B)
+#define RCC_FLAG_SFTRST                  ((uint8_t)0x7C)
+#define RCC_FLAG_IWDGRST                 ((uint8_t)0x7D)
+#define RCC_FLAG_WWDGRST                 ((uint8_t)0x7E)
+#define RCC_FLAG_LPWRRST                 ((uint8_t)0x7F)
+#define IS_RCC_FLAG(FLAG) (((FLAG) == RCC_FLAG_HSIRDY) || ((FLAG) == RCC_FLAG_HSERDY) || \
+                           ((FLAG) == RCC_FLAG_PLLRDY) || ((FLAG) == RCC_FLAG_LSERDY) || \
+                           ((FLAG) == RCC_FLAG_LSIRDY) || ((FLAG) == RCC_FLAG_BORRST) || \
+                           ((FLAG) == RCC_FLAG_PINRST) || ((FLAG) == RCC_FLAG_PORRST) || \
+                           ((FLAG) == RCC_FLAG_SFTRST) || ((FLAG) == RCC_FLAG_IWDGRST)|| \
+                           ((FLAG) == RCC_FLAG_WWDGRST)|| ((FLAG) == RCC_FLAG_LPWRRST)|| \
+                           ((FLAG) == RCC_FLAG_PLLI2SRDY))
+#define IS_RCC_CALIBRATION_VALUE(VALUE) ((VALUE) <= 0x1F)
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+
+/* Exported macro ------------------------------------------------------------*/
+/* Exported functions --------------------------------------------------------*/ 
+
+/* Function used to set the RCC clock configuration to the default reset state */
+void RCC_DeInit(void);
+
+/* Internal/external clocks, PLL, CSS and MCO configuration functions *********/
+void RCC_HSEConfig(uint8_t RCC_HSE);
+ErrorStatus RCC_WaitForHSEStartUp(void);
+void RCC_AdjustHSICalibrationValue(uint8_t HSICalibrationValue);
+void RCC_HSICmd(FunctionalState NewState);
+void RCC_LSEConfig(uint8_t RCC_LSE);
+void RCC_LSICmd(FunctionalState NewState);
+
+void RCC_PLLConfig(uint32_t RCC_PLLSource, uint32_t PLLM, uint32_t PLLN, uint32_t PLLP, uint32_t PLLQ);
+void RCC_PLLCmd(FunctionalState NewState);
+void RCC_PLLI2SConfig(uint32_t PLLI2SN, uint32_t PLLI2SR);
+void RCC_PLLI2SCmd(FunctionalState NewState);
+
+void RCC_ClockSecuritySystemCmd(FunctionalState NewState);
+void RCC_MCO1Config(uint32_t RCC_MCO1Source, uint32_t RCC_MCO1Div);
+void RCC_MCO2Config(uint32_t RCC_MCO2Source, uint32_t RCC_MCO2Div);
+
+/* System, AHB and APB busses clocks configuration functions ******************/
+void RCC_SYSCLKConfig(uint32_t RCC_SYSCLKSource);
+uint8_t RCC_GetSYSCLKSource(void);
+void RCC_HCLKConfig(uint32_t RCC_SYSCLK);
+void RCC_PCLK1Config(uint32_t RCC_HCLK);
+void RCC_PCLK2Config(uint32_t RCC_HCLK);
+void RCC_GetClocksFreq(RCC_ClocksTypeDef* RCC_Clocks);
+
+/* Peripheral clocks configuration functions **********************************/
+void RCC_RTCCLKConfig(uint32_t RCC_RTCCLKSource);
+void RCC_RTCCLKCmd(FunctionalState NewState);
+void RCC_BackupResetCmd(FunctionalState NewState);
+void RCC_I2SCLKConfig(uint32_t RCC_I2SCLKSource); 
+
+void RCC_AHB1PeriphClockCmd(uint32_t RCC_AHB1Periph, FunctionalState NewState);
+void RCC_AHB2PeriphClockCmd(uint32_t RCC_AHB2Periph, FunctionalState NewState);
+void RCC_AHB3PeriphClockCmd(uint32_t RCC_AHB3Periph, FunctionalState NewState);
+void RCC_APB1PeriphClockCmd(uint32_t RCC_APB1Periph, FunctionalState NewState);
+void RCC_APB2PeriphClockCmd(uint32_t RCC_APB2Periph, FunctionalState NewState);
+
+void RCC_AHB1PeriphResetCmd(uint32_t RCC_AHB1Periph, FunctionalState NewState);
+void RCC_AHB2PeriphResetCmd(uint32_t RCC_AHB2Periph, FunctionalState NewState);
+void RCC_AHB3PeriphResetCmd(uint32_t RCC_AHB3Periph, FunctionalState NewState);
+void RCC_APB1PeriphResetCmd(uint32_t RCC_APB1Periph, FunctionalState NewState);
+void RCC_APB2PeriphResetCmd(uint32_t RCC_APB2Periph, FunctionalState NewState);
+
+void RCC_AHB1PeriphClockLPModeCmd(uint32_t RCC_AHB1Periph, FunctionalState NewState);
+void RCC_AHB2PeriphClockLPModeCmd(uint32_t RCC_AHB2Periph, FunctionalState NewState);
+void RCC_AHB3PeriphClockLPModeCmd(uint32_t RCC_AHB3Periph, FunctionalState NewState);
+void RCC_APB1PeriphClockLPModeCmd(uint32_t RCC_APB1Periph, FunctionalState NewState);
+void RCC_APB2PeriphClockLPModeCmd(uint32_t RCC_APB2Periph, FunctionalState NewState);
+
+/* Interrupts and flags management functions **********************************/
+void RCC_ITConfig(uint8_t RCC_IT, FunctionalState NewState);
+FlagStatus RCC_GetFlagStatus(uint8_t RCC_FLAG);
+void RCC_ClearFlag(void);
+ITStatus RCC_GetITStatus(uint8_t RCC_IT);
+void RCC_ClearITPendingBit(uint8_t RCC_IT);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32F4xx_RCC_H */
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/src/lib/stm32f4xx_tim.c
+++ b/src/lib/stm32f4xx_tim.c
@@ -1,0 +1,3358 @@
+/**
+  ******************************************************************************
+  * @file    stm32f4xx_tim.c
+  * @author  MCD Application Team
+  * @version V1.0.2
+  * @date    05-March-2012
+  * @brief   This file provides firmware functions to manage the following 
+  *          functionalities of the TIM peripheral:
+  *            - TimeBase management
+  *            - Output Compare management
+  *            - Input Capture management
+  *            - Advanced-control timers (TIM1 and TIM8) specific features  
+  *            - Interrupts, DMA and flags management
+  *            - Clocks management
+  *            - Synchronization management
+  *            - Specific interface management
+  *            - Specific remapping management      
+  *              
+  *  @verbatim
+  *  
+  *          ===================================================================
+  *                                 How to use this driver
+  *          ===================================================================
+  *          This driver provides functions to configure and program the TIM 
+  *          of all STM32F4xx devices.
+  *          These functions are split in 9 groups: 
+  *   
+  *          1. TIM TimeBase management: this group includes all needed functions 
+  *             to configure the TM Timebase unit:
+  *                   - Set/Get Prescaler
+  *                   - Set/Get Autoreload  
+  *                   - Counter modes configuration
+  *                   - Set Clock division  
+  *                   - Select the One Pulse mode
+  *                   - Update Request Configuration
+  *                   - Update Disable Configuration
+  *                   - Auto-Preload Configuration 
+  *                   - Enable/Disable the counter     
+  *                 
+  *          2. TIM Output Compare management: this group includes all needed 
+  *             functions to configure the Capture/Compare unit used in Output 
+  *             compare mode: 
+  *                   - Configure each channel, independently, in Output Compare mode
+  *                   - Select the output compare modes
+  *                   - Select the Polarities of each channel
+  *                   - Set/Get the Capture/Compare register values
+  *                   - Select the Output Compare Fast mode 
+  *                   - Select the Output Compare Forced mode  
+  *                   - Output Compare-Preload Configuration 
+  *                   - Clear Output Compare Reference
+  *                   - Select the OCREF Clear signal
+  *                   - Enable/Disable the Capture/Compare Channels    
+  *                   
+  *          3. TIM Input Capture management: this group includes all needed 
+  *             functions to configure the Capture/Compare unit used in 
+  *             Input Capture mode:
+  *                   - Configure each channel in input capture mode
+  *                   - Configure Channel1/2 in PWM Input mode
+  *                   - Set the Input Capture Prescaler
+  *                   - Get the Capture/Compare values      
+  *                   
+  *          4. Advanced-control timers (TIM1 and TIM8) specific features
+  *                   - Configures the Break input, dead time, Lock level, the OSSI,
+  *                      the OSSR State and the AOE(automatic output enable)
+  *                   - Enable/Disable the TIM peripheral Main Outputs
+  *                   - Select the Commutation event
+  *                   - Set/Reset the Capture Compare Preload Control bit
+  *                              
+  *          5. TIM interrupts, DMA and flags management
+  *                   - Enable/Disable interrupt sources
+  *                   - Get flags status
+  *                   - Clear flags/ Pending bits
+  *                   - Enable/Disable DMA requests 
+  *                   - Configure DMA burst mode
+  *                   - Select CaptureCompare DMA request  
+  *              
+  *          6. TIM clocks management: this group includes all needed functions 
+  *             to configure the clock controller unit:
+  *                   - Select internal/External clock
+  *                   - Select the external clock mode: ETR(Mode1/Mode2), TIx or ITRx
+  *         
+  *          7. TIM synchronization management: this group includes all needed 
+  *             functions to configure the Synchronization unit:
+  *                   - Select Input Trigger  
+  *                   - Select Output Trigger  
+  *                   - Select Master Slave Mode 
+  *                   - ETR Configuration when used as external trigger   
+  *     
+  *          8. TIM specific interface management, this group includes all 
+  *             needed functions to use the specific TIM interface:
+  *                   - Encoder Interface Configuration
+  *                   - Select Hall Sensor   
+  *         
+  *          9. TIM specific remapping management includes the Remapping 
+  *             configuration of specific timers               
+  *   
+  *  @endverbatim
+  *    
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT 2012 STMicroelectronics</center></h2>
+  *
+  * Licensed under MCD-ST Liberty SW License Agreement V2, (the "License");
+  * You may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at:
+  *
+  *        http://www.st.com/software_license_agreement_liberty_v2
+  *
+  * Unless required by applicable law or agreed to in writing, software 
+  * distributed under the License is distributed on an "AS IS" BASIS, 
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f4xx_tim.h"
+#include "stm32f4xx_rcc.h"
+
+/** @addtogroup STM32F4xx_StdPeriph_Driver
+  * @{
+  */
+
+/** @defgroup TIM 
+  * @brief TIM driver modules
+  * @{
+  */
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+
+/* ---------------------- TIM registers bit mask ------------------------ */
+#define SMCR_ETR_MASK      ((uint16_t)0x00FF) 
+#define CCMR_OFFSET        ((uint16_t)0x0018)
+#define CCER_CCE_SET       ((uint16_t)0x0001)  
+#define	CCER_CCNE_SET      ((uint16_t)0x0004) 
+#define CCMR_OC13M_MASK    ((uint16_t)0xFF8F)
+#define CCMR_OC24M_MASK    ((uint16_t)0x8FFF) 
+
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+static void TI1_Config(TIM_TypeDef* TIMx, uint16_t TIM_ICPolarity, uint16_t TIM_ICSelection,
+                       uint16_t TIM_ICFilter);
+static void TI2_Config(TIM_TypeDef* TIMx, uint16_t TIM_ICPolarity, uint16_t TIM_ICSelection,
+                       uint16_t TIM_ICFilter);
+static void TI3_Config(TIM_TypeDef* TIMx, uint16_t TIM_ICPolarity, uint16_t TIM_ICSelection,
+                       uint16_t TIM_ICFilter);
+static void TI4_Config(TIM_TypeDef* TIMx, uint16_t TIM_ICPolarity, uint16_t TIM_ICSelection,
+                       uint16_t TIM_ICFilter);
+
+/* Private functions ---------------------------------------------------------*/
+
+/** @defgroup TIM_Private_Functions
+  * @{
+  */
+
+/** @defgroup TIM_Group1 TimeBase management functions
+ *  @brief   TimeBase management functions 
+ *
+@verbatim   
+ ===============================================================================
+                       TimeBase management functions
+ ===============================================================================  
+  
+       ===================================================================      
+              TIM Driver: how to use it in Timing(Time base) Mode
+       =================================================================== 
+       To use the Timer in Timing(Time base) mode, the following steps are mandatory:
+       
+       1. Enable TIM clock using RCC_APBxPeriphClockCmd(RCC_APBxPeriph_TIMx, ENABLE) function
+                    
+       2. Fill the TIM_TimeBaseInitStruct with the desired parameters.
+       
+       3. Call TIM_TimeBaseInit(TIMx, &TIM_TimeBaseInitStruct) to configure the Time Base unit
+          with the corresponding configuration
+          
+       4. Enable the NVIC if you need to generate the update interrupt. 
+          
+       5. Enable the corresponding interrupt using the function TIM_ITConfig(TIMx, TIM_IT_Update) 
+       
+       6. Call the TIM_Cmd(ENABLE) function to enable the TIM counter.
+             
+       Note1: All other functions can be used separately to modify, if needed,
+          a specific feature of the Timer. 
+
+@endverbatim
+  * @{
+  */
+  
+/**
+  * @brief  Deinitializes the TIMx peripheral registers to their default reset values.
+  * @param  TIMx: where x can be 1 to 14 to select the TIM peripheral.
+  * @retval None
+
+  */
+void TIM_DeInit(TIM_TypeDef* TIMx)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_ALL_PERIPH(TIMx)); 
+ 
+  if (TIMx == TIM1)
+  {
+    RCC_APB2PeriphResetCmd(RCC_APB2Periph_TIM1, ENABLE);
+    RCC_APB2PeriphResetCmd(RCC_APB2Periph_TIM1, DISABLE);  
+  } 
+  else if (TIMx == TIM2) 
+  {     
+    RCC_APB1PeriphResetCmd(RCC_APB1Periph_TIM2, ENABLE);
+    RCC_APB1PeriphResetCmd(RCC_APB1Periph_TIM2, DISABLE);
+  }  
+  else if (TIMx == TIM3)
+  { 
+    RCC_APB1PeriphResetCmd(RCC_APB1Periph_TIM3, ENABLE);
+    RCC_APB1PeriphResetCmd(RCC_APB1Periph_TIM3, DISABLE);
+  }  
+  else if (TIMx == TIM4)
+  { 
+    RCC_APB1PeriphResetCmd(RCC_APB1Periph_TIM4, ENABLE);
+    RCC_APB1PeriphResetCmd(RCC_APB1Periph_TIM4, DISABLE);
+  }  
+  else if (TIMx == TIM5)
+  {      
+    RCC_APB1PeriphResetCmd(RCC_APB1Periph_TIM5, ENABLE);
+    RCC_APB1PeriphResetCmd(RCC_APB1Periph_TIM5, DISABLE);
+  }  
+  else if (TIMx == TIM6)  
+  {    
+    RCC_APB1PeriphResetCmd(RCC_APB1Periph_TIM6, ENABLE);
+    RCC_APB1PeriphResetCmd(RCC_APB1Periph_TIM6, DISABLE);
+  }  
+  else if (TIMx == TIM7)
+  {      
+    RCC_APB1PeriphResetCmd(RCC_APB1Periph_TIM7, ENABLE);
+    RCC_APB1PeriphResetCmd(RCC_APB1Periph_TIM7, DISABLE);
+  }  
+  else if (TIMx == TIM8)
+  {      
+    RCC_APB2PeriphResetCmd(RCC_APB2Periph_TIM8, ENABLE);
+    RCC_APB2PeriphResetCmd(RCC_APB2Periph_TIM8, DISABLE);  
+  }  
+  else if (TIMx == TIM9)
+  {      
+    RCC_APB2PeriphResetCmd(RCC_APB2Periph_TIM9, ENABLE);
+    RCC_APB2PeriphResetCmd(RCC_APB2Periph_TIM9, DISABLE);  
+   }  
+  else if (TIMx == TIM10)
+  {      
+    RCC_APB2PeriphResetCmd(RCC_APB2Periph_TIM10, ENABLE);
+    RCC_APB2PeriphResetCmd(RCC_APB2Periph_TIM10, DISABLE);  
+  }  
+  else if (TIMx == TIM11) 
+  {     
+    RCC_APB2PeriphResetCmd(RCC_APB2Periph_TIM11, ENABLE);
+    RCC_APB2PeriphResetCmd(RCC_APB2Periph_TIM11, DISABLE);  
+  }  
+  else if (TIMx == TIM12)
+  {      
+    RCC_APB1PeriphResetCmd(RCC_APB1Periph_TIM12, ENABLE);
+    RCC_APB1PeriphResetCmd(RCC_APB1Periph_TIM12, DISABLE);  
+  }  
+  else if (TIMx == TIM13) 
+  {       
+    RCC_APB1PeriphResetCmd(RCC_APB1Periph_TIM13, ENABLE);
+    RCC_APB1PeriphResetCmd(RCC_APB1Periph_TIM13, DISABLE);  
+  }  
+  else
+  { 
+    if (TIMx == TIM14) 
+    {     
+      RCC_APB1PeriphResetCmd(RCC_APB1Periph_TIM14, ENABLE);
+      RCC_APB1PeriphResetCmd(RCC_APB1Periph_TIM14, DISABLE); 
+    }   
+  }
+}
+
+/**
+  * @brief  Initializes the TIMx Time Base Unit peripheral according to 
+  *         the specified parameters in the TIM_TimeBaseInitStruct.
+  * @param  TIMx: where x can be  1 to 14 to select the TIM peripheral.
+  * @param  TIM_TimeBaseInitStruct: pointer to a TIM_TimeBaseInitTypeDef structure
+  *         that contains the configuration information for the specified TIM peripheral.
+  * @retval None
+  */
+void TIM_TimeBaseInit(TIM_TypeDef* TIMx, TIM_TimeBaseInitTypeDef* TIM_TimeBaseInitStruct)
+{
+  uint16_t tmpcr1 = 0;
+
+  /* Check the parameters */
+  assert_param(IS_TIM_ALL_PERIPH(TIMx)); 
+  assert_param(IS_TIM_COUNTER_MODE(TIM_TimeBaseInitStruct->TIM_CounterMode));
+  assert_param(IS_TIM_CKD_DIV(TIM_TimeBaseInitStruct->TIM_ClockDivision));
+
+  tmpcr1 = TIMx->CR1;  
+
+  if((TIMx == TIM1) || (TIMx == TIM8)||
+     (TIMx == TIM2) || (TIMx == TIM3)||
+     (TIMx == TIM4) || (TIMx == TIM5)) 
+  {
+    /* Select the Counter Mode */
+    tmpcr1 &= (uint16_t)(~(TIM_CR1_DIR | TIM_CR1_CMS));
+    tmpcr1 |= (uint32_t)TIM_TimeBaseInitStruct->TIM_CounterMode;
+  }
+ 
+  if((TIMx != TIM6) && (TIMx != TIM7))
+  {
+    /* Set the clock division */
+    tmpcr1 &=  (uint16_t)(~TIM_CR1_CKD);
+    tmpcr1 |= (uint32_t)TIM_TimeBaseInitStruct->TIM_ClockDivision;
+  }
+
+  TIMx->CR1 = tmpcr1;
+
+  /* Set the Autoreload value */
+  TIMx->ARR = TIM_TimeBaseInitStruct->TIM_Period ;
+ 
+  /* Set the Prescaler value */
+  TIMx->PSC = TIM_TimeBaseInitStruct->TIM_Prescaler;
+    
+  if ((TIMx == TIM1) || (TIMx == TIM8))  
+  {
+    /* Set the Repetition Counter value */
+    TIMx->RCR = TIM_TimeBaseInitStruct->TIM_RepetitionCounter;
+  }
+
+  /* Generate an update event to reload the Prescaler 
+     and the repetition counter(only for TIM1 and TIM8) value immediatly */
+  TIMx->EGR = TIM_PSCReloadMode_Immediate;          
+}
+
+/**
+  * @brief  Fills each TIM_TimeBaseInitStruct member with its default value.
+  * @param  TIM_TimeBaseInitStruct : pointer to a TIM_TimeBaseInitTypeDef
+  *         structure which will be initialized.
+  * @retval None
+  */
+void TIM_TimeBaseStructInit(TIM_TimeBaseInitTypeDef* TIM_TimeBaseInitStruct)
+{
+  /* Set the default configuration */
+  TIM_TimeBaseInitStruct->TIM_Period = 0xFFFFFFFF;
+  TIM_TimeBaseInitStruct->TIM_Prescaler = 0x0000;
+  TIM_TimeBaseInitStruct->TIM_ClockDivision = TIM_CKD_DIV1;
+  TIM_TimeBaseInitStruct->TIM_CounterMode = TIM_CounterMode_Up;
+  TIM_TimeBaseInitStruct->TIM_RepetitionCounter = 0x0000;
+}
+
+/**
+  * @brief  Configures the TIMx Prescaler.
+  * @param  TIMx: where x can be  1 to 14 to select the TIM peripheral.
+  * @param  Prescaler: specifies the Prescaler Register value
+  * @param  TIM_PSCReloadMode: specifies the TIM Prescaler Reload mode
+  *          This parameter can be one of the following values:
+  *            @arg TIM_PSCReloadMode_Update: The Prescaler is loaded at the update event.
+  *            @arg TIM_PSCReloadMode_Immediate: The Prescaler is loaded immediatly.
+  * @retval None
+  */
+void TIM_PrescalerConfig(TIM_TypeDef* TIMx, uint16_t Prescaler, uint16_t TIM_PSCReloadMode)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_ALL_PERIPH(TIMx));
+  assert_param(IS_TIM_PRESCALER_RELOAD(TIM_PSCReloadMode));
+  /* Set the Prescaler value */
+  TIMx->PSC = Prescaler;
+  /* Set or reset the UG Bit */
+  TIMx->EGR = TIM_PSCReloadMode;
+}
+
+/**
+  * @brief  Specifies the TIMx Counter Mode to be used.
+  * @param  TIMx: where x can be  1, 2, 3, 4, 5 or 8 to select the TIM peripheral.
+  * @param  TIM_CounterMode: specifies the Counter Mode to be used
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CounterMode_Up: TIM Up Counting Mode
+  *            @arg TIM_CounterMode_Down: TIM Down Counting Mode
+  *            @arg TIM_CounterMode_CenterAligned1: TIM Center Aligned Mode1
+  *            @arg TIM_CounterMode_CenterAligned2: TIM Center Aligned Mode2
+  *            @arg TIM_CounterMode_CenterAligned3: TIM Center Aligned Mode3
+  * @retval None
+  */
+void TIM_CounterModeConfig(TIM_TypeDef* TIMx, uint16_t TIM_CounterMode)
+{
+  uint16_t tmpcr1 = 0;
+
+  /* Check the parameters */
+  assert_param(IS_TIM_LIST3_PERIPH(TIMx));
+  assert_param(IS_TIM_COUNTER_MODE(TIM_CounterMode));
+
+  tmpcr1 = TIMx->CR1;
+
+  /* Reset the CMS and DIR Bits */
+  tmpcr1 &= (uint16_t)~(TIM_CR1_DIR | TIM_CR1_CMS);
+
+  /* Set the Counter Mode */
+  tmpcr1 |= TIM_CounterMode;
+
+  /* Write to TIMx CR1 register */
+  TIMx->CR1 = tmpcr1;
+}
+
+/**
+  * @brief  Sets the TIMx Counter Register value
+  * @param  TIMx: where x can be 1 to 14 to select the TIM peripheral.
+  * @param  Counter: specifies the Counter register new value.
+  * @retval None
+  */
+void TIM_SetCounter(TIM_TypeDef* TIMx, uint32_t Counter)
+{
+  /* Check the parameters */
+   assert_param(IS_TIM_ALL_PERIPH(TIMx));
+
+  /* Set the Counter Register value */
+  TIMx->CNT = Counter;
+}
+
+/**
+  * @brief  Sets the TIMx Autoreload Register value
+  * @param  TIMx: where x can be 1 to 14 to select the TIM peripheral.
+  * @param  Autoreload: specifies the Autoreload register new value.
+  * @retval None
+  */
+void TIM_SetAutoreload(TIM_TypeDef* TIMx, uint32_t Autoreload)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_ALL_PERIPH(TIMx));
+  
+  /* Set the Autoreload Register value */
+  TIMx->ARR = Autoreload;
+}
+
+/**
+  * @brief  Gets the TIMx Counter value.
+  * @param  TIMx: where x can be 1 to 14 to select the TIM peripheral.
+  * @retval Counter Register value
+  */
+uint32_t TIM_GetCounter(TIM_TypeDef* TIMx)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_ALL_PERIPH(TIMx));
+
+  /* Get the Counter Register value */
+  return TIMx->CNT;
+}
+
+/**
+  * @brief  Gets the TIMx Prescaler value.
+  * @param  TIMx: where x can be 1 to 14 to select the TIM peripheral.
+  * @retval Prescaler Register value.
+  */
+uint16_t TIM_GetPrescaler(TIM_TypeDef* TIMx)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_ALL_PERIPH(TIMx));
+
+  /* Get the Prescaler Register value */
+  return TIMx->PSC;
+}
+
+/**
+  * @brief  Enables or Disables the TIMx Update event.
+  * @param  TIMx: where x can be 1 to 14 to select the TIM peripheral.
+  * @param  NewState: new state of the TIMx UDIS bit
+  *          This parameter can be: ENABLE or DISABLE.
+  * @retval None
+  */
+void TIM_UpdateDisableConfig(TIM_TypeDef* TIMx, FunctionalState NewState)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_ALL_PERIPH(TIMx));
+  assert_param(IS_FUNCTIONAL_STATE(NewState));
+
+  if (NewState != DISABLE)
+  {
+    /* Set the Update Disable Bit */
+    TIMx->CR1 |= TIM_CR1_UDIS;
+  }
+  else
+  {
+    /* Reset the Update Disable Bit */
+    TIMx->CR1 &= (uint16_t)~TIM_CR1_UDIS;
+  }
+}
+
+/**
+  * @brief  Configures the TIMx Update Request Interrupt source.
+  * @param  TIMx: where x can be 1 to 14 to select the TIM peripheral.
+  * @param  TIM_UpdateSource: specifies the Update source.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_UpdateSource_Global: Source of update is the counter
+  *                 overflow/underflow or the setting of UG bit, or an update
+  *                 generation through the slave mode controller.
+  *            @arg TIM_UpdateSource_Regular: Source of update is counter overflow/underflow.
+  * @retval None
+  */
+void TIM_UpdateRequestConfig(TIM_TypeDef* TIMx, uint16_t TIM_UpdateSource)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_ALL_PERIPH(TIMx));
+  assert_param(IS_TIM_UPDATE_SOURCE(TIM_UpdateSource));
+
+  if (TIM_UpdateSource != TIM_UpdateSource_Global)
+  {
+    /* Set the URS Bit */
+    TIMx->CR1 |= TIM_CR1_URS;
+  }
+  else
+  {
+    /* Reset the URS Bit */
+    TIMx->CR1 &= (uint16_t)~TIM_CR1_URS;
+  }
+}
+
+/**
+  * @brief  Enables or disables TIMx peripheral Preload register on ARR.
+  * @param  TIMx: where x can be 1 to 14 to select the TIM peripheral.
+  * @param  NewState: new state of the TIMx peripheral Preload register
+  *          This parameter can be: ENABLE or DISABLE.
+  * @retval None
+  */
+void TIM_ARRPreloadConfig(TIM_TypeDef* TIMx, FunctionalState NewState)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_ALL_PERIPH(TIMx));
+  assert_param(IS_FUNCTIONAL_STATE(NewState));
+
+  if (NewState != DISABLE)
+  {
+    /* Set the ARR Preload Bit */
+    TIMx->CR1 |= TIM_CR1_ARPE;
+  }
+  else
+  {
+    /* Reset the ARR Preload Bit */
+    TIMx->CR1 &= (uint16_t)~TIM_CR1_ARPE;
+  }
+}
+
+/**
+  * @brief  Selects the TIMx's One Pulse Mode.
+  * @param  TIMx: where x can be 1 to 14 to select the TIM peripheral.
+  * @param  TIM_OPMode: specifies the OPM Mode to be used.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_OPMode_Single
+  *            @arg TIM_OPMode_Repetitive
+  * @retval None
+  */
+void TIM_SelectOnePulseMode(TIM_TypeDef* TIMx, uint16_t TIM_OPMode)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_ALL_PERIPH(TIMx));
+  assert_param(IS_TIM_OPM_MODE(TIM_OPMode));
+
+  /* Reset the OPM Bit */
+  TIMx->CR1 &= (uint16_t)~TIM_CR1_OPM;
+
+  /* Configure the OPM Mode */
+  TIMx->CR1 |= TIM_OPMode;
+}
+
+/**
+  * @brief  Sets the TIMx Clock Division value.
+  * @param  TIMx: where x can be 1 to 14 except 6 and 7, to select the TIM peripheral.
+  * @param  TIM_CKD: specifies the clock division value.
+  *          This parameter can be one of the following value:
+  *            @arg TIM_CKD_DIV1: TDTS = Tck_tim
+  *            @arg TIM_CKD_DIV2: TDTS = 2*Tck_tim
+  *            @arg TIM_CKD_DIV4: TDTS = 4*Tck_tim
+  * @retval None
+  */
+void TIM_SetClockDivision(TIM_TypeDef* TIMx, uint16_t TIM_CKD)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_LIST1_PERIPH(TIMx));
+  assert_param(IS_TIM_CKD_DIV(TIM_CKD));
+
+  /* Reset the CKD Bits */
+  TIMx->CR1 &= (uint16_t)(~TIM_CR1_CKD);
+
+  /* Set the CKD value */
+  TIMx->CR1 |= TIM_CKD;
+}
+
+/**
+  * @brief  Enables or disables the specified TIM peripheral.
+  * @param  TIMx: where x can be 1 to 14 to select the TIMx peripheral.
+  * @param  NewState: new state of the TIMx peripheral.
+  *          This parameter can be: ENABLE or DISABLE.
+  * @retval None
+  */
+void TIM_Cmd(TIM_TypeDef* TIMx, FunctionalState NewState)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_ALL_PERIPH(TIMx)); 
+  assert_param(IS_FUNCTIONAL_STATE(NewState));
+  
+  if (NewState != DISABLE)
+  {
+    /* Enable the TIM Counter */
+    TIMx->CR1 |= TIM_CR1_CEN;
+  }
+  else
+  {
+    /* Disable the TIM Counter */
+    TIMx->CR1 &= (uint16_t)~TIM_CR1_CEN;
+  }
+}
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Group2 Output Compare management functions
+ *  @brief    Output Compare management functions 
+ *
+@verbatim   
+ ===============================================================================
+                        Output Compare management functions
+ ===============================================================================  
+   
+       ===================================================================      
+              TIM Driver: how to use it in Output Compare Mode
+       =================================================================== 
+       To use the Timer in Output Compare mode, the following steps are mandatory:
+       
+       1. Enable TIM clock using RCC_APBxPeriphClockCmd(RCC_APBxPeriph_TIMx, ENABLE) function
+       
+       2. Configure the TIM pins by configuring the corresponding GPIO pins
+       
+       2. Configure the Time base unit as described in the first part of this driver, 
+          if needed, else the Timer will run with the default configuration:
+          - Autoreload value = 0xFFFF
+          - Prescaler value = 0x0000
+          - Counter mode = Up counting
+          - Clock Division = TIM_CKD_DIV1
+          
+       3. Fill the TIM_OCInitStruct with the desired parameters including:
+          - The TIM Output Compare mode: TIM_OCMode
+          - TIM Output State: TIM_OutputState
+          - TIM Pulse value: TIM_Pulse
+          - TIM Output Compare Polarity : TIM_OCPolarity
+       
+       4. Call TIM_OCxInit(TIMx, &TIM_OCInitStruct) to configure the desired channel with the 
+          corresponding configuration
+       
+       5. Call the TIM_Cmd(ENABLE) function to enable the TIM counter.
+       
+       Note1: All other functions can be used separately to modify, if needed,
+              a specific feature of the Timer. 
+          
+       Note2: In case of PWM mode, this function is mandatory:
+              TIM_OCxPreloadConfig(TIMx, TIM_OCPreload_ENABLE); 
+              
+       Note3: If the corresponding interrupt or DMA request are needed, the user should:
+                1. Enable the NVIC (or the DMA) to use the TIM interrupts (or DMA requests). 
+                2. Enable the corresponding interrupt (or DMA request) using the function 
+                   TIM_ITConfig(TIMx, TIM_IT_CCx) (or TIM_DMA_Cmd(TIMx, TIM_DMA_CCx))   
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Initializes the TIMx Channel1 according to the specified parameters in
+  *         the TIM_OCInitStruct.
+  * @param  TIMx: where x can be 1 to 14 except 6 and 7, to select the TIM peripheral.
+  * @param  TIM_OCInitStruct: pointer to a TIM_OCInitTypeDef structure that contains
+  *         the configuration information for the specified TIM peripheral.
+  * @retval None
+  */
+void TIM_OC1Init(TIM_TypeDef* TIMx, TIM_OCInitTypeDef* TIM_OCInitStruct)
+{
+  uint16_t tmpccmrx = 0, tmpccer = 0, tmpcr2 = 0;
+   
+  /* Check the parameters */
+  assert_param(IS_TIM_LIST1_PERIPH(TIMx)); 
+  assert_param(IS_TIM_OC_MODE(TIM_OCInitStruct->TIM_OCMode));
+  assert_param(IS_TIM_OUTPUT_STATE(TIM_OCInitStruct->TIM_OutputState));
+  assert_param(IS_TIM_OC_POLARITY(TIM_OCInitStruct->TIM_OCPolarity));   
+
+  /* Disable the Channel 1: Reset the CC1E Bit */
+  TIMx->CCER &= (uint16_t)~TIM_CCER_CC1E;
+  
+  /* Get the TIMx CCER register value */
+  tmpccer = TIMx->CCER;
+  /* Get the TIMx CR2 register value */
+  tmpcr2 =  TIMx->CR2;
+  
+  /* Get the TIMx CCMR1 register value */
+  tmpccmrx = TIMx->CCMR1;
+    
+  /* Reset the Output Compare Mode Bits */
+  tmpccmrx &= (uint16_t)~TIM_CCMR1_OC1M;
+  tmpccmrx &= (uint16_t)~TIM_CCMR1_CC1S;
+  /* Select the Output Compare Mode */
+  tmpccmrx |= TIM_OCInitStruct->TIM_OCMode;
+  
+  /* Reset the Output Polarity level */
+  tmpccer &= (uint16_t)~TIM_CCER_CC1P;
+  /* Set the Output Compare Polarity */
+  tmpccer |= TIM_OCInitStruct->TIM_OCPolarity;
+  
+  /* Set the Output State */
+  tmpccer |= TIM_OCInitStruct->TIM_OutputState;
+    
+  if((TIMx == TIM1) || (TIMx == TIM8))
+  {
+    assert_param(IS_TIM_OUTPUTN_STATE(TIM_OCInitStruct->TIM_OutputNState));
+    assert_param(IS_TIM_OCN_POLARITY(TIM_OCInitStruct->TIM_OCNPolarity));
+    assert_param(IS_TIM_OCNIDLE_STATE(TIM_OCInitStruct->TIM_OCNIdleState));
+    assert_param(IS_TIM_OCIDLE_STATE(TIM_OCInitStruct->TIM_OCIdleState));
+    
+    /* Reset the Output N Polarity level */
+    tmpccer &= (uint16_t)~TIM_CCER_CC1NP;
+    /* Set the Output N Polarity */
+    tmpccer |= TIM_OCInitStruct->TIM_OCNPolarity;
+    /* Reset the Output N State */
+    tmpccer &= (uint16_t)~TIM_CCER_CC1NE;
+    
+    /* Set the Output N State */
+    tmpccer |= TIM_OCInitStruct->TIM_OutputNState;
+    /* Reset the Output Compare and Output Compare N IDLE State */
+    tmpcr2 &= (uint16_t)~TIM_CR2_OIS1;
+    tmpcr2 &= (uint16_t)~TIM_CR2_OIS1N;
+    /* Set the Output Idle state */
+    tmpcr2 |= TIM_OCInitStruct->TIM_OCIdleState;
+    /* Set the Output N Idle state */
+    tmpcr2 |= TIM_OCInitStruct->TIM_OCNIdleState;
+  }
+  /* Write to TIMx CR2 */
+  TIMx->CR2 = tmpcr2;
+  
+  /* Write to TIMx CCMR1 */
+  TIMx->CCMR1 = tmpccmrx;
+  
+  /* Set the Capture Compare Register value */
+  TIMx->CCR1 = TIM_OCInitStruct->TIM_Pulse;
+  
+  /* Write to TIMx CCER */
+  TIMx->CCER = tmpccer;
+}
+
+/**
+  * @brief  Initializes the TIMx Channel2 according to the specified parameters 
+  *         in the TIM_OCInitStruct.
+  * @param  TIMx: where x can be 1, 2, 3, 4, 5, 8, 9 or 12 to select the TIM 
+  *         peripheral.
+  * @param  TIM_OCInitStruct: pointer to a TIM_OCInitTypeDef structure that contains
+  *         the configuration information for the specified TIM peripheral.
+  * @retval None
+  */
+void TIM_OC2Init(TIM_TypeDef* TIMx, TIM_OCInitTypeDef* TIM_OCInitStruct)
+{
+  uint16_t tmpccmrx = 0, tmpccer = 0, tmpcr2 = 0;
+   
+  /* Check the parameters */
+  assert_param(IS_TIM_LIST2_PERIPH(TIMx)); 
+  assert_param(IS_TIM_OC_MODE(TIM_OCInitStruct->TIM_OCMode));
+  assert_param(IS_TIM_OUTPUT_STATE(TIM_OCInitStruct->TIM_OutputState));
+  assert_param(IS_TIM_OC_POLARITY(TIM_OCInitStruct->TIM_OCPolarity));   
+
+  /* Disable the Channel 2: Reset the CC2E Bit */
+  TIMx->CCER &= (uint16_t)~TIM_CCER_CC2E;
+  
+  /* Get the TIMx CCER register value */  
+  tmpccer = TIMx->CCER;
+  /* Get the TIMx CR2 register value */
+  tmpcr2 =  TIMx->CR2;
+  
+  /* Get the TIMx CCMR1 register value */
+  tmpccmrx = TIMx->CCMR1;
+    
+  /* Reset the Output Compare mode and Capture/Compare selection Bits */
+  tmpccmrx &= (uint16_t)~TIM_CCMR1_OC2M;
+  tmpccmrx &= (uint16_t)~TIM_CCMR1_CC2S;
+  
+  /* Select the Output Compare Mode */
+  tmpccmrx |= (uint16_t)(TIM_OCInitStruct->TIM_OCMode << 8);
+  
+  /* Reset the Output Polarity level */
+  tmpccer &= (uint16_t)~TIM_CCER_CC2P;
+  /* Set the Output Compare Polarity */
+  tmpccer |= (uint16_t)(TIM_OCInitStruct->TIM_OCPolarity << 4);
+  
+  /* Set the Output State */
+  tmpccer |= (uint16_t)(TIM_OCInitStruct->TIM_OutputState << 4);
+    
+  if((TIMx == TIM1) || (TIMx == TIM8))
+  {
+    assert_param(IS_TIM_OUTPUTN_STATE(TIM_OCInitStruct->TIM_OutputNState));
+    assert_param(IS_TIM_OCN_POLARITY(TIM_OCInitStruct->TIM_OCNPolarity));
+    assert_param(IS_TIM_OCNIDLE_STATE(TIM_OCInitStruct->TIM_OCNIdleState));
+    assert_param(IS_TIM_OCIDLE_STATE(TIM_OCInitStruct->TIM_OCIdleState));
+    
+    /* Reset the Output N Polarity level */
+    tmpccer &= (uint16_t)~TIM_CCER_CC2NP;
+    /* Set the Output N Polarity */
+    tmpccer |= (uint16_t)(TIM_OCInitStruct->TIM_OCNPolarity << 4);
+    /* Reset the Output N State */
+    tmpccer &= (uint16_t)~TIM_CCER_CC2NE;
+    
+    /* Set the Output N State */
+    tmpccer |= (uint16_t)(TIM_OCInitStruct->TIM_OutputNState << 4);
+    /* Reset the Output Compare and Output Compare N IDLE State */
+    tmpcr2 &= (uint16_t)~TIM_CR2_OIS2;
+    tmpcr2 &= (uint16_t)~TIM_CR2_OIS2N;
+    /* Set the Output Idle state */
+    tmpcr2 |= (uint16_t)(TIM_OCInitStruct->TIM_OCIdleState << 2);
+    /* Set the Output N Idle state */
+    tmpcr2 |= (uint16_t)(TIM_OCInitStruct->TIM_OCNIdleState << 2);
+  }
+  /* Write to TIMx CR2 */
+  TIMx->CR2 = tmpcr2;
+  
+  /* Write to TIMx CCMR1 */
+  TIMx->CCMR1 = tmpccmrx;
+  
+  /* Set the Capture Compare Register value */
+  TIMx->CCR2 = TIM_OCInitStruct->TIM_Pulse;
+  
+  /* Write to TIMx CCER */
+  TIMx->CCER = tmpccer;
+}
+
+/**
+  * @brief  Initializes the TIMx Channel3 according to the specified parameters
+  *         in the TIM_OCInitStruct.
+  * @param  TIMx: where x can be 1, 2, 3, 4, 5 or 8 to select the TIM peripheral.
+  * @param  TIM_OCInitStruct: pointer to a TIM_OCInitTypeDef structure that contains
+  *         the configuration information for the specified TIM peripheral.
+  * @retval None
+  */
+void TIM_OC3Init(TIM_TypeDef* TIMx, TIM_OCInitTypeDef* TIM_OCInitStruct)
+{
+  uint16_t tmpccmrx = 0, tmpccer = 0, tmpcr2 = 0;
+   
+  /* Check the parameters */
+  assert_param(IS_TIM_LIST3_PERIPH(TIMx)); 
+  assert_param(IS_TIM_OC_MODE(TIM_OCInitStruct->TIM_OCMode));
+  assert_param(IS_TIM_OUTPUT_STATE(TIM_OCInitStruct->TIM_OutputState));
+  assert_param(IS_TIM_OC_POLARITY(TIM_OCInitStruct->TIM_OCPolarity));   
+
+  /* Disable the Channel 3: Reset the CC2E Bit */
+  TIMx->CCER &= (uint16_t)~TIM_CCER_CC3E;
+  
+  /* Get the TIMx CCER register value */
+  tmpccer = TIMx->CCER;
+  /* Get the TIMx CR2 register value */
+  tmpcr2 =  TIMx->CR2;
+  
+  /* Get the TIMx CCMR2 register value */
+  tmpccmrx = TIMx->CCMR2;
+    
+  /* Reset the Output Compare mode and Capture/Compare selection Bits */
+  tmpccmrx &= (uint16_t)~TIM_CCMR2_OC3M;
+  tmpccmrx &= (uint16_t)~TIM_CCMR2_CC3S;  
+  /* Select the Output Compare Mode */
+  tmpccmrx |= TIM_OCInitStruct->TIM_OCMode;
+  
+  /* Reset the Output Polarity level */
+  tmpccer &= (uint16_t)~TIM_CCER_CC3P;
+  /* Set the Output Compare Polarity */
+  tmpccer |= (uint16_t)(TIM_OCInitStruct->TIM_OCPolarity << 8);
+  
+  /* Set the Output State */
+  tmpccer |= (uint16_t)(TIM_OCInitStruct->TIM_OutputState << 8);
+    
+  if((TIMx == TIM1) || (TIMx == TIM8))
+  {
+    assert_param(IS_TIM_OUTPUTN_STATE(TIM_OCInitStruct->TIM_OutputNState));
+    assert_param(IS_TIM_OCN_POLARITY(TIM_OCInitStruct->TIM_OCNPolarity));
+    assert_param(IS_TIM_OCNIDLE_STATE(TIM_OCInitStruct->TIM_OCNIdleState));
+    assert_param(IS_TIM_OCIDLE_STATE(TIM_OCInitStruct->TIM_OCIdleState));
+    
+    /* Reset the Output N Polarity level */
+    tmpccer &= (uint16_t)~TIM_CCER_CC3NP;
+    /* Set the Output N Polarity */
+    tmpccer |= (uint16_t)(TIM_OCInitStruct->TIM_OCNPolarity << 8);
+    /* Reset the Output N State */
+    tmpccer &= (uint16_t)~TIM_CCER_CC3NE;
+    
+    /* Set the Output N State */
+    tmpccer |= (uint16_t)(TIM_OCInitStruct->TIM_OutputNState << 8);
+    /* Reset the Output Compare and Output Compare N IDLE State */
+    tmpcr2 &= (uint16_t)~TIM_CR2_OIS3;
+    tmpcr2 &= (uint16_t)~TIM_CR2_OIS3N;
+    /* Set the Output Idle state */
+    tmpcr2 |= (uint16_t)(TIM_OCInitStruct->TIM_OCIdleState << 4);
+    /* Set the Output N Idle state */
+    tmpcr2 |= (uint16_t)(TIM_OCInitStruct->TIM_OCNIdleState << 4);
+  }
+  /* Write to TIMx CR2 */
+  TIMx->CR2 = tmpcr2;
+  
+  /* Write to TIMx CCMR2 */
+  TIMx->CCMR2 = tmpccmrx;
+  
+  /* Set the Capture Compare Register value */
+  TIMx->CCR3 = TIM_OCInitStruct->TIM_Pulse;
+  
+  /* Write to TIMx CCER */
+  TIMx->CCER = tmpccer;
+}
+
+/**
+  * @brief  Initializes the TIMx Channel4 according to the specified parameters
+  *         in the TIM_OCInitStruct.
+  * @param  TIMx: where x can be 1, 2, 3, 4, 5 or 8 to select the TIM peripheral.
+  * @param  TIM_OCInitStruct: pointer to a TIM_OCInitTypeDef structure that contains
+  *         the configuration information for the specified TIM peripheral.
+  * @retval None
+  */
+void TIM_OC4Init(TIM_TypeDef* TIMx, TIM_OCInitTypeDef* TIM_OCInitStruct)
+{
+  uint16_t tmpccmrx = 0, tmpccer = 0, tmpcr2 = 0;
+   
+  /* Check the parameters */
+  assert_param(IS_TIM_LIST3_PERIPH(TIMx)); 
+  assert_param(IS_TIM_OC_MODE(TIM_OCInitStruct->TIM_OCMode));
+  assert_param(IS_TIM_OUTPUT_STATE(TIM_OCInitStruct->TIM_OutputState));
+  assert_param(IS_TIM_OC_POLARITY(TIM_OCInitStruct->TIM_OCPolarity));   
+
+  /* Disable the Channel 4: Reset the CC4E Bit */
+  TIMx->CCER &= (uint16_t)~TIM_CCER_CC4E;
+  
+  /* Get the TIMx CCER register value */
+  tmpccer = TIMx->CCER;
+  /* Get the TIMx CR2 register value */
+  tmpcr2 =  TIMx->CR2;
+  
+  /* Get the TIMx CCMR2 register value */
+  tmpccmrx = TIMx->CCMR2;
+    
+  /* Reset the Output Compare mode and Capture/Compare selection Bits */
+  tmpccmrx &= (uint16_t)~TIM_CCMR2_OC4M;
+  tmpccmrx &= (uint16_t)~TIM_CCMR2_CC4S;
+  
+  /* Select the Output Compare Mode */
+  tmpccmrx |= (uint16_t)(TIM_OCInitStruct->TIM_OCMode << 8);
+  
+  /* Reset the Output Polarity level */
+  tmpccer &= (uint16_t)~TIM_CCER_CC4P;
+  /* Set the Output Compare Polarity */
+  tmpccer |= (uint16_t)(TIM_OCInitStruct->TIM_OCPolarity << 12);
+  
+  /* Set the Output State */
+  tmpccer |= (uint16_t)(TIM_OCInitStruct->TIM_OutputState << 12);
+  
+  if((TIMx == TIM1) || (TIMx == TIM8))
+  {
+    assert_param(IS_TIM_OCIDLE_STATE(TIM_OCInitStruct->TIM_OCIdleState));
+    /* Reset the Output Compare IDLE State */
+    tmpcr2 &=(uint16_t) ~TIM_CR2_OIS4;
+    /* Set the Output Idle state */
+    tmpcr2 |= (uint16_t)(TIM_OCInitStruct->TIM_OCIdleState << 6);
+  }
+  /* Write to TIMx CR2 */
+  TIMx->CR2 = tmpcr2;
+  
+  /* Write to TIMx CCMR2 */  
+  TIMx->CCMR2 = tmpccmrx;
+    
+  /* Set the Capture Compare Register value */
+  TIMx->CCR4 = TIM_OCInitStruct->TIM_Pulse;
+  
+  /* Write to TIMx CCER */
+  TIMx->CCER = tmpccer;
+}
+
+/**
+  * @brief  Fills each TIM_OCInitStruct member with its default value.
+  * @param  TIM_OCInitStruct: pointer to a TIM_OCInitTypeDef structure which will
+  *         be initialized.
+  * @retval None
+  */
+void TIM_OCStructInit(TIM_OCInitTypeDef* TIM_OCInitStruct)
+{
+  /* Set the default configuration */
+  TIM_OCInitStruct->TIM_OCMode = TIM_OCMode_Timing;
+  TIM_OCInitStruct->TIM_OutputState = TIM_OutputState_Disable;
+  TIM_OCInitStruct->TIM_OutputNState = TIM_OutputNState_Disable;
+  TIM_OCInitStruct->TIM_Pulse = 0x00000000;
+  TIM_OCInitStruct->TIM_OCPolarity = TIM_OCPolarity_High;
+  TIM_OCInitStruct->TIM_OCNPolarity = TIM_OCPolarity_High;
+  TIM_OCInitStruct->TIM_OCIdleState = TIM_OCIdleState_Reset;
+  TIM_OCInitStruct->TIM_OCNIdleState = TIM_OCNIdleState_Reset;
+}
+
+/**
+  * @brief  Selects the TIM Output Compare Mode.
+  * @note   This function disables the selected channel before changing the Output
+  *         Compare Mode. If needed, user has to enable this channel using
+  *         TIM_CCxCmd() and TIM_CCxNCmd() functions.
+  * @param  TIMx: where x can be 1 to 14 except 6 and 7, to select the TIM peripheral.
+  * @param  TIM_Channel: specifies the TIM Channel
+  *          This parameter can be one of the following values:
+  *            @arg TIM_Channel_1: TIM Channel 1
+  *            @arg TIM_Channel_2: TIM Channel 2
+  *            @arg TIM_Channel_3: TIM Channel 3
+  *            @arg TIM_Channel_4: TIM Channel 4
+  * @param  TIM_OCMode: specifies the TIM Output Compare Mode.
+  *           This parameter can be one of the following values:
+  *            @arg TIM_OCMode_Timing
+  *            @arg TIM_OCMode_Active
+  *            @arg TIM_OCMode_Toggle
+  *            @arg TIM_OCMode_PWM1
+  *            @arg TIM_OCMode_PWM2
+  *            @arg TIM_ForcedAction_Active
+  *            @arg TIM_ForcedAction_InActive
+  * @retval None
+  */
+void TIM_SelectOCxM(TIM_TypeDef* TIMx, uint16_t TIM_Channel, uint16_t TIM_OCMode)
+{
+  uint32_t tmp = 0;
+  uint16_t tmp1 = 0;
+
+  /* Check the parameters */
+  assert_param(IS_TIM_LIST1_PERIPH(TIMx));
+  assert_param(IS_TIM_CHANNEL(TIM_Channel));
+  assert_param(IS_TIM_OCM(TIM_OCMode));
+
+  tmp = (uint32_t) TIMx;
+  tmp += CCMR_OFFSET;
+
+  tmp1 = CCER_CCE_SET << (uint16_t)TIM_Channel;
+
+  /* Disable the Channel: Reset the CCxE Bit */
+  TIMx->CCER &= (uint16_t) ~tmp1;
+
+  if((TIM_Channel == TIM_Channel_1) ||(TIM_Channel == TIM_Channel_3))
+  {
+    tmp += (TIM_Channel>>1);
+
+    /* Reset the OCxM bits in the CCMRx register */
+    *(__IO uint32_t *) tmp &= CCMR_OC13M_MASK;
+   
+    /* Configure the OCxM bits in the CCMRx register */
+    *(__IO uint32_t *) tmp |= TIM_OCMode;
+  }
+  else
+  {
+    tmp += (uint16_t)(TIM_Channel - (uint16_t)4)>> (uint16_t)1;
+
+    /* Reset the OCxM bits in the CCMRx register */
+    *(__IO uint32_t *) tmp &= CCMR_OC24M_MASK;
+    
+    /* Configure the OCxM bits in the CCMRx register */
+    *(__IO uint32_t *) tmp |= (uint16_t)(TIM_OCMode << 8);
+  }
+}
+
+/**
+  * @brief  Sets the TIMx Capture Compare1 Register value
+  * @param  TIMx: where x can be 1 to 14 except 6 and 7, to select the TIM peripheral.
+  * @param  Compare1: specifies the Capture Compare1 register new value.
+  * @retval None
+  */
+void TIM_SetCompare1(TIM_TypeDef* TIMx, uint32_t Compare1)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_LIST1_PERIPH(TIMx));
+
+  /* Set the Capture Compare1 Register value */
+  TIMx->CCR1 = Compare1;
+}
+
+/**
+  * @brief  Sets the TIMx Capture Compare2 Register value
+  * @param  TIMx: where x can be 1, 2, 3, 4, 5, 8, 9 or 12 to select the TIM 
+  *         peripheral.
+  * @param  Compare2: specifies the Capture Compare2 register new value.
+  * @retval None
+  */
+void TIM_SetCompare2(TIM_TypeDef* TIMx, uint32_t Compare2)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_LIST2_PERIPH(TIMx));
+
+  /* Set the Capture Compare2 Register value */
+  TIMx->CCR2 = Compare2;
+}
+
+/**
+  * @brief  Sets the TIMx Capture Compare3 Register value
+  * @param  TIMx: where x can be 1, 2, 3, 4, 5 or 8 to select the TIM peripheral.
+  * @param  Compare3: specifies the Capture Compare3 register new value.
+  * @retval None
+  */
+void TIM_SetCompare3(TIM_TypeDef* TIMx, uint32_t Compare3)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_LIST3_PERIPH(TIMx));
+
+  /* Set the Capture Compare3 Register value */
+  TIMx->CCR3 = Compare3;
+}
+
+/**
+  * @brief  Sets the TIMx Capture Compare4 Register value
+  * @param  TIMx: where x can be 1, 2, 3, 4, 5 or 8 to select the TIM peripheral.
+  * @param  Compare4: specifies the Capture Compare4 register new value.
+  * @retval None
+  */
+void TIM_SetCompare4(TIM_TypeDef* TIMx, uint32_t Compare4)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_LIST3_PERIPH(TIMx));
+
+  /* Set the Capture Compare4 Register value */
+  TIMx->CCR4 = Compare4;
+}
+
+/**
+  * @brief  Forces the TIMx output 1 waveform to active or inactive level.
+  * @param  TIMx: where x can be 1 to 14 except 6 and 7, to select the TIM peripheral.
+  * @param  TIM_ForcedAction: specifies the forced Action to be set to the output waveform.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_ForcedAction_Active: Force active level on OC1REF
+  *            @arg TIM_ForcedAction_InActive: Force inactive level on OC1REF.
+  * @retval None
+  */
+void TIM_ForcedOC1Config(TIM_TypeDef* TIMx, uint16_t TIM_ForcedAction)
+{
+  uint16_t tmpccmr1 = 0;
+
+  /* Check the parameters */
+  assert_param(IS_TIM_LIST1_PERIPH(TIMx));
+  assert_param(IS_TIM_FORCED_ACTION(TIM_ForcedAction));
+  tmpccmr1 = TIMx->CCMR1;
+
+  /* Reset the OC1M Bits */
+  tmpccmr1 &= (uint16_t)~TIM_CCMR1_OC1M;
+
+  /* Configure The Forced output Mode */
+  tmpccmr1 |= TIM_ForcedAction;
+
+  /* Write to TIMx CCMR1 register */
+  TIMx->CCMR1 = tmpccmr1;
+}
+
+/**
+  * @brief  Forces the TIMx output 2 waveform to active or inactive level.
+  * @param  TIMx: where x can be  1, 2, 3, 4, 5, 8, 9 or 12 to select the TIM 
+  *         peripheral.
+  * @param  TIM_ForcedAction: specifies the forced Action to be set to the output waveform.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_ForcedAction_Active: Force active level on OC2REF
+  *            @arg TIM_ForcedAction_InActive: Force inactive level on OC2REF.
+  * @retval None
+  */
+void TIM_ForcedOC2Config(TIM_TypeDef* TIMx, uint16_t TIM_ForcedAction)
+{
+  uint16_t tmpccmr1 = 0;
+
+  /* Check the parameters */
+  assert_param(IS_TIM_LIST2_PERIPH(TIMx));
+  assert_param(IS_TIM_FORCED_ACTION(TIM_ForcedAction));
+  tmpccmr1 = TIMx->CCMR1;
+
+  /* Reset the OC2M Bits */
+  tmpccmr1 &= (uint16_t)~TIM_CCMR1_OC2M;
+
+  /* Configure The Forced output Mode */
+  tmpccmr1 |= (uint16_t)(TIM_ForcedAction << 8);
+
+  /* Write to TIMx CCMR1 register */
+  TIMx->CCMR1 = tmpccmr1;
+}
+
+/**
+  * @brief  Forces the TIMx output 3 waveform to active or inactive level.
+  * @param  TIMx: where x can be  1, 2, 3, 4, 5 or 8 to select the TIM peripheral.
+  * @param  TIM_ForcedAction: specifies the forced Action to be set to the output waveform.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_ForcedAction_Active: Force active level on OC3REF
+  *            @arg TIM_ForcedAction_InActive: Force inactive level on OC3REF.
+  * @retval None
+  */
+void TIM_ForcedOC3Config(TIM_TypeDef* TIMx, uint16_t TIM_ForcedAction)
+{
+  uint16_t tmpccmr2 = 0;
+
+  /* Check the parameters */
+  assert_param(IS_TIM_LIST3_PERIPH(TIMx));
+  assert_param(IS_TIM_FORCED_ACTION(TIM_ForcedAction));
+
+  tmpccmr2 = TIMx->CCMR2;
+
+  /* Reset the OC1M Bits */
+  tmpccmr2 &= (uint16_t)~TIM_CCMR2_OC3M;
+
+  /* Configure The Forced output Mode */
+  tmpccmr2 |= TIM_ForcedAction;
+
+  /* Write to TIMx CCMR2 register */
+  TIMx->CCMR2 = tmpccmr2;
+}
+
+/**
+  * @brief  Forces the TIMx output 4 waveform to active or inactive level.
+  * @param  TIMx: where x can be  1, 2, 3, 4, 5 or 8 to select the TIM peripheral.
+  * @param  TIM_ForcedAction: specifies the forced Action to be set to the output waveform.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_ForcedAction_Active: Force active level on OC4REF
+  *            @arg TIM_ForcedAction_InActive: Force inactive level on OC4REF.
+  * @retval None
+  */
+void TIM_ForcedOC4Config(TIM_TypeDef* TIMx, uint16_t TIM_ForcedAction)
+{
+  uint16_t tmpccmr2 = 0;
+
+  /* Check the parameters */
+  assert_param(IS_TIM_LIST3_PERIPH(TIMx));
+  assert_param(IS_TIM_FORCED_ACTION(TIM_ForcedAction));
+  tmpccmr2 = TIMx->CCMR2;
+
+  /* Reset the OC2M Bits */
+  tmpccmr2 &= (uint16_t)~TIM_CCMR2_OC4M;
+
+  /* Configure The Forced output Mode */
+  tmpccmr2 |= (uint16_t)(TIM_ForcedAction << 8);
+
+  /* Write to TIMx CCMR2 register */
+  TIMx->CCMR2 = tmpccmr2;
+}
+
+/**
+  * @brief  Enables or disables the TIMx peripheral Preload register on CCR1.
+  * @param  TIMx: where x can be 1 to 14 except 6 and 7, to select the TIM peripheral.
+  * @param  TIM_OCPreload: new state of the TIMx peripheral Preload register
+  *          This parameter can be one of the following values:
+  *            @arg TIM_OCPreload_Enable
+  *            @arg TIM_OCPreload_Disable
+  * @retval None
+  */
+void TIM_OC1PreloadConfig(TIM_TypeDef* TIMx, uint16_t TIM_OCPreload)
+{
+  uint16_t tmpccmr1 = 0;
+
+  /* Check the parameters */
+  assert_param(IS_TIM_LIST1_PERIPH(TIMx));
+  assert_param(IS_TIM_OCPRELOAD_STATE(TIM_OCPreload));
+
+  tmpccmr1 = TIMx->CCMR1;
+
+  /* Reset the OC1PE Bit */
+  tmpccmr1 &= (uint16_t)(~TIM_CCMR1_OC1PE);
+
+  /* Enable or Disable the Output Compare Preload feature */
+  tmpccmr1 |= TIM_OCPreload;
+
+  /* Write to TIMx CCMR1 register */
+  TIMx->CCMR1 = tmpccmr1;
+}
+
+/**
+  * @brief  Enables or disables the TIMx peripheral Preload register on CCR2.
+  * @param  TIMx: where x can be  1, 2, 3, 4, 5, 8, 9 or 12 to select the TIM 
+  *         peripheral.
+  * @param  TIM_OCPreload: new state of the TIMx peripheral Preload register
+  *          This parameter can be one of the following values:
+  *            @arg TIM_OCPreload_Enable
+  *            @arg TIM_OCPreload_Disable
+  * @retval None
+  */
+void TIM_OC2PreloadConfig(TIM_TypeDef* TIMx, uint16_t TIM_OCPreload)
+{
+  uint16_t tmpccmr1 = 0;
+
+  /* Check the parameters */
+  assert_param(IS_TIM_LIST2_PERIPH(TIMx));
+  assert_param(IS_TIM_OCPRELOAD_STATE(TIM_OCPreload));
+
+  tmpccmr1 = TIMx->CCMR1;
+
+  /* Reset the OC2PE Bit */
+  tmpccmr1 &= (uint16_t)(~TIM_CCMR1_OC2PE);
+
+  /* Enable or Disable the Output Compare Preload feature */
+  tmpccmr1 |= (uint16_t)(TIM_OCPreload << 8);
+
+  /* Write to TIMx CCMR1 register */
+  TIMx->CCMR1 = tmpccmr1;
+}
+
+/**
+  * @brief  Enables or disables the TIMx peripheral Preload register on CCR3.
+  * @param  TIMx: where x can be  1, 2, 3, 4, 5 or 8 to select the TIM peripheral.
+  * @param  TIM_OCPreload: new state of the TIMx peripheral Preload register
+  *          This parameter can be one of the following values:
+  *            @arg TIM_OCPreload_Enable
+  *            @arg TIM_OCPreload_Disable
+  * @retval None
+  */
+void TIM_OC3PreloadConfig(TIM_TypeDef* TIMx, uint16_t TIM_OCPreload)
+{
+  uint16_t tmpccmr2 = 0;
+
+  /* Check the parameters */
+  assert_param(IS_TIM_LIST3_PERIPH(TIMx));
+  assert_param(IS_TIM_OCPRELOAD_STATE(TIM_OCPreload));
+
+  tmpccmr2 = TIMx->CCMR2;
+
+  /* Reset the OC3PE Bit */
+  tmpccmr2 &= (uint16_t)(~TIM_CCMR2_OC3PE);
+
+  /* Enable or Disable the Output Compare Preload feature */
+  tmpccmr2 |= TIM_OCPreload;
+
+  /* Write to TIMx CCMR2 register */
+  TIMx->CCMR2 = tmpccmr2;
+}
+
+/**
+  * @brief  Enables or disables the TIMx peripheral Preload register on CCR4.
+  * @param  TIMx: where x can be  1, 2, 3, 4, 5 or 8 to select the TIM peripheral.
+  * @param  TIM_OCPreload: new state of the TIMx peripheral Preload register
+  *          This parameter can be one of the following values:
+  *            @arg TIM_OCPreload_Enable
+  *            @arg TIM_OCPreload_Disable
+  * @retval None
+  */
+void TIM_OC4PreloadConfig(TIM_TypeDef* TIMx, uint16_t TIM_OCPreload)
+{
+  uint16_t tmpccmr2 = 0;
+
+  /* Check the parameters */
+  assert_param(IS_TIM_LIST3_PERIPH(TIMx));
+  assert_param(IS_TIM_OCPRELOAD_STATE(TIM_OCPreload));
+
+  tmpccmr2 = TIMx->CCMR2;
+
+  /* Reset the OC4PE Bit */
+  tmpccmr2 &= (uint16_t)(~TIM_CCMR2_OC4PE);
+
+  /* Enable or Disable the Output Compare Preload feature */
+  tmpccmr2 |= (uint16_t)(TIM_OCPreload << 8);
+
+  /* Write to TIMx CCMR2 register */
+  TIMx->CCMR2 = tmpccmr2;
+}
+
+/**
+  * @brief  Configures the TIMx Output Compare 1 Fast feature.
+  * @param  TIMx: where x can be 1 to 14 except 6 and 7, to select the TIM peripheral.
+  * @param  TIM_OCFast: new state of the Output Compare Fast Enable Bit.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_OCFast_Enable: TIM output compare fast enable
+  *            @arg TIM_OCFast_Disable: TIM output compare fast disable
+  * @retval None
+  */
+void TIM_OC1FastConfig(TIM_TypeDef* TIMx, uint16_t TIM_OCFast)
+{
+  uint16_t tmpccmr1 = 0;
+
+  /* Check the parameters */
+  assert_param(IS_TIM_LIST1_PERIPH(TIMx));
+  assert_param(IS_TIM_OCFAST_STATE(TIM_OCFast));
+
+  /* Get the TIMx CCMR1 register value */
+  tmpccmr1 = TIMx->CCMR1;
+
+  /* Reset the OC1FE Bit */
+  tmpccmr1 &= (uint16_t)~TIM_CCMR1_OC1FE;
+
+  /* Enable or Disable the Output Compare Fast Bit */
+  tmpccmr1 |= TIM_OCFast;
+
+  /* Write to TIMx CCMR1 */
+  TIMx->CCMR1 = tmpccmr1;
+}
+
+/**
+  * @brief  Configures the TIMx Output Compare 2 Fast feature.
+  * @param  TIMx: where x can be  1, 2, 3, 4, 5, 8, 9 or 12 to select the TIM 
+  *         peripheral.
+  * @param  TIM_OCFast: new state of the Output Compare Fast Enable Bit.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_OCFast_Enable: TIM output compare fast enable
+  *            @arg TIM_OCFast_Disable: TIM output compare fast disable
+  * @retval None
+  */
+void TIM_OC2FastConfig(TIM_TypeDef* TIMx, uint16_t TIM_OCFast)
+{
+  uint16_t tmpccmr1 = 0;
+
+  /* Check the parameters */
+  assert_param(IS_TIM_LIST2_PERIPH(TIMx));
+  assert_param(IS_TIM_OCFAST_STATE(TIM_OCFast));
+
+  /* Get the TIMx CCMR1 register value */
+  tmpccmr1 = TIMx->CCMR1;
+
+  /* Reset the OC2FE Bit */
+  tmpccmr1 &= (uint16_t)(~TIM_CCMR1_OC2FE);
+
+  /* Enable or Disable the Output Compare Fast Bit */
+  tmpccmr1 |= (uint16_t)(TIM_OCFast << 8);
+
+  /* Write to TIMx CCMR1 */
+  TIMx->CCMR1 = tmpccmr1;
+}
+
+/**
+  * @brief  Configures the TIMx Output Compare 3 Fast feature.
+  * @param  TIMx: where x can be  1, 2, 3, 4, 5 or 8 to select the TIM peripheral.
+  * @param  TIM_OCFast: new state of the Output Compare Fast Enable Bit.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_OCFast_Enable: TIM output compare fast enable
+  *            @arg TIM_OCFast_Disable: TIM output compare fast disable
+  * @retval None
+  */
+void TIM_OC3FastConfig(TIM_TypeDef* TIMx, uint16_t TIM_OCFast)
+{
+  uint16_t tmpccmr2 = 0;
+  
+  /* Check the parameters */
+  assert_param(IS_TIM_LIST3_PERIPH(TIMx));
+  assert_param(IS_TIM_OCFAST_STATE(TIM_OCFast));
+
+  /* Get the TIMx CCMR2 register value */
+  tmpccmr2 = TIMx->CCMR2;
+
+  /* Reset the OC3FE Bit */
+  tmpccmr2 &= (uint16_t)~TIM_CCMR2_OC3FE;
+
+  /* Enable or Disable the Output Compare Fast Bit */
+  tmpccmr2 |= TIM_OCFast;
+
+  /* Write to TIMx CCMR2 */
+  TIMx->CCMR2 = tmpccmr2;
+}
+
+/**
+  * @brief  Configures the TIMx Output Compare 4 Fast feature.
+  * @param  TIMx: where x can be  1, 2, 3, 4, 5 or 8 to select the TIM peripheral.
+  * @param  TIM_OCFast: new state of the Output Compare Fast Enable Bit.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_OCFast_Enable: TIM output compare fast enable
+  *            @arg TIM_OCFast_Disable: TIM output compare fast disable
+  * @retval None
+  */
+void TIM_OC4FastConfig(TIM_TypeDef* TIMx, uint16_t TIM_OCFast)
+{
+  uint16_t tmpccmr2 = 0;
+
+  /* Check the parameters */
+  assert_param(IS_TIM_LIST3_PERIPH(TIMx));
+  assert_param(IS_TIM_OCFAST_STATE(TIM_OCFast));
+
+  /* Get the TIMx CCMR2 register value */
+  tmpccmr2 = TIMx->CCMR2;
+
+  /* Reset the OC4FE Bit */
+  tmpccmr2 &= (uint16_t)(~TIM_CCMR2_OC4FE);
+
+  /* Enable or Disable the Output Compare Fast Bit */
+  tmpccmr2 |= (uint16_t)(TIM_OCFast << 8);
+
+  /* Write to TIMx CCMR2 */
+  TIMx->CCMR2 = tmpccmr2;
+}
+
+/**
+  * @brief  Clears or safeguards the OCREF1 signal on an external event
+  * @param  TIMx: where x can be 1 to 14 except 6 and 7, to select the TIM peripheral.
+  * @param  TIM_OCClear: new state of the Output Compare Clear Enable Bit.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_OCClear_Enable: TIM Output clear enable
+  *            @arg TIM_OCClear_Disable: TIM Output clear disable
+  * @retval None
+  */
+void TIM_ClearOC1Ref(TIM_TypeDef* TIMx, uint16_t TIM_OCClear)
+{
+  uint16_t tmpccmr1 = 0;
+
+  /* Check the parameters */
+  assert_param(IS_TIM_LIST1_PERIPH(TIMx));
+  assert_param(IS_TIM_OCCLEAR_STATE(TIM_OCClear));
+
+  tmpccmr1 = TIMx->CCMR1;
+
+  /* Reset the OC1CE Bit */
+  tmpccmr1 &= (uint16_t)~TIM_CCMR1_OC1CE;
+
+  /* Enable or Disable the Output Compare Clear Bit */
+  tmpccmr1 |= TIM_OCClear;
+
+  /* Write to TIMx CCMR1 register */
+  TIMx->CCMR1 = tmpccmr1;
+}
+
+/**
+  * @brief  Clears or safeguards the OCREF2 signal on an external event
+  * @param  TIMx: where x can be  1, 2, 3, 4, 5, 8, 9 or 12 to select the TIM 
+  *         peripheral.
+  * @param  TIM_OCClear: new state of the Output Compare Clear Enable Bit.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_OCClear_Enable: TIM Output clear enable
+  *            @arg TIM_OCClear_Disable: TIM Output clear disable
+  * @retval None
+  */
+void TIM_ClearOC2Ref(TIM_TypeDef* TIMx, uint16_t TIM_OCClear)
+{
+  uint16_t tmpccmr1 = 0;
+
+  /* Check the parameters */
+  assert_param(IS_TIM_LIST2_PERIPH(TIMx));
+  assert_param(IS_TIM_OCCLEAR_STATE(TIM_OCClear));
+
+  tmpccmr1 = TIMx->CCMR1;
+
+  /* Reset the OC2CE Bit */
+  tmpccmr1 &= (uint16_t)~TIM_CCMR1_OC2CE;
+
+  /* Enable or Disable the Output Compare Clear Bit */
+  tmpccmr1 |= (uint16_t)(TIM_OCClear << 8);
+
+  /* Write to TIMx CCMR1 register */
+  TIMx->CCMR1 = tmpccmr1;
+}
+
+/**
+  * @brief  Clears or safeguards the OCREF3 signal on an external event
+  * @param  TIMx: where x can be  1, 2, 3, 4, 5 or 8 to select the TIM peripheral.
+  * @param  TIM_OCClear: new state of the Output Compare Clear Enable Bit.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_OCClear_Enable: TIM Output clear enable
+  *            @arg TIM_OCClear_Disable: TIM Output clear disable
+  * @retval None
+  */
+void TIM_ClearOC3Ref(TIM_TypeDef* TIMx, uint16_t TIM_OCClear)
+{
+  uint16_t tmpccmr2 = 0;
+
+  /* Check the parameters */
+  assert_param(IS_TIM_LIST3_PERIPH(TIMx));
+  assert_param(IS_TIM_OCCLEAR_STATE(TIM_OCClear));
+
+  tmpccmr2 = TIMx->CCMR2;
+
+  /* Reset the OC3CE Bit */
+  tmpccmr2 &= (uint16_t)~TIM_CCMR2_OC3CE;
+
+  /* Enable or Disable the Output Compare Clear Bit */
+  tmpccmr2 |= TIM_OCClear;
+
+  /* Write to TIMx CCMR2 register */
+  TIMx->CCMR2 = tmpccmr2;
+}
+
+/**
+  * @brief  Clears or safeguards the OCREF4 signal on an external event
+  * @param  TIMx: where x can be  1, 2, 3, 4, 5 or 8 to select the TIM peripheral.
+  * @param  TIM_OCClear: new state of the Output Compare Clear Enable Bit.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_OCClear_Enable: TIM Output clear enable
+  *            @arg TIM_OCClear_Disable: TIM Output clear disable
+  * @retval None
+  */
+void TIM_ClearOC4Ref(TIM_TypeDef* TIMx, uint16_t TIM_OCClear)
+{
+  uint16_t tmpccmr2 = 0;
+
+  /* Check the parameters */
+  assert_param(IS_TIM_LIST3_PERIPH(TIMx));
+  assert_param(IS_TIM_OCCLEAR_STATE(TIM_OCClear));
+
+  tmpccmr2 = TIMx->CCMR2;
+
+  /* Reset the OC4CE Bit */
+  tmpccmr2 &= (uint16_t)~TIM_CCMR2_OC4CE;
+
+  /* Enable or Disable the Output Compare Clear Bit */
+  tmpccmr2 |= (uint16_t)(TIM_OCClear << 8);
+
+  /* Write to TIMx CCMR2 register */
+  TIMx->CCMR2 = tmpccmr2;
+}
+
+/**
+  * @brief  Configures the TIMx channel 1 polarity.
+  * @param  TIMx: where x can be 1 to 14 except 6 and 7, to select the TIM peripheral.
+  * @param  TIM_OCPolarity: specifies the OC1 Polarity
+  *          This parameter can be one of the following values:
+  *            @arg TIM_OCPolarity_High: Output Compare active high
+  *            @arg TIM_OCPolarity_Low: Output Compare active low
+  * @retval None
+  */
+void TIM_OC1PolarityConfig(TIM_TypeDef* TIMx, uint16_t TIM_OCPolarity)
+{
+  uint16_t tmpccer = 0;
+
+  /* Check the parameters */
+  assert_param(IS_TIM_LIST1_PERIPH(TIMx));
+  assert_param(IS_TIM_OC_POLARITY(TIM_OCPolarity));
+
+  tmpccer = TIMx->CCER;
+
+  /* Set or Reset the CC1P Bit */
+  tmpccer &= (uint16_t)(~TIM_CCER_CC1P);
+  tmpccer |= TIM_OCPolarity;
+
+  /* Write to TIMx CCER register */
+  TIMx->CCER = tmpccer;
+}
+
+/**
+  * @brief  Configures the TIMx Channel 1N polarity.
+  * @param  TIMx: where x can be 1 or 8 to select the TIM peripheral.
+  * @param  TIM_OCNPolarity: specifies the OC1N Polarity
+  *          This parameter can be one of the following values:
+  *            @arg TIM_OCNPolarity_High: Output Compare active high
+  *            @arg TIM_OCNPolarity_Low: Output Compare active low
+  * @retval None
+  */
+void TIM_OC1NPolarityConfig(TIM_TypeDef* TIMx, uint16_t TIM_OCNPolarity)
+{
+  uint16_t tmpccer = 0;
+  /* Check the parameters */
+  assert_param(IS_TIM_LIST4_PERIPH(TIMx));
+  assert_param(IS_TIM_OCN_POLARITY(TIM_OCNPolarity));
+   
+  tmpccer = TIMx->CCER;
+
+  /* Set or Reset the CC1NP Bit */
+  tmpccer &= (uint16_t)~TIM_CCER_CC1NP;
+  tmpccer |= TIM_OCNPolarity;
+
+  /* Write to TIMx CCER register */
+  TIMx->CCER = tmpccer;
+}
+
+/**
+  * @brief  Configures the TIMx channel 2 polarity.
+  * @param  TIMx: where x can be 1, 2, 3, 4, 5, 8, 9 or 12 to select the TIM 
+  *         peripheral.
+  * @param  TIM_OCPolarity: specifies the OC2 Polarity
+  *          This parameter can be one of the following values:
+  *            @arg TIM_OCPolarity_High: Output Compare active high
+  *            @arg TIM_OCPolarity_Low: Output Compare active low
+  * @retval None
+  */
+void TIM_OC2PolarityConfig(TIM_TypeDef* TIMx, uint16_t TIM_OCPolarity)
+{
+  uint16_t tmpccer = 0;
+
+  /* Check the parameters */
+  assert_param(IS_TIM_LIST2_PERIPH(TIMx));
+  assert_param(IS_TIM_OC_POLARITY(TIM_OCPolarity));
+
+  tmpccer = TIMx->CCER;
+
+  /* Set or Reset the CC2P Bit */
+  tmpccer &= (uint16_t)(~TIM_CCER_CC2P);
+  tmpccer |= (uint16_t)(TIM_OCPolarity << 4);
+
+  /* Write to TIMx CCER register */
+  TIMx->CCER = tmpccer;
+}
+
+/**
+  * @brief  Configures the TIMx Channel 2N polarity.
+  * @param  TIMx: where x can be 1 or 8 to select the TIM peripheral.
+  * @param  TIM_OCNPolarity: specifies the OC2N Polarity
+  *          This parameter can be one of the following values:
+  *            @arg TIM_OCNPolarity_High: Output Compare active high
+  *            @arg TIM_OCNPolarity_Low: Output Compare active low
+  * @retval None
+  */
+void TIM_OC2NPolarityConfig(TIM_TypeDef* TIMx, uint16_t TIM_OCNPolarity)
+{
+  uint16_t tmpccer = 0;
+
+  /* Check the parameters */
+  assert_param(IS_TIM_LIST4_PERIPH(TIMx));
+  assert_param(IS_TIM_OCN_POLARITY(TIM_OCNPolarity));
+  
+  tmpccer = TIMx->CCER;
+
+  /* Set or Reset the CC2NP Bit */
+  tmpccer &= (uint16_t)~TIM_CCER_CC2NP;
+  tmpccer |= (uint16_t)(TIM_OCNPolarity << 4);
+
+  /* Write to TIMx CCER register */
+  TIMx->CCER = tmpccer;
+}
+
+/**
+  * @brief  Configures the TIMx channel 3 polarity.
+  * @param  TIMx: where x can be 1, 2, 3, 4, 5 or 8 to select the TIM peripheral.
+  * @param  TIM_OCPolarity: specifies the OC3 Polarity
+  *          This parameter can be one of the following values:
+  *            @arg TIM_OCPolarity_High: Output Compare active high
+  *            @arg TIM_OCPolarity_Low: Output Compare active low
+  * @retval None
+  */
+void TIM_OC3PolarityConfig(TIM_TypeDef* TIMx, uint16_t TIM_OCPolarity)
+{
+  uint16_t tmpccer = 0;
+
+  /* Check the parameters */
+  assert_param(IS_TIM_LIST3_PERIPH(TIMx));
+  assert_param(IS_TIM_OC_POLARITY(TIM_OCPolarity));
+
+  tmpccer = TIMx->CCER;
+
+  /* Set or Reset the CC3P Bit */
+  tmpccer &= (uint16_t)~TIM_CCER_CC3P;
+  tmpccer |= (uint16_t)(TIM_OCPolarity << 8);
+
+  /* Write to TIMx CCER register */
+  TIMx->CCER = tmpccer;
+}
+
+/**
+  * @brief  Configures the TIMx Channel 3N polarity.
+  * @param  TIMx: where x can be 1 or 8 to select the TIM peripheral.
+  * @param  TIM_OCNPolarity: specifies the OC3N Polarity
+  *          This parameter can be one of the following values:
+  *            @arg TIM_OCNPolarity_High: Output Compare active high
+  *            @arg TIM_OCNPolarity_Low: Output Compare active low
+  * @retval None
+  */
+void TIM_OC3NPolarityConfig(TIM_TypeDef* TIMx, uint16_t TIM_OCNPolarity)
+{
+  uint16_t tmpccer = 0;
+ 
+  /* Check the parameters */
+  assert_param(IS_TIM_LIST4_PERIPH(TIMx));
+  assert_param(IS_TIM_OCN_POLARITY(TIM_OCNPolarity));
+    
+  tmpccer = TIMx->CCER;
+
+  /* Set or Reset the CC3NP Bit */
+  tmpccer &= (uint16_t)~TIM_CCER_CC3NP;
+  tmpccer |= (uint16_t)(TIM_OCNPolarity << 8);
+
+  /* Write to TIMx CCER register */
+  TIMx->CCER = tmpccer;
+}
+
+/**
+  * @brief  Configures the TIMx channel 4 polarity.
+  * @param  TIMx: where x can be 1, 2, 3, 4, 5 or 8 to select the TIM peripheral.
+  * @param  TIM_OCPolarity: specifies the OC4 Polarity
+  *          This parameter can be one of the following values:
+  *            @arg TIM_OCPolarity_High: Output Compare active high
+  *            @arg TIM_OCPolarity_Low: Output Compare active low
+  * @retval None
+  */
+void TIM_OC4PolarityConfig(TIM_TypeDef* TIMx, uint16_t TIM_OCPolarity)
+{
+  uint16_t tmpccer = 0;
+
+  /* Check the parameters */
+  assert_param(IS_TIM_LIST3_PERIPH(TIMx));
+  assert_param(IS_TIM_OC_POLARITY(TIM_OCPolarity));
+
+  tmpccer = TIMx->CCER;
+
+  /* Set or Reset the CC4P Bit */
+  tmpccer &= (uint16_t)~TIM_CCER_CC4P;
+  tmpccer |= (uint16_t)(TIM_OCPolarity << 12);
+
+  /* Write to TIMx CCER register */
+  TIMx->CCER = tmpccer;
+}
+
+/**
+  * @brief  Enables or disables the TIM Capture Compare Channel x.
+  * @param  TIMx: where x can be 1 to 14 except 6 and 7, to select the TIM peripheral.
+  * @param  TIM_Channel: specifies the TIM Channel
+  *          This parameter can be one of the following values:
+  *            @arg TIM_Channel_1: TIM Channel 1
+  *            @arg TIM_Channel_2: TIM Channel 2
+  *            @arg TIM_Channel_3: TIM Channel 3
+  *            @arg TIM_Channel_4: TIM Channel 4
+  * @param  TIM_CCx: specifies the TIM Channel CCxE bit new state.
+  *          This parameter can be: TIM_CCx_Enable or TIM_CCx_Disable. 
+  * @retval None
+  */
+void TIM_CCxCmd(TIM_TypeDef* TIMx, uint16_t TIM_Channel, uint16_t TIM_CCx)
+{
+  uint16_t tmp = 0;
+
+  /* Check the parameters */
+  assert_param(IS_TIM_LIST1_PERIPH(TIMx)); 
+  assert_param(IS_TIM_CHANNEL(TIM_Channel));
+  assert_param(IS_TIM_CCX(TIM_CCx));
+
+  tmp = CCER_CCE_SET << TIM_Channel;
+
+  /* Reset the CCxE Bit */
+  TIMx->CCER &= (uint16_t)~ tmp;
+
+  /* Set or reset the CCxE Bit */ 
+  TIMx->CCER |=  (uint16_t)(TIM_CCx << TIM_Channel);
+}
+
+/**
+  * @brief  Enables or disables the TIM Capture Compare Channel xN.
+  * @param  TIMx: where x can be 1 or 8 to select the TIM peripheral.
+  * @param  TIM_Channel: specifies the TIM Channel
+  *          This parameter can be one of the following values:
+  *            @arg TIM_Channel_1: TIM Channel 1
+  *            @arg TIM_Channel_2: TIM Channel 2
+  *            @arg TIM_Channel_3: TIM Channel 3
+  * @param  TIM_CCxN: specifies the TIM Channel CCxNE bit new state.
+  *          This parameter can be: TIM_CCxN_Enable or TIM_CCxN_Disable. 
+  * @retval None
+  */
+void TIM_CCxNCmd(TIM_TypeDef* TIMx, uint16_t TIM_Channel, uint16_t TIM_CCxN)
+{
+  uint16_t tmp = 0;
+
+  /* Check the parameters */
+  assert_param(IS_TIM_LIST4_PERIPH(TIMx));
+  assert_param(IS_TIM_COMPLEMENTARY_CHANNEL(TIM_Channel));
+  assert_param(IS_TIM_CCXN(TIM_CCxN));
+
+  tmp = CCER_CCNE_SET << TIM_Channel;
+
+  /* Reset the CCxNE Bit */
+  TIMx->CCER &= (uint16_t) ~tmp;
+
+  /* Set or reset the CCxNE Bit */ 
+  TIMx->CCER |=  (uint16_t)(TIM_CCxN << TIM_Channel);
+}
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Group3 Input Capture management functions
+ *  @brief    Input Capture management functions 
+ *
+@verbatim   
+ ===============================================================================
+                      Input Capture management functions
+ ===============================================================================  
+   
+       ===================================================================      
+              TIM Driver: how to use it in Input Capture Mode
+       =================================================================== 
+       To use the Timer in Input Capture mode, the following steps are mandatory:
+       
+       1. Enable TIM clock using RCC_APBxPeriphClockCmd(RCC_APBxPeriph_TIMx, ENABLE) function
+       
+       2. Configure the TIM pins by configuring the corresponding GPIO pins
+       
+       2. Configure the Time base unit as described in the first part of this driver,
+          if needed, else the Timer will run with the default configuration:
+          - Autoreload value = 0xFFFF
+          - Prescaler value = 0x0000
+          - Counter mode = Up counting
+          - Clock Division = TIM_CKD_DIV1
+          
+       3. Fill the TIM_ICInitStruct with the desired parameters including:
+          - TIM Channel: TIM_Channel
+          - TIM Input Capture polarity: TIM_ICPolarity
+          - TIM Input Capture selection: TIM_ICSelection
+          - TIM Input Capture Prescaler: TIM_ICPrescaler
+          - TIM Input CApture filter value: TIM_ICFilter
+       
+       4. Call TIM_ICInit(TIMx, &TIM_ICInitStruct) to configure the desired channel with the 
+          corresponding configuration and to measure only frequency or duty cycle of the input signal,
+          or,
+          Call TIM_PWMIConfig(TIMx, &TIM_ICInitStruct) to configure the desired channels with the 
+          corresponding configuration and to measure the frequency and the duty cycle of the input signal
+          
+       5. Enable the NVIC or the DMA to read the measured frequency. 
+          
+       6. Enable the corresponding interrupt (or DMA request) to read the Captured value,
+          using the function TIM_ITConfig(TIMx, TIM_IT_CCx) (or TIM_DMA_Cmd(TIMx, TIM_DMA_CCx)) 
+       
+       7. Call the TIM_Cmd(ENABLE) function to enable the TIM counter.
+       
+       8. Use TIM_GetCapturex(TIMx); to read the captured value.
+       
+       Note1: All other functions can be used separately to modify, if needed,
+              a specific feature of the Timer. 
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Initializes the TIM peripheral according to the specified parameters
+  *         in the TIM_ICInitStruct.
+  * @param  TIMx: where x can be 1 to 14 except 6 and 7, to select the TIM peripheral.
+  * @param  TIM_ICInitStruct: pointer to a TIM_ICInitTypeDef structure that contains
+  *         the configuration information for the specified TIM peripheral.
+  * @retval None
+  */
+void TIM_ICInit(TIM_TypeDef* TIMx, TIM_ICInitTypeDef* TIM_ICInitStruct)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_LIST1_PERIPH(TIMx));
+  assert_param(IS_TIM_IC_POLARITY(TIM_ICInitStruct->TIM_ICPolarity));
+  assert_param(IS_TIM_IC_SELECTION(TIM_ICInitStruct->TIM_ICSelection));
+  assert_param(IS_TIM_IC_PRESCALER(TIM_ICInitStruct->TIM_ICPrescaler));
+  assert_param(IS_TIM_IC_FILTER(TIM_ICInitStruct->TIM_ICFilter));
+  
+  if (TIM_ICInitStruct->TIM_Channel == TIM_Channel_1)
+  {
+    /* TI1 Configuration */
+    TI1_Config(TIMx, TIM_ICInitStruct->TIM_ICPolarity,
+               TIM_ICInitStruct->TIM_ICSelection,
+               TIM_ICInitStruct->TIM_ICFilter);
+    /* Set the Input Capture Prescaler value */
+    TIM_SetIC1Prescaler(TIMx, TIM_ICInitStruct->TIM_ICPrescaler);
+  }
+  else if (TIM_ICInitStruct->TIM_Channel == TIM_Channel_2)
+  {
+    /* TI2 Configuration */
+    assert_param(IS_TIM_LIST2_PERIPH(TIMx));
+    TI2_Config(TIMx, TIM_ICInitStruct->TIM_ICPolarity,
+               TIM_ICInitStruct->TIM_ICSelection,
+               TIM_ICInitStruct->TIM_ICFilter);
+    /* Set the Input Capture Prescaler value */
+    TIM_SetIC2Prescaler(TIMx, TIM_ICInitStruct->TIM_ICPrescaler);
+  }
+  else if (TIM_ICInitStruct->TIM_Channel == TIM_Channel_3)
+  {
+    /* TI3 Configuration */
+    assert_param(IS_TIM_LIST3_PERIPH(TIMx));
+    TI3_Config(TIMx,  TIM_ICInitStruct->TIM_ICPolarity,
+               TIM_ICInitStruct->TIM_ICSelection,
+               TIM_ICInitStruct->TIM_ICFilter);
+    /* Set the Input Capture Prescaler value */
+    TIM_SetIC3Prescaler(TIMx, TIM_ICInitStruct->TIM_ICPrescaler);
+  }
+  else
+  {
+    /* TI4 Configuration */
+    assert_param(IS_TIM_LIST3_PERIPH(TIMx));
+    TI4_Config(TIMx, TIM_ICInitStruct->TIM_ICPolarity,
+               TIM_ICInitStruct->TIM_ICSelection,
+               TIM_ICInitStruct->TIM_ICFilter);
+    /* Set the Input Capture Prescaler value */
+    TIM_SetIC4Prescaler(TIMx, TIM_ICInitStruct->TIM_ICPrescaler);
+  }
+}
+
+/**
+  * @brief  Fills each TIM_ICInitStruct member with its default value.
+  * @param  TIM_ICInitStruct: pointer to a TIM_ICInitTypeDef structure which will
+  *         be initialized.
+  * @retval None
+  */
+void TIM_ICStructInit(TIM_ICInitTypeDef* TIM_ICInitStruct)
+{
+  /* Set the default configuration */
+  TIM_ICInitStruct->TIM_Channel = TIM_Channel_1;
+  TIM_ICInitStruct->TIM_ICPolarity = TIM_ICPolarity_Rising;
+  TIM_ICInitStruct->TIM_ICSelection = TIM_ICSelection_DirectTI;
+  TIM_ICInitStruct->TIM_ICPrescaler = TIM_ICPSC_DIV1;
+  TIM_ICInitStruct->TIM_ICFilter = 0x00;
+}
+
+/**
+  * @brief  Configures the TIM peripheral according to the specified parameters
+  *         in the TIM_ICInitStruct to measure an external PWM signal.
+  * @param  TIMx: where x can be  1, 2, 3, 4, 5,8, 9 or 12 to select the TIM 
+  *         peripheral.
+  * @param  TIM_ICInitStruct: pointer to a TIM_ICInitTypeDef structure that contains
+  *         the configuration information for the specified TIM peripheral.
+  * @retval None
+  */
+void TIM_PWMIConfig(TIM_TypeDef* TIMx, TIM_ICInitTypeDef* TIM_ICInitStruct)
+{
+  uint16_t icoppositepolarity = TIM_ICPolarity_Rising;
+  uint16_t icoppositeselection = TIM_ICSelection_DirectTI;
+
+  /* Check the parameters */
+  assert_param(IS_TIM_LIST2_PERIPH(TIMx));
+
+  /* Select the Opposite Input Polarity */
+  if (TIM_ICInitStruct->TIM_ICPolarity == TIM_ICPolarity_Rising)
+  {
+    icoppositepolarity = TIM_ICPolarity_Falling;
+  }
+  else
+  {
+    icoppositepolarity = TIM_ICPolarity_Rising;
+  }
+  /* Select the Opposite Input */
+  if (TIM_ICInitStruct->TIM_ICSelection == TIM_ICSelection_DirectTI)
+  {
+    icoppositeselection = TIM_ICSelection_IndirectTI;
+  }
+  else
+  {
+    icoppositeselection = TIM_ICSelection_DirectTI;
+  }
+  if (TIM_ICInitStruct->TIM_Channel == TIM_Channel_1)
+  {
+    /* TI1 Configuration */
+    TI1_Config(TIMx, TIM_ICInitStruct->TIM_ICPolarity, TIM_ICInitStruct->TIM_ICSelection,
+               TIM_ICInitStruct->TIM_ICFilter);
+    /* Set the Input Capture Prescaler value */
+    TIM_SetIC1Prescaler(TIMx, TIM_ICInitStruct->TIM_ICPrescaler);
+    /* TI2 Configuration */
+    TI2_Config(TIMx, icoppositepolarity, icoppositeselection, TIM_ICInitStruct->TIM_ICFilter);
+    /* Set the Input Capture Prescaler value */
+    TIM_SetIC2Prescaler(TIMx, TIM_ICInitStruct->TIM_ICPrescaler);
+  }
+  else
+  { 
+    /* TI2 Configuration */
+    TI2_Config(TIMx, TIM_ICInitStruct->TIM_ICPolarity, TIM_ICInitStruct->TIM_ICSelection,
+               TIM_ICInitStruct->TIM_ICFilter);
+    /* Set the Input Capture Prescaler value */
+    TIM_SetIC2Prescaler(TIMx, TIM_ICInitStruct->TIM_ICPrescaler);
+    /* TI1 Configuration */
+    TI1_Config(TIMx, icoppositepolarity, icoppositeselection, TIM_ICInitStruct->TIM_ICFilter);
+    /* Set the Input Capture Prescaler value */
+    TIM_SetIC1Prescaler(TIMx, TIM_ICInitStruct->TIM_ICPrescaler);
+  }
+}
+
+/**
+  * @brief  Gets the TIMx Input Capture 1 value.
+  * @param  TIMx: where x can be 1 to 14 except 6 and 7, to select the TIM peripheral.
+  * @retval Capture Compare 1 Register value.
+  */
+uint32_t TIM_GetCapture1(TIM_TypeDef* TIMx)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_LIST1_PERIPH(TIMx));
+
+  /* Get the Capture 1 Register value */
+  return TIMx->CCR1;
+}
+
+/**
+  * @brief  Gets the TIMx Input Capture 2 value.
+  * @param  TIMx: where x can be 1, 2, 3, 4, 5, 8, 9 or 12 to select the TIM 
+  *         peripheral.
+  * @retval Capture Compare 2 Register value.
+  */
+uint32_t TIM_GetCapture2(TIM_TypeDef* TIMx)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_LIST2_PERIPH(TIMx));
+
+  /* Get the Capture 2 Register value */
+  return TIMx->CCR2;
+}
+
+/**
+  * @brief  Gets the TIMx Input Capture 3 value.
+  * @param  TIMx: where x can be 1, 2, 3, 4, 5 or 8 to select the TIM peripheral.
+  * @retval Capture Compare 3 Register value.
+  */
+uint32_t TIM_GetCapture3(TIM_TypeDef* TIMx)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_LIST3_PERIPH(TIMx)); 
+
+  /* Get the Capture 3 Register value */
+  return TIMx->CCR3;
+}
+
+/**
+  * @brief  Gets the TIMx Input Capture 4 value.
+  * @param  TIMx: where x can be 1, 2, 3, 4, 5 or 8 to select the TIM peripheral.
+  * @retval Capture Compare 4 Register value.
+  */
+uint32_t TIM_GetCapture4(TIM_TypeDef* TIMx)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_LIST3_PERIPH(TIMx));
+
+  /* Get the Capture 4 Register value */
+  return TIMx->CCR4;
+}
+
+/**
+  * @brief  Sets the TIMx Input Capture 1 prescaler.
+  * @param  TIMx: where x can be 1 to 14 except 6 and 7, to select the TIM peripheral.
+  * @param  TIM_ICPSC: specifies the Input Capture1 prescaler new value.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_ICPSC_DIV1: no prescaler
+  *            @arg TIM_ICPSC_DIV2: capture is done once every 2 events
+  *            @arg TIM_ICPSC_DIV4: capture is done once every 4 events
+  *            @arg TIM_ICPSC_DIV8: capture is done once every 8 events
+  * @retval None
+  */
+void TIM_SetIC1Prescaler(TIM_TypeDef* TIMx, uint16_t TIM_ICPSC)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_LIST1_PERIPH(TIMx));
+  assert_param(IS_TIM_IC_PRESCALER(TIM_ICPSC));
+
+  /* Reset the IC1PSC Bits */
+  TIMx->CCMR1 &= (uint16_t)~TIM_CCMR1_IC1PSC;
+
+  /* Set the IC1PSC value */
+  TIMx->CCMR1 |= TIM_ICPSC;
+}
+
+/**
+  * @brief  Sets the TIMx Input Capture 2 prescaler.
+  * @param  TIMx: where x can be 1, 2, 3, 4, 5, 8, 9 or 12 to select the TIM 
+  *         peripheral.
+  * @param  TIM_ICPSC: specifies the Input Capture2 prescaler new value.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_ICPSC_DIV1: no prescaler
+  *            @arg TIM_ICPSC_DIV2: capture is done once every 2 events
+  *            @arg TIM_ICPSC_DIV4: capture is done once every 4 events
+  *            @arg TIM_ICPSC_DIV8: capture is done once every 8 events
+  * @retval None
+  */
+void TIM_SetIC2Prescaler(TIM_TypeDef* TIMx, uint16_t TIM_ICPSC)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_LIST2_PERIPH(TIMx));
+  assert_param(IS_TIM_IC_PRESCALER(TIM_ICPSC));
+
+  /* Reset the IC2PSC Bits */
+  TIMx->CCMR1 &= (uint16_t)~TIM_CCMR1_IC2PSC;
+
+  /* Set the IC2PSC value */
+  TIMx->CCMR1 |= (uint16_t)(TIM_ICPSC << 8);
+}
+
+/**
+  * @brief  Sets the TIMx Input Capture 3 prescaler.
+  * @param  TIMx: where x can be 1, 2, 3, 4, 5 or 8 to select the TIM peripheral.
+  * @param  TIM_ICPSC: specifies the Input Capture3 prescaler new value.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_ICPSC_DIV1: no prescaler
+  *            @arg TIM_ICPSC_DIV2: capture is done once every 2 events
+  *            @arg TIM_ICPSC_DIV4: capture is done once every 4 events
+  *            @arg TIM_ICPSC_DIV8: capture is done once every 8 events
+  * @retval None
+  */
+void TIM_SetIC3Prescaler(TIM_TypeDef* TIMx, uint16_t TIM_ICPSC)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_LIST3_PERIPH(TIMx));
+  assert_param(IS_TIM_IC_PRESCALER(TIM_ICPSC));
+
+  /* Reset the IC3PSC Bits */
+  TIMx->CCMR2 &= (uint16_t)~TIM_CCMR2_IC3PSC;
+
+  /* Set the IC3PSC value */
+  TIMx->CCMR2 |= TIM_ICPSC;
+}
+
+/**
+  * @brief  Sets the TIMx Input Capture 4 prescaler.
+  * @param  TIMx: where x can be 1, 2, 3, 4, 5 or 8 to select the TIM peripheral.
+  * @param  TIM_ICPSC: specifies the Input Capture4 prescaler new value.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_ICPSC_DIV1: no prescaler
+  *            @arg TIM_ICPSC_DIV2: capture is done once every 2 events
+  *            @arg TIM_ICPSC_DIV4: capture is done once every 4 events
+  *            @arg TIM_ICPSC_DIV8: capture is done once every 8 events
+  * @retval None
+  */
+void TIM_SetIC4Prescaler(TIM_TypeDef* TIMx, uint16_t TIM_ICPSC)
+{  
+  /* Check the parameters */
+  assert_param(IS_TIM_LIST3_PERIPH(TIMx));
+  assert_param(IS_TIM_IC_PRESCALER(TIM_ICPSC));
+
+  /* Reset the IC4PSC Bits */
+  TIMx->CCMR2 &= (uint16_t)~TIM_CCMR2_IC4PSC;
+
+  /* Set the IC4PSC value */
+  TIMx->CCMR2 |= (uint16_t)(TIM_ICPSC << 8);
+}
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Group4 Advanced-control timers (TIM1 and TIM8) specific features
+ *  @brief   Advanced-control timers (TIM1 and TIM8) specific features
+ *
+@verbatim   
+ ===============================================================================
+          Advanced-control timers (TIM1 and TIM8) specific features
+ ===============================================================================  
+  
+       ===================================================================      
+              TIM Driver: how to use the Break feature
+       =================================================================== 
+       After configuring the Timer channel(s) in the appropriate Output Compare mode: 
+                         
+       1. Fill the TIM_BDTRInitStruct with the desired parameters for the Timer
+          Break Polarity, dead time, Lock level, the OSSI/OSSR State and the 
+          AOE(automatic output enable).
+               
+       2. Call TIM_BDTRConfig(TIMx, &TIM_BDTRInitStruct) to configure the Timer
+          
+       3. Enable the Main Output using TIM_CtrlPWMOutputs(TIM1, ENABLE) 
+          
+       4. Once the break even occurs, the Timer's output signals are put in reset
+          state or in a known state (according to the configuration made in
+          TIM_BDTRConfig() function).
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Configures the Break feature, dead time, Lock level, OSSI/OSSR State
+  *         and the AOE(automatic output enable).
+  * @param  TIMx: where x can be  1 or 8 to select the TIM 
+  * @param  TIM_BDTRInitStruct: pointer to a TIM_BDTRInitTypeDef structure that
+  *         contains the BDTR Register configuration  information for the TIM peripheral.
+  * @retval None
+  */
+void TIM_BDTRConfig(TIM_TypeDef* TIMx, TIM_BDTRInitTypeDef *TIM_BDTRInitStruct)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_LIST4_PERIPH(TIMx));
+  assert_param(IS_TIM_OSSR_STATE(TIM_BDTRInitStruct->TIM_OSSRState));
+  assert_param(IS_TIM_OSSI_STATE(TIM_BDTRInitStruct->TIM_OSSIState));
+  assert_param(IS_TIM_LOCK_LEVEL(TIM_BDTRInitStruct->TIM_LOCKLevel));
+  assert_param(IS_TIM_BREAK_STATE(TIM_BDTRInitStruct->TIM_Break));
+  assert_param(IS_TIM_BREAK_POLARITY(TIM_BDTRInitStruct->TIM_BreakPolarity));
+  assert_param(IS_TIM_AUTOMATIC_OUTPUT_STATE(TIM_BDTRInitStruct->TIM_AutomaticOutput));
+
+  /* Set the Lock level, the Break enable Bit and the Polarity, the OSSR State,
+     the OSSI State, the dead time value and the Automatic Output Enable Bit */
+  TIMx->BDTR = (uint32_t)TIM_BDTRInitStruct->TIM_OSSRState | TIM_BDTRInitStruct->TIM_OSSIState |
+             TIM_BDTRInitStruct->TIM_LOCKLevel | TIM_BDTRInitStruct->TIM_DeadTime |
+             TIM_BDTRInitStruct->TIM_Break | TIM_BDTRInitStruct->TIM_BreakPolarity |
+             TIM_BDTRInitStruct->TIM_AutomaticOutput;
+}
+
+/**
+  * @brief  Fills each TIM_BDTRInitStruct member with its default value.
+  * @param  TIM_BDTRInitStruct: pointer to a TIM_BDTRInitTypeDef structure which
+  *         will be initialized.
+  * @retval None
+  */
+void TIM_BDTRStructInit(TIM_BDTRInitTypeDef* TIM_BDTRInitStruct)
+{
+  /* Set the default configuration */
+  TIM_BDTRInitStruct->TIM_OSSRState = TIM_OSSRState_Disable;
+  TIM_BDTRInitStruct->TIM_OSSIState = TIM_OSSIState_Disable;
+  TIM_BDTRInitStruct->TIM_LOCKLevel = TIM_LOCKLevel_OFF;
+  TIM_BDTRInitStruct->TIM_DeadTime = 0x00;
+  TIM_BDTRInitStruct->TIM_Break = TIM_Break_Disable;
+  TIM_BDTRInitStruct->TIM_BreakPolarity = TIM_BreakPolarity_Low;
+  TIM_BDTRInitStruct->TIM_AutomaticOutput = TIM_AutomaticOutput_Disable;
+}
+
+/**
+  * @brief  Enables or disables the TIM peripheral Main Outputs.
+  * @param  TIMx: where x can be 1 or 8 to select the TIMx peripheral.
+  * @param  NewState: new state of the TIM peripheral Main Outputs.
+  *          This parameter can be: ENABLE or DISABLE.
+  * @retval None
+  */
+void TIM_CtrlPWMOutputs(TIM_TypeDef* TIMx, FunctionalState NewState)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_LIST4_PERIPH(TIMx));
+  assert_param(IS_FUNCTIONAL_STATE(NewState));
+
+  if (NewState != DISABLE)
+  {
+    /* Enable the TIM Main Output */
+    TIMx->BDTR |= TIM_BDTR_MOE;
+  }
+  else
+  {
+    /* Disable the TIM Main Output */
+    TIMx->BDTR &= (uint16_t)~TIM_BDTR_MOE;
+  }  
+}
+
+/**
+  * @brief  Selects the TIM peripheral Commutation event.
+  * @param  TIMx: where x can be  1 or 8 to select the TIMx peripheral
+  * @param  NewState: new state of the Commutation event.
+  *          This parameter can be: ENABLE or DISABLE.
+  * @retval None
+  */
+void TIM_SelectCOM(TIM_TypeDef* TIMx, FunctionalState NewState)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_LIST4_PERIPH(TIMx));
+  assert_param(IS_FUNCTIONAL_STATE(NewState));
+
+  if (NewState != DISABLE)
+  {
+    /* Set the COM Bit */
+    TIMx->CR2 |= TIM_CR2_CCUS;
+  }
+  else
+  {
+    /* Reset the COM Bit */
+    TIMx->CR2 &= (uint16_t)~TIM_CR2_CCUS;
+  }
+}
+
+/**
+  * @brief  Sets or Resets the TIM peripheral Capture Compare Preload Control bit.
+  * @param  TIMx: where x can be  1 or 8 to select the TIMx peripheral
+  * @param  NewState: new state of the Capture Compare Preload Control bit
+  *          This parameter can be: ENABLE or DISABLE.
+  * @retval None
+  */
+void TIM_CCPreloadControl(TIM_TypeDef* TIMx, FunctionalState NewState)
+{ 
+  /* Check the parameters */
+  assert_param(IS_TIM_LIST4_PERIPH(TIMx));
+  assert_param(IS_FUNCTIONAL_STATE(NewState));
+  if (NewState != DISABLE)
+  {
+    /* Set the CCPC Bit */
+    TIMx->CR2 |= TIM_CR2_CCPC;
+  }
+  else
+  {
+    /* Reset the CCPC Bit */
+    TIMx->CR2 &= (uint16_t)~TIM_CR2_CCPC;
+  }
+}
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Group5 Interrupts DMA and flags management functions
+ *  @brief    Interrupts, DMA and flags management functions 
+ *
+@verbatim   
+ ===============================================================================
+                 Interrupts, DMA and flags management functions
+ ===============================================================================  
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Enables or disables the specified TIM interrupts.
+  * @param  TIMx: where x can be 1 to 14 to select the TIMx peripheral.
+  * @param  TIM_IT: specifies the TIM interrupts sources to be enabled or disabled.
+  *          This parameter can be any combination of the following values:
+  *            @arg TIM_IT_Update: TIM update Interrupt source
+  *            @arg TIM_IT_CC1: TIM Capture Compare 1 Interrupt source
+  *            @arg TIM_IT_CC2: TIM Capture Compare 2 Interrupt source
+  *            @arg TIM_IT_CC3: TIM Capture Compare 3 Interrupt source
+  *            @arg TIM_IT_CC4: TIM Capture Compare 4 Interrupt source
+  *            @arg TIM_IT_COM: TIM Commutation Interrupt source
+  *            @arg TIM_IT_Trigger: TIM Trigger Interrupt source
+  *            @arg TIM_IT_Break: TIM Break Interrupt source
+  *  
+  * @note   For TIM6 and TIM7 only the parameter TIM_IT_Update can be used
+  * @note   For TIM9 and TIM12 only one of the following parameters can be used: TIM_IT_Update,
+  *          TIM_IT_CC1, TIM_IT_CC2 or TIM_IT_Trigger. 
+  * @note   For TIM10, TIM11, TIM13 and TIM14 only one of the following parameters can
+  *          be used: TIM_IT_Update or TIM_IT_CC1   
+  * @note   TIM_IT_COM and TIM_IT_Break can be used only with TIM1 and TIM8 
+  *        
+  * @param  NewState: new state of the TIM interrupts.
+  *          This parameter can be: ENABLE or DISABLE.
+  * @retval None
+  */
+void TIM_ITConfig(TIM_TypeDef* TIMx, uint16_t TIM_IT, FunctionalState NewState)
+{  
+  /* Check the parameters */
+  assert_param(IS_TIM_ALL_PERIPH(TIMx));
+  assert_param(IS_TIM_IT(TIM_IT));
+  assert_param(IS_FUNCTIONAL_STATE(NewState));
+  
+  if (NewState != DISABLE)
+  {
+    /* Enable the Interrupt sources */
+    TIMx->DIER |= TIM_IT;
+  }
+  else
+  {
+    /* Disable the Interrupt sources */
+    TIMx->DIER &= (uint16_t)~TIM_IT;
+  }
+}
+
+/**
+  * @brief  Configures the TIMx event to be generate by software.
+  * @param  TIMx: where x can be 1 to 14 to select the TIM peripheral.
+  * @param  TIM_EventSource: specifies the event source.
+  *          This parameter can be one or more of the following values:	   
+  *            @arg TIM_EventSource_Update: Timer update Event source
+  *            @arg TIM_EventSource_CC1: Timer Capture Compare 1 Event source
+  *            @arg TIM_EventSource_CC2: Timer Capture Compare 2 Event source
+  *            @arg TIM_EventSource_CC3: Timer Capture Compare 3 Event source
+  *            @arg TIM_EventSource_CC4: Timer Capture Compare 4 Event source
+  *            @arg TIM_EventSource_COM: Timer COM event source  
+  *            @arg TIM_EventSource_Trigger: Timer Trigger Event source
+  *            @arg TIM_EventSource_Break: Timer Break event source
+  * 
+  * @note   TIM6 and TIM7 can only generate an update event. 
+  * @note   TIM_EventSource_COM and TIM_EventSource_Break are used only with TIM1 and TIM8.
+  *        
+  * @retval None
+  */
+void TIM_GenerateEvent(TIM_TypeDef* TIMx, uint16_t TIM_EventSource)
+{ 
+  /* Check the parameters */
+  assert_param(IS_TIM_ALL_PERIPH(TIMx));
+  assert_param(IS_TIM_EVENT_SOURCE(TIM_EventSource));
+ 
+  /* Set the event sources */
+  TIMx->EGR = TIM_EventSource;
+}
+
+/**
+  * @brief  Checks whether the specified TIM flag is set or not.
+  * @param  TIMx: where x can be 1 to 14 to select the TIM peripheral.
+  * @param  TIM_FLAG: specifies the flag to check.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_FLAG_Update: TIM update Flag
+  *            @arg TIM_FLAG_CC1: TIM Capture Compare 1 Flag
+  *            @arg TIM_FLAG_CC2: TIM Capture Compare 2 Flag
+  *            @arg TIM_FLAG_CC3: TIM Capture Compare 3 Flag
+  *            @arg TIM_FLAG_CC4: TIM Capture Compare 4 Flag
+  *            @arg TIM_FLAG_COM: TIM Commutation Flag
+  *            @arg TIM_FLAG_Trigger: TIM Trigger Flag
+  *            @arg TIM_FLAG_Break: TIM Break Flag
+  *            @arg TIM_FLAG_CC1OF: TIM Capture Compare 1 over capture Flag
+  *            @arg TIM_FLAG_CC2OF: TIM Capture Compare 2 over capture Flag
+  *            @arg TIM_FLAG_CC3OF: TIM Capture Compare 3 over capture Flag
+  *            @arg TIM_FLAG_CC4OF: TIM Capture Compare 4 over capture Flag
+  *
+  * @note   TIM6 and TIM7 can have only one update flag. 
+  * @note   TIM_FLAG_COM and TIM_FLAG_Break are used only with TIM1 and TIM8.    
+  *
+  * @retval The new state of TIM_FLAG (SET or RESET).
+  */
+FlagStatus TIM_GetFlagStatus(TIM_TypeDef* TIMx, uint16_t TIM_FLAG)
+{ 
+  ITStatus bitstatus = RESET;  
+  /* Check the parameters */
+  assert_param(IS_TIM_ALL_PERIPH(TIMx));
+  assert_param(IS_TIM_GET_FLAG(TIM_FLAG));
+
+  
+  if ((TIMx->SR & TIM_FLAG) != (uint16_t)RESET)
+  {
+    bitstatus = SET;
+  }
+  else
+  {
+    bitstatus = RESET;
+  }
+  return bitstatus;
+}
+
+/**
+  * @brief  Clears the TIMx's pending flags.
+  * @param  TIMx: where x can be 1 to 14 to select the TIM peripheral.
+  * @param  TIM_FLAG: specifies the flag bit to clear.
+  *          This parameter can be any combination of the following values:
+  *            @arg TIM_FLAG_Update: TIM update Flag
+  *            @arg TIM_FLAG_CC1: TIM Capture Compare 1 Flag
+  *            @arg TIM_FLAG_CC2: TIM Capture Compare 2 Flag
+  *            @arg TIM_FLAG_CC3: TIM Capture Compare 3 Flag
+  *            @arg TIM_FLAG_CC4: TIM Capture Compare 4 Flag
+  *            @arg TIM_FLAG_COM: TIM Commutation Flag
+  *            @arg TIM_FLAG_Trigger: TIM Trigger Flag
+  *            @arg TIM_FLAG_Break: TIM Break Flag
+  *            @arg TIM_FLAG_CC1OF: TIM Capture Compare 1 over capture Flag
+  *            @arg TIM_FLAG_CC2OF: TIM Capture Compare 2 over capture Flag
+  *            @arg TIM_FLAG_CC3OF: TIM Capture Compare 3 over capture Flag
+  *            @arg TIM_FLAG_CC4OF: TIM Capture Compare 4 over capture Flag
+  *
+  * @note   TIM6 and TIM7 can have only one update flag. 
+  * @note   TIM_FLAG_COM and TIM_FLAG_Break are used only with TIM1 and TIM8.
+  *    
+  * @retval None
+  */
+void TIM_ClearFlag(TIM_TypeDef* TIMx, uint16_t TIM_FLAG)
+{  
+  /* Check the parameters */
+  assert_param(IS_TIM_ALL_PERIPH(TIMx));
+   
+  /* Clear the flags */
+  TIMx->SR = (uint16_t)~TIM_FLAG;
+}
+
+/**
+  * @brief  Checks whether the TIM interrupt has occurred or not.
+  * @param  TIMx: where x can be 1 to 14 to select the TIM peripheral.
+  * @param  TIM_IT: specifies the TIM interrupt source to check.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_IT_Update: TIM update Interrupt source
+  *            @arg TIM_IT_CC1: TIM Capture Compare 1 Interrupt source
+  *            @arg TIM_IT_CC2: TIM Capture Compare 2 Interrupt source
+  *            @arg TIM_IT_CC3: TIM Capture Compare 3 Interrupt source
+  *            @arg TIM_IT_CC4: TIM Capture Compare 4 Interrupt source
+  *            @arg TIM_IT_COM: TIM Commutation Interrupt source
+  *            @arg TIM_IT_Trigger: TIM Trigger Interrupt source
+  *            @arg TIM_IT_Break: TIM Break Interrupt source
+  *
+  * @note   TIM6 and TIM7 can generate only an update interrupt.
+  * @note   TIM_IT_COM and TIM_IT_Break are used only with TIM1 and TIM8.
+  *     
+  * @retval The new state of the TIM_IT(SET or RESET).
+  */
+ITStatus TIM_GetITStatus(TIM_TypeDef* TIMx, uint16_t TIM_IT)
+{
+  ITStatus bitstatus = RESET;  
+  uint16_t itstatus = 0x0, itenable = 0x0;
+  /* Check the parameters */
+  assert_param(IS_TIM_ALL_PERIPH(TIMx));
+  assert_param(IS_TIM_GET_IT(TIM_IT));
+   
+  itstatus = TIMx->SR & TIM_IT;
+  
+  itenable = TIMx->DIER & TIM_IT;
+  if ((itstatus != (uint16_t)RESET) && (itenable != (uint16_t)RESET))
+  {
+    bitstatus = SET;
+  }
+  else
+  {
+    bitstatus = RESET;
+  }
+  return bitstatus;
+}
+
+/**
+  * @brief  Clears the TIMx's interrupt pending bits.
+  * @param  TIMx: where x can be 1 to 14 to select the TIM peripheral.
+  * @param  TIM_IT: specifies the pending bit to clear.
+  *          This parameter can be any combination of the following values:
+  *            @arg TIM_IT_Update: TIM1 update Interrupt source
+  *            @arg TIM_IT_CC1: TIM Capture Compare 1 Interrupt source
+  *            @arg TIM_IT_CC2: TIM Capture Compare 2 Interrupt source
+  *            @arg TIM_IT_CC3: TIM Capture Compare 3 Interrupt source
+  *            @arg TIM_IT_CC4: TIM Capture Compare 4 Interrupt source
+  *            @arg TIM_IT_COM: TIM Commutation Interrupt source
+  *            @arg TIM_IT_Trigger: TIM Trigger Interrupt source
+  *            @arg TIM_IT_Break: TIM Break Interrupt source
+  *
+  * @note   TIM6 and TIM7 can generate only an update interrupt.
+  * @note   TIM_IT_COM and TIM_IT_Break are used only with TIM1 and TIM8.
+  *      
+  * @retval None
+  */
+void TIM_ClearITPendingBit(TIM_TypeDef* TIMx, uint16_t TIM_IT)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_ALL_PERIPH(TIMx));
+
+  /* Clear the IT pending Bit */
+  TIMx->SR = (uint16_t)~TIM_IT;
+}
+
+/**
+  * @brief  Configures the TIMx's DMA interface.
+  * @param  TIMx: where x can be 1, 2, 3, 4, 5 or 8 to select the TIM peripheral.
+  * @param  TIM_DMABase: DMA Base address.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_DMABase_CR1  
+  *            @arg TIM_DMABase_CR2
+  *            @arg TIM_DMABase_SMCR
+  *            @arg TIM_DMABase_DIER
+  *            @arg TIM1_DMABase_SR
+  *            @arg TIM_DMABase_EGR
+  *            @arg TIM_DMABase_CCMR1
+  *            @arg TIM_DMABase_CCMR2
+  *            @arg TIM_DMABase_CCER
+  *            @arg TIM_DMABase_CNT   
+  *            @arg TIM_DMABase_PSC   
+  *            @arg TIM_DMABase_ARR
+  *            @arg TIM_DMABase_RCR
+  *            @arg TIM_DMABase_CCR1
+  *            @arg TIM_DMABase_CCR2
+  *            @arg TIM_DMABase_CCR3  
+  *            @arg TIM_DMABase_CCR4
+  *            @arg TIM_DMABase_BDTR
+  *            @arg TIM_DMABase_DCR
+  * @param  TIM_DMABurstLength: DMA Burst length. This parameter can be one value
+  *         between: TIM_DMABurstLength_1Transfer and TIM_DMABurstLength_18Transfers.
+  * @retval None
+  */
+void TIM_DMAConfig(TIM_TypeDef* TIMx, uint16_t TIM_DMABase, uint16_t TIM_DMABurstLength)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_LIST3_PERIPH(TIMx));
+  assert_param(IS_TIM_DMA_BASE(TIM_DMABase)); 
+  assert_param(IS_TIM_DMA_LENGTH(TIM_DMABurstLength));
+
+  /* Set the DMA Base and the DMA Burst Length */
+  TIMx->DCR = TIM_DMABase | TIM_DMABurstLength;
+}
+
+/**
+  * @brief  Enables or disables the TIMx's DMA Requests.
+  * @param  TIMx: where x can be 1, 2, 3, 4, 5, 6, 7 or 8 to select the TIM peripheral.
+  * @param  TIM_DMASource: specifies the DMA Request sources.
+  *          This parameter can be any combination of the following values:
+  *            @arg TIM_DMA_Update: TIM update Interrupt source
+  *            @arg TIM_DMA_CC1: TIM Capture Compare 1 DMA source
+  *            @arg TIM_DMA_CC2: TIM Capture Compare 2 DMA source
+  *            @arg TIM_DMA_CC3: TIM Capture Compare 3 DMA source
+  *            @arg TIM_DMA_CC4: TIM Capture Compare 4 DMA source
+  *            @arg TIM_DMA_COM: TIM Commutation DMA source
+  *            @arg TIM_DMA_Trigger: TIM Trigger DMA source
+  * @param  NewState: new state of the DMA Request sources.
+  *          This parameter can be: ENABLE or DISABLE.
+  * @retval None
+  */
+void TIM_DMACmd(TIM_TypeDef* TIMx, uint16_t TIM_DMASource, FunctionalState NewState)
+{ 
+  /* Check the parameters */
+  assert_param(IS_TIM_LIST5_PERIPH(TIMx)); 
+  assert_param(IS_TIM_DMA_SOURCE(TIM_DMASource));
+  assert_param(IS_FUNCTIONAL_STATE(NewState));
+  
+  if (NewState != DISABLE)
+  {
+    /* Enable the DMA sources */
+    TIMx->DIER |= TIM_DMASource; 
+  }
+  else
+  {
+    /* Disable the DMA sources */
+    TIMx->DIER &= (uint16_t)~TIM_DMASource;
+  }
+}
+
+/**
+  * @brief  Selects the TIMx peripheral Capture Compare DMA source.
+  * @param  TIMx: where x can be  1, 2, 3, 4, 5 or 8 to select the TIM peripheral.
+  * @param  NewState: new state of the Capture Compare DMA source
+  *          This parameter can be: ENABLE or DISABLE.
+  * @retval None
+  */
+void TIM_SelectCCDMA(TIM_TypeDef* TIMx, FunctionalState NewState)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_LIST3_PERIPH(TIMx));
+  assert_param(IS_FUNCTIONAL_STATE(NewState));
+
+  if (NewState != DISABLE)
+  {
+    /* Set the CCDS Bit */
+    TIMx->CR2 |= TIM_CR2_CCDS;
+  }
+  else
+  {
+    /* Reset the CCDS Bit */
+    TIMx->CR2 &= (uint16_t)~TIM_CR2_CCDS;
+  }
+}
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Group6 Clocks management functions
+ *  @brief    Clocks management functions
+ *
+@verbatim   
+ ===============================================================================
+                         Clocks management functions
+ ===============================================================================  
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Configures the TIMx internal Clock
+  * @param  TIMx: where x can be 1, 2, 3, 4, 5, 8, 9 or 12 to select the TIM 
+  *         peripheral.
+  * @retval None
+  */
+void TIM_InternalClockConfig(TIM_TypeDef* TIMx)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_LIST2_PERIPH(TIMx));
+
+  /* Disable slave mode to clock the prescaler directly with the internal clock */
+  TIMx->SMCR &=  (uint16_t)~TIM_SMCR_SMS;
+}
+
+/**
+  * @brief  Configures the TIMx Internal Trigger as External Clock
+  * @param  TIMx: where x can be 1, 2, 3, 4, 5, 8, 9 or 12 to select the TIM 
+  *         peripheral.
+  * @param  TIM_InputTriggerSource: Trigger source.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_TS_ITR0: Internal Trigger 0
+  *            @arg TIM_TS_ITR1: Internal Trigger 1
+  *            @arg TIM_TS_ITR2: Internal Trigger 2
+  *            @arg TIM_TS_ITR3: Internal Trigger 3
+  * @retval None
+  */
+void TIM_ITRxExternalClockConfig(TIM_TypeDef* TIMx, uint16_t TIM_InputTriggerSource)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_LIST2_PERIPH(TIMx));
+  assert_param(IS_TIM_INTERNAL_TRIGGER_SELECTION(TIM_InputTriggerSource));
+
+  /* Select the Internal Trigger */
+  TIM_SelectInputTrigger(TIMx, TIM_InputTriggerSource);
+
+  /* Select the External clock mode1 */
+  TIMx->SMCR |= TIM_SlaveMode_External1;
+}
+
+/**
+  * @brief  Configures the TIMx Trigger as External Clock
+  * @param  TIMx: where x can be 1, 2, 3, 4, 5, 8, 9, 10, 11, 12, 13 or 14  
+  *         to select the TIM peripheral.
+  * @param  TIM_TIxExternalCLKSource: Trigger source.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_TIxExternalCLK1Source_TI1ED: TI1 Edge Detector
+  *            @arg TIM_TIxExternalCLK1Source_TI1: Filtered Timer Input 1
+  *            @arg TIM_TIxExternalCLK1Source_TI2: Filtered Timer Input 2
+  * @param  TIM_ICPolarity: specifies the TIx Polarity.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_ICPolarity_Rising
+  *            @arg TIM_ICPolarity_Falling
+  * @param  ICFilter: specifies the filter value.
+  *          This parameter must be a value between 0x0 and 0xF.
+  * @retval None
+  */
+void TIM_TIxExternalClockConfig(TIM_TypeDef* TIMx, uint16_t TIM_TIxExternalCLKSource,
+                                uint16_t TIM_ICPolarity, uint16_t ICFilter)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_LIST1_PERIPH(TIMx));
+  assert_param(IS_TIM_IC_POLARITY(TIM_ICPolarity));
+  assert_param(IS_TIM_IC_FILTER(ICFilter));
+
+  /* Configure the Timer Input Clock Source */
+  if (TIM_TIxExternalCLKSource == TIM_TIxExternalCLK1Source_TI2)
+  {
+    TI2_Config(TIMx, TIM_ICPolarity, TIM_ICSelection_DirectTI, ICFilter);
+  }
+  else
+  {
+    TI1_Config(TIMx, TIM_ICPolarity, TIM_ICSelection_DirectTI, ICFilter);
+  }
+  /* Select the Trigger source */
+  TIM_SelectInputTrigger(TIMx, TIM_TIxExternalCLKSource);
+  /* Select the External clock mode1 */
+  TIMx->SMCR |= TIM_SlaveMode_External1;
+}
+
+/**
+  * @brief  Configures the External clock Mode1
+  * @param  TIMx: where x can be  1, 2, 3, 4, 5 or 8 to select the TIM peripheral.
+  * @param  TIM_ExtTRGPrescaler: The external Trigger Prescaler.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_ExtTRGPSC_OFF: ETRP Prescaler OFF.
+  *            @arg TIM_ExtTRGPSC_DIV2: ETRP frequency divided by 2.
+  *            @arg TIM_ExtTRGPSC_DIV4: ETRP frequency divided by 4.
+  *            @arg TIM_ExtTRGPSC_DIV8: ETRP frequency divided by 8.
+  * @param  TIM_ExtTRGPolarity: The external Trigger Polarity.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_ExtTRGPolarity_Inverted: active low or falling edge active.
+  *            @arg TIM_ExtTRGPolarity_NonInverted: active high or rising edge active.
+  * @param  ExtTRGFilter: External Trigger Filter.
+  *          This parameter must be a value between 0x00 and 0x0F
+  * @retval None
+  */
+void TIM_ETRClockMode1Config(TIM_TypeDef* TIMx, uint16_t TIM_ExtTRGPrescaler,
+                            uint16_t TIM_ExtTRGPolarity, uint16_t ExtTRGFilter)
+{
+  uint16_t tmpsmcr = 0;
+
+  /* Check the parameters */
+  assert_param(IS_TIM_LIST3_PERIPH(TIMx));
+  assert_param(IS_TIM_EXT_PRESCALER(TIM_ExtTRGPrescaler));
+  assert_param(IS_TIM_EXT_POLARITY(TIM_ExtTRGPolarity));
+  assert_param(IS_TIM_EXT_FILTER(ExtTRGFilter));
+  /* Configure the ETR Clock source */
+  TIM_ETRConfig(TIMx, TIM_ExtTRGPrescaler, TIM_ExtTRGPolarity, ExtTRGFilter);
+  
+  /* Get the TIMx SMCR register value */
+  tmpsmcr = TIMx->SMCR;
+
+  /* Reset the SMS Bits */
+  tmpsmcr &= (uint16_t)~TIM_SMCR_SMS;
+
+  /* Select the External clock mode1 */
+  tmpsmcr |= TIM_SlaveMode_External1;
+
+  /* Select the Trigger selection : ETRF */
+  tmpsmcr &= (uint16_t)~TIM_SMCR_TS;
+  tmpsmcr |= TIM_TS_ETRF;
+
+  /* Write to TIMx SMCR */
+  TIMx->SMCR = tmpsmcr;
+}
+
+/**
+  * @brief  Configures the External clock Mode2
+  * @param  TIMx: where x can be  1, 2, 3, 4, 5 or 8 to select the TIM peripheral.
+  * @param  TIM_ExtTRGPrescaler: The external Trigger Prescaler.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_ExtTRGPSC_OFF: ETRP Prescaler OFF.
+  *            @arg TIM_ExtTRGPSC_DIV2: ETRP frequency divided by 2.
+  *            @arg TIM_ExtTRGPSC_DIV4: ETRP frequency divided by 4.
+  *            @arg TIM_ExtTRGPSC_DIV8: ETRP frequency divided by 8.
+  * @param  TIM_ExtTRGPolarity: The external Trigger Polarity.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_ExtTRGPolarity_Inverted: active low or falling edge active.
+  *            @arg TIM_ExtTRGPolarity_NonInverted: active high or rising edge active.
+  * @param  ExtTRGFilter: External Trigger Filter.
+  *          This parameter must be a value between 0x00 and 0x0F
+  * @retval None
+  */
+void TIM_ETRClockMode2Config(TIM_TypeDef* TIMx, uint16_t TIM_ExtTRGPrescaler, 
+                             uint16_t TIM_ExtTRGPolarity, uint16_t ExtTRGFilter)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_LIST3_PERIPH(TIMx));
+  assert_param(IS_TIM_EXT_PRESCALER(TIM_ExtTRGPrescaler));
+  assert_param(IS_TIM_EXT_POLARITY(TIM_ExtTRGPolarity));
+  assert_param(IS_TIM_EXT_FILTER(ExtTRGFilter));
+
+  /* Configure the ETR Clock source */
+  TIM_ETRConfig(TIMx, TIM_ExtTRGPrescaler, TIM_ExtTRGPolarity, ExtTRGFilter);
+
+  /* Enable the External clock mode2 */
+  TIMx->SMCR |= TIM_SMCR_ECE;
+}
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Group7 Synchronization management functions
+ *  @brief    Synchronization management functions 
+ *
+@verbatim   
+ ===============================================================================
+                       Synchronization management functions
+ ===============================================================================  
+                   
+       ===================================================================      
+              TIM Driver: how to use it in synchronization Mode
+       =================================================================== 
+       Case of two/several Timers
+       **************************
+       1. Configure the Master Timers using the following functions:
+          - void TIM_SelectOutputTrigger(TIM_TypeDef* TIMx, uint16_t TIM_TRGOSource); 
+          - void TIM_SelectMasterSlaveMode(TIM_TypeDef* TIMx, uint16_t TIM_MasterSlaveMode);  
+       2. Configure the Slave Timers using the following functions: 
+          - void TIM_SelectInputTrigger(TIM_TypeDef* TIMx, uint16_t TIM_InputTriggerSource);  
+          - void TIM_SelectSlaveMode(TIM_TypeDef* TIMx, uint16_t TIM_SlaveMode); 
+          
+       Case of Timers and external trigger(ETR pin)
+       ********************************************       
+       1. Configure the External trigger using this function:
+          - void TIM_ETRConfig(TIM_TypeDef* TIMx, uint16_t TIM_ExtTRGPrescaler, uint16_t TIM_ExtTRGPolarity,
+                               uint16_t ExtTRGFilter);
+       2. Configure the Slave Timers using the following functions: 
+          - void TIM_SelectInputTrigger(TIM_TypeDef* TIMx, uint16_t TIM_InputTriggerSource);  
+          - void TIM_SelectSlaveMode(TIM_TypeDef* TIMx, uint16_t TIM_SlaveMode); 
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Selects the Input Trigger source
+  * @param  TIMx: where x can be  1, 2, 3, 4, 5, 8, 9, 10, 11, 12, 13 or 14  
+  *         to select the TIM peripheral.
+  * @param  TIM_InputTriggerSource: The Input Trigger source.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_TS_ITR0: Internal Trigger 0
+  *            @arg TIM_TS_ITR1: Internal Trigger 1
+  *            @arg TIM_TS_ITR2: Internal Trigger 2
+  *            @arg TIM_TS_ITR3: Internal Trigger 3
+  *            @arg TIM_TS_TI1F_ED: TI1 Edge Detector
+  *            @arg TIM_TS_TI1FP1: Filtered Timer Input 1
+  *            @arg TIM_TS_TI2FP2: Filtered Timer Input 2
+  *            @arg TIM_TS_ETRF: External Trigger input
+  * @retval None
+  */
+void TIM_SelectInputTrigger(TIM_TypeDef* TIMx, uint16_t TIM_InputTriggerSource)
+{
+  uint16_t tmpsmcr = 0;
+
+  /* Check the parameters */
+  assert_param(IS_TIM_LIST1_PERIPH(TIMx)); 
+  assert_param(IS_TIM_TRIGGER_SELECTION(TIM_InputTriggerSource));
+
+  /* Get the TIMx SMCR register value */
+  tmpsmcr = TIMx->SMCR;
+
+  /* Reset the TS Bits */
+  tmpsmcr &= (uint16_t)~TIM_SMCR_TS;
+
+  /* Set the Input Trigger source */
+  tmpsmcr |= TIM_InputTriggerSource;
+
+  /* Write to TIMx SMCR */
+  TIMx->SMCR = tmpsmcr;
+}
+
+/**
+  * @brief  Selects the TIMx Trigger Output Mode.
+  * @param  TIMx: where x can be 1, 2, 3, 4, 5, 6, 7 or 8 to select the TIM peripheral.
+  *     
+  * @param  TIM_TRGOSource: specifies the Trigger Output source.
+  *   This parameter can be one of the following values:
+  *
+  *  - For all TIMx
+  *            @arg TIM_TRGOSource_Reset:  The UG bit in the TIM_EGR register is used as the trigger output(TRGO)
+  *            @arg TIM_TRGOSource_Enable: The Counter Enable CEN is used as the trigger output(TRGO)
+  *            @arg TIM_TRGOSource_Update: The update event is selected as the trigger output(TRGO)
+  *
+  *  - For all TIMx except TIM6 and TIM7
+  *            @arg TIM_TRGOSource_OC1: The trigger output sends a positive pulse when the CC1IF flag
+  *                                     is to be set, as soon as a capture or compare match occurs(TRGO)
+  *            @arg TIM_TRGOSource_OC1Ref: OC1REF signal is used as the trigger output(TRGO)
+  *            @arg TIM_TRGOSource_OC2Ref: OC2REF signal is used as the trigger output(TRGO)
+  *            @arg TIM_TRGOSource_OC3Ref: OC3REF signal is used as the trigger output(TRGO)
+  *            @arg TIM_TRGOSource_OC4Ref: OC4REF signal is used as the trigger output(TRGO)
+  *
+  * @retval None
+  */
+void TIM_SelectOutputTrigger(TIM_TypeDef* TIMx, uint16_t TIM_TRGOSource)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_LIST5_PERIPH(TIMx));
+  assert_param(IS_TIM_TRGO_SOURCE(TIM_TRGOSource));
+
+  /* Reset the MMS Bits */
+  TIMx->CR2 &= (uint16_t)~TIM_CR2_MMS;
+  /* Select the TRGO source */
+  TIMx->CR2 |=  TIM_TRGOSource;
+}
+
+/**
+  * @brief  Selects the TIMx Slave Mode.
+  * @param  TIMx: where x can be 1, 2, 3, 4, 5, 8, 9 or 12 to select the TIM peripheral.
+  * @param  TIM_SlaveMode: specifies the Timer Slave Mode.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_SlaveMode_Reset: Rising edge of the selected trigger signal(TRGI) reinitialize 
+  *                                      the counter and triggers an update of the registers
+  *            @arg TIM_SlaveMode_Gated:     The counter clock is enabled when the trigger signal (TRGI) is high
+  *            @arg TIM_SlaveMode_Trigger:   The counter starts at a rising edge of the trigger TRGI
+  *            @arg TIM_SlaveMode_External1: Rising edges of the selected trigger (TRGI) clock the counter
+  * @retval None
+  */
+void TIM_SelectSlaveMode(TIM_TypeDef* TIMx, uint16_t TIM_SlaveMode)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_LIST2_PERIPH(TIMx));
+  assert_param(IS_TIM_SLAVE_MODE(TIM_SlaveMode));
+
+  /* Reset the SMS Bits */
+  TIMx->SMCR &= (uint16_t)~TIM_SMCR_SMS;
+
+  /* Select the Slave Mode */
+  TIMx->SMCR |= TIM_SlaveMode;
+}
+
+/**
+  * @brief  Sets or Resets the TIMx Master/Slave Mode.
+  * @param  TIMx: where x can be 1, 2, 3, 4, 5, 8, 9 or 12 to select the TIM peripheral.
+  * @param  TIM_MasterSlaveMode: specifies the Timer Master Slave Mode.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_MasterSlaveMode_Enable: synchronization between the current timer
+  *                                             and its slaves (through TRGO)
+  *            @arg TIM_MasterSlaveMode_Disable: No action
+  * @retval None
+  */
+void TIM_SelectMasterSlaveMode(TIM_TypeDef* TIMx, uint16_t TIM_MasterSlaveMode)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_LIST2_PERIPH(TIMx));
+  assert_param(IS_TIM_MSM_STATE(TIM_MasterSlaveMode));
+
+  /* Reset the MSM Bit */
+  TIMx->SMCR &= (uint16_t)~TIM_SMCR_MSM;
+  
+  /* Set or Reset the MSM Bit */
+  TIMx->SMCR |= TIM_MasterSlaveMode;
+}
+
+/**
+  * @brief  Configures the TIMx External Trigger (ETR).
+  * @param  TIMx: where x can be  1, 2, 3, 4, 5 or 8 to select the TIM peripheral.
+  * @param  TIM_ExtTRGPrescaler: The external Trigger Prescaler.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_ExtTRGPSC_OFF: ETRP Prescaler OFF.
+  *            @arg TIM_ExtTRGPSC_DIV2: ETRP frequency divided by 2.
+  *            @arg TIM_ExtTRGPSC_DIV4: ETRP frequency divided by 4.
+  *            @arg TIM_ExtTRGPSC_DIV8: ETRP frequency divided by 8.
+  * @param  TIM_ExtTRGPolarity: The external Trigger Polarity.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_ExtTRGPolarity_Inverted: active low or falling edge active.
+  *            @arg TIM_ExtTRGPolarity_NonInverted: active high or rising edge active.
+  * @param  ExtTRGFilter: External Trigger Filter.
+  *          This parameter must be a value between 0x00 and 0x0F
+  * @retval None
+  */
+void TIM_ETRConfig(TIM_TypeDef* TIMx, uint16_t TIM_ExtTRGPrescaler,
+                   uint16_t TIM_ExtTRGPolarity, uint16_t ExtTRGFilter)
+{
+  uint16_t tmpsmcr = 0;
+
+  /* Check the parameters */
+  assert_param(IS_TIM_LIST3_PERIPH(TIMx));
+  assert_param(IS_TIM_EXT_PRESCALER(TIM_ExtTRGPrescaler));
+  assert_param(IS_TIM_EXT_POLARITY(TIM_ExtTRGPolarity));
+  assert_param(IS_TIM_EXT_FILTER(ExtTRGFilter));
+
+  tmpsmcr = TIMx->SMCR;
+
+  /* Reset the ETR Bits */
+  tmpsmcr &= SMCR_ETR_MASK;
+
+  /* Set the Prescaler, the Filter value and the Polarity */
+  tmpsmcr |= (uint16_t)(TIM_ExtTRGPrescaler | (uint16_t)(TIM_ExtTRGPolarity | (uint16_t)(ExtTRGFilter << (uint16_t)8)));
+
+  /* Write to TIMx SMCR */
+  TIMx->SMCR = tmpsmcr;
+}
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Group8 Specific interface management functions
+ *  @brief    Specific interface management functions 
+ *
+@verbatim   
+ ===============================================================================
+                    Specific interface management functions
+ ===============================================================================  
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Configures the TIMx Encoder Interface.
+  * @param  TIMx: where x can be 1, 2, 3, 4, 5, 8, 9 or 12 to select the TIM 
+  *         peripheral.
+  * @param  TIM_EncoderMode: specifies the TIMx Encoder Mode.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_EncoderMode_TI1: Counter counts on TI1FP1 edge depending on TI2FP2 level.
+  *            @arg TIM_EncoderMode_TI2: Counter counts on TI2FP2 edge depending on TI1FP1 level.
+  *            @arg TIM_EncoderMode_TI12: Counter counts on both TI1FP1 and TI2FP2 edges depending
+  *                                       on the level of the other input.
+  * @param  TIM_IC1Polarity: specifies the IC1 Polarity
+  *          This parameter can be one of the following values:
+  *            @arg TIM_ICPolarity_Falling: IC Falling edge.
+  *            @arg TIM_ICPolarity_Rising: IC Rising edge.
+  * @param  TIM_IC2Polarity: specifies the IC2 Polarity
+  *          This parameter can be one of the following values:
+  *            @arg TIM_ICPolarity_Falling: IC Falling edge.
+  *            @arg TIM_ICPolarity_Rising: IC Rising edge.
+  * @retval None
+  */
+void TIM_EncoderInterfaceConfig(TIM_TypeDef* TIMx, uint16_t TIM_EncoderMode,
+                                uint16_t TIM_IC1Polarity, uint16_t TIM_IC2Polarity)
+{
+  uint16_t tmpsmcr = 0;
+  uint16_t tmpccmr1 = 0;
+  uint16_t tmpccer = 0;
+    
+  /* Check the parameters */
+  assert_param(IS_TIM_LIST2_PERIPH(TIMx));
+  assert_param(IS_TIM_ENCODER_MODE(TIM_EncoderMode));
+  assert_param(IS_TIM_IC_POLARITY(TIM_IC1Polarity));
+  assert_param(IS_TIM_IC_POLARITY(TIM_IC2Polarity));
+
+  /* Get the TIMx SMCR register value */
+  tmpsmcr = TIMx->SMCR;
+
+  /* Get the TIMx CCMR1 register value */
+  tmpccmr1 = TIMx->CCMR1;
+
+  /* Get the TIMx CCER register value */
+  tmpccer = TIMx->CCER;
+
+  /* Set the encoder Mode */
+  tmpsmcr &= (uint16_t)~TIM_SMCR_SMS;
+  tmpsmcr |= TIM_EncoderMode;
+
+  /* Select the Capture Compare 1 and the Capture Compare 2 as input */
+  tmpccmr1 &= ((uint16_t)~TIM_CCMR1_CC1S) & ((uint16_t)~TIM_CCMR1_CC2S);
+  tmpccmr1 |= TIM_CCMR1_CC1S_0 | TIM_CCMR1_CC2S_0;
+
+  /* Set the TI1 and the TI2 Polarities */
+  tmpccer &= ((uint16_t)~TIM_CCER_CC1P) & ((uint16_t)~TIM_CCER_CC2P);
+  tmpccer |= (uint16_t)(TIM_IC1Polarity | (uint16_t)(TIM_IC2Polarity << (uint16_t)4));
+
+  /* Write to TIMx SMCR */
+  TIMx->SMCR = tmpsmcr;
+
+  /* Write to TIMx CCMR1 */
+  TIMx->CCMR1 = tmpccmr1;
+
+  /* Write to TIMx CCER */
+  TIMx->CCER = tmpccer;
+}
+
+/**
+  * @brief  Enables or disables the TIMx's Hall sensor interface.
+  * @param  TIMx: where x can be 1, 2, 3, 4, 5, 8, 9 or 12 to select the TIM 
+  *         peripheral.
+  * @param  NewState: new state of the TIMx Hall sensor interface.
+  *          This parameter can be: ENABLE or DISABLE.
+  * @retval None
+  */
+void TIM_SelectHallSensor(TIM_TypeDef* TIMx, FunctionalState NewState)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_LIST2_PERIPH(TIMx));
+  assert_param(IS_FUNCTIONAL_STATE(NewState));
+
+  if (NewState != DISABLE)
+  {
+    /* Set the TI1S Bit */
+    TIMx->CR2 |= TIM_CR2_TI1S;
+  }
+  else
+  {
+    /* Reset the TI1S Bit */
+    TIMx->CR2 &= (uint16_t)~TIM_CR2_TI1S;
+  }
+}
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Group9 Specific remapping management function
+ *  @brief   Specific remapping management function
+ *
+@verbatim   
+ ===============================================================================
+                     Specific remapping management function
+ ===============================================================================  
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Configures the TIM2, TIM5 and TIM11 Remapping input capabilities.
+  * @param  TIMx: where x can be 2, 5 or 11 to select the TIM peripheral.
+  * @param  TIM_Remap: specifies the TIM input remapping source.
+  *          This parameter can be one of the following values:
+  *            @arg TIM2_TIM8_TRGO: TIM2 ITR1 input is connected to TIM8 Trigger output(default)
+  *            @arg TIM2_ETH_PTP:   TIM2 ITR1 input is connected to ETH PTP trogger output.
+  *            @arg TIM2_USBFS_SOF: TIM2 ITR1 input is connected to USB FS SOF. 
+  *            @arg TIM2_USBHS_SOF: TIM2 ITR1 input is connected to USB HS SOF. 
+  *            @arg TIM5_GPIO:      TIM5 CH4 input is connected to dedicated Timer pin(default)
+  *            @arg TIM5_LSI:       TIM5 CH4 input is connected to LSI clock.
+  *            @arg TIM5_LSE:       TIM5 CH4 input is connected to LSE clock.
+  *            @arg TIM5_RTC:       TIM5 CH4 input is connected to RTC Output event.
+  *            @arg TIM11_GPIO:     TIM11 CH4 input is connected to dedicated Timer pin(default) 
+  *            @arg TIM11_HSE:      TIM11 CH4 input is connected to HSE_RTC clock
+  *                                 (HSE divided by a programmable prescaler)  
+  * @retval None
+  */
+void TIM_RemapConfig(TIM_TypeDef* TIMx, uint16_t TIM_Remap)
+{
+ /* Check the parameters */
+  assert_param(IS_TIM_LIST6_PERIPH(TIMx));
+  assert_param(IS_TIM_REMAP(TIM_Remap));
+
+  /* Set the Timer remapping configuration */
+  TIMx->OR =  TIM_Remap;
+}
+/**
+  * @}
+  */
+
+/**
+  * @brief  Configure the TI1 as Input.
+  * @param  TIMx: where x can be 1, 2, 3, 4, 5, 8, 9, 10, 11, 12, 13 or 14 
+  *         to select the TIM peripheral.
+  * @param  TIM_ICPolarity : The Input Polarity.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_ICPolarity_Rising
+  *            @arg TIM_ICPolarity_Falling
+  *            @arg TIM_ICPolarity_BothEdge  
+  * @param  TIM_ICSelection: specifies the input to be used.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_ICSelection_DirectTI: TIM Input 1 is selected to be connected to IC1.
+  *            @arg TIM_ICSelection_IndirectTI: TIM Input 1 is selected to be connected to IC2.
+  *            @arg TIM_ICSelection_TRC: TIM Input 1 is selected to be connected to TRC.
+  * @param  TIM_ICFilter: Specifies the Input Capture Filter.
+  *          This parameter must be a value between 0x00 and 0x0F.
+  * @retval None
+  */
+static void TI1_Config(TIM_TypeDef* TIMx, uint16_t TIM_ICPolarity, uint16_t TIM_ICSelection,
+                       uint16_t TIM_ICFilter)
+{
+  uint16_t tmpccmr1 = 0, tmpccer = 0;
+
+  /* Disable the Channel 1: Reset the CC1E Bit */
+  TIMx->CCER &= (uint16_t)~TIM_CCER_CC1E;
+  tmpccmr1 = TIMx->CCMR1;
+  tmpccer = TIMx->CCER;
+
+  /* Select the Input and set the filter */
+  tmpccmr1 &= ((uint16_t)~TIM_CCMR1_CC1S) & ((uint16_t)~TIM_CCMR1_IC1F);
+  tmpccmr1 |= (uint16_t)(TIM_ICSelection | (uint16_t)(TIM_ICFilter << (uint16_t)4));
+
+  /* Select the Polarity and set the CC1E Bit */
+  tmpccer &= (uint16_t)~(TIM_CCER_CC1P | TIM_CCER_CC1NP);
+  tmpccer |= (uint16_t)(TIM_ICPolarity | (uint16_t)TIM_CCER_CC1E);
+
+  /* Write to TIMx CCMR1 and CCER registers */
+  TIMx->CCMR1 = tmpccmr1;
+  TIMx->CCER = tmpccer;
+}
+
+/**
+  * @brief  Configure the TI2 as Input.
+  * @param  TIMx: where x can be 1, 2, 3, 4, 5, 8, 9 or 12 to select the TIM 
+  *         peripheral.
+  * @param  TIM_ICPolarity : The Input Polarity.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_ICPolarity_Rising
+  *            @arg TIM_ICPolarity_Falling
+  *            @arg TIM_ICPolarity_BothEdge   
+  * @param  TIM_ICSelection: specifies the input to be used.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_ICSelection_DirectTI: TIM Input 2 is selected to be connected to IC2.
+  *            @arg TIM_ICSelection_IndirectTI: TIM Input 2 is selected to be connected to IC1.
+  *            @arg TIM_ICSelection_TRC: TIM Input 2 is selected to be connected to TRC.
+  * @param  TIM_ICFilter: Specifies the Input Capture Filter.
+  *          This parameter must be a value between 0x00 and 0x0F.
+  * @retval None
+  */
+static void TI2_Config(TIM_TypeDef* TIMx, uint16_t TIM_ICPolarity, uint16_t TIM_ICSelection,
+                       uint16_t TIM_ICFilter)
+{
+  uint16_t tmpccmr1 = 0, tmpccer = 0, tmp = 0;
+
+  /* Disable the Channel 2: Reset the CC2E Bit */
+  TIMx->CCER &= (uint16_t)~TIM_CCER_CC2E;
+  tmpccmr1 = TIMx->CCMR1;
+  tmpccer = TIMx->CCER;
+  tmp = (uint16_t)(TIM_ICPolarity << 4);
+
+  /* Select the Input and set the filter */
+  tmpccmr1 &= ((uint16_t)~TIM_CCMR1_CC2S) & ((uint16_t)~TIM_CCMR1_IC2F);
+  tmpccmr1 |= (uint16_t)(TIM_ICFilter << 12);
+  tmpccmr1 |= (uint16_t)(TIM_ICSelection << 8);
+
+  /* Select the Polarity and set the CC2E Bit */
+  tmpccer &= (uint16_t)~(TIM_CCER_CC2P | TIM_CCER_CC2NP);
+  tmpccer |=  (uint16_t)(tmp | (uint16_t)TIM_CCER_CC2E);
+
+  /* Write to TIMx CCMR1 and CCER registers */
+  TIMx->CCMR1 = tmpccmr1 ;
+  TIMx->CCER = tmpccer;
+}
+
+/**
+  * @brief  Configure the TI3 as Input.
+  * @param  TIMx: where x can be 1, 2, 3, 4, 5 or 8 to select the TIM peripheral.
+  * @param  TIM_ICPolarity : The Input Polarity.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_ICPolarity_Rising
+  *            @arg TIM_ICPolarity_Falling
+  *            @arg TIM_ICPolarity_BothEdge         
+  * @param  TIM_ICSelection: specifies the input to be used.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_ICSelection_DirectTI: TIM Input 3 is selected to be connected to IC3.
+  *            @arg TIM_ICSelection_IndirectTI: TIM Input 3 is selected to be connected to IC4.
+  *            @arg TIM_ICSelection_TRC: TIM Input 3 is selected to be connected to TRC.
+  * @param  TIM_ICFilter: Specifies the Input Capture Filter.
+  *          This parameter must be a value between 0x00 and 0x0F.
+  * @retval None
+  */
+static void TI3_Config(TIM_TypeDef* TIMx, uint16_t TIM_ICPolarity, uint16_t TIM_ICSelection,
+                       uint16_t TIM_ICFilter)
+{
+  uint16_t tmpccmr2 = 0, tmpccer = 0, tmp = 0;
+
+  /* Disable the Channel 3: Reset the CC3E Bit */
+  TIMx->CCER &= (uint16_t)~TIM_CCER_CC3E;
+  tmpccmr2 = TIMx->CCMR2;
+  tmpccer = TIMx->CCER;
+  tmp = (uint16_t)(TIM_ICPolarity << 8);
+
+  /* Select the Input and set the filter */
+  tmpccmr2 &= ((uint16_t)~TIM_CCMR1_CC1S) & ((uint16_t)~TIM_CCMR2_IC3F);
+  tmpccmr2 |= (uint16_t)(TIM_ICSelection | (uint16_t)(TIM_ICFilter << (uint16_t)4));
+
+  /* Select the Polarity and set the CC3E Bit */
+  tmpccer &= (uint16_t)~(TIM_CCER_CC3P | TIM_CCER_CC3NP);
+  tmpccer |= (uint16_t)(tmp | (uint16_t)TIM_CCER_CC3E);
+
+  /* Write to TIMx CCMR2 and CCER registers */
+  TIMx->CCMR2 = tmpccmr2;
+  TIMx->CCER = tmpccer;
+}
+
+/**
+  * @brief  Configure the TI4 as Input.
+  * @param  TIMx: where x can be 1, 2, 3, 4, 5 or 8 to select the TIM peripheral.
+  * @param  TIM_ICPolarity : The Input Polarity.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_ICPolarity_Rising
+  *            @arg TIM_ICPolarity_Falling
+  *            @arg TIM_ICPolarity_BothEdge     
+  * @param  TIM_ICSelection: specifies the input to be used.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_ICSelection_DirectTI: TIM Input 4 is selected to be connected to IC4.
+  *            @arg TIM_ICSelection_IndirectTI: TIM Input 4 is selected to be connected to IC3.
+  *            @arg TIM_ICSelection_TRC: TIM Input 4 is selected to be connected to TRC.
+  * @param  TIM_ICFilter: Specifies the Input Capture Filter.
+  *          This parameter must be a value between 0x00 and 0x0F.
+  * @retval None
+  */
+static void TI4_Config(TIM_TypeDef* TIMx, uint16_t TIM_ICPolarity, uint16_t TIM_ICSelection,
+                       uint16_t TIM_ICFilter)
+{
+  uint16_t tmpccmr2 = 0, tmpccer = 0, tmp = 0;
+
+  /* Disable the Channel 4: Reset the CC4E Bit */
+  TIMx->CCER &= (uint16_t)~TIM_CCER_CC4E;
+  tmpccmr2 = TIMx->CCMR2;
+  tmpccer = TIMx->CCER;
+  tmp = (uint16_t)(TIM_ICPolarity << 12);
+
+  /* Select the Input and set the filter */
+  tmpccmr2 &= ((uint16_t)~TIM_CCMR1_CC2S) & ((uint16_t)~TIM_CCMR1_IC2F);
+  tmpccmr2 |= (uint16_t)(TIM_ICSelection << 8);
+  tmpccmr2 |= (uint16_t)(TIM_ICFilter << 12);
+
+  /* Select the Polarity and set the CC4E Bit */
+  tmpccer &= (uint16_t)~(TIM_CCER_CC4P | TIM_CCER_CC4NP);
+  tmpccer |= (uint16_t)(tmp | (uint16_t)TIM_CCER_CC4E);
+
+  /* Write to TIMx CCMR2 and CCER registers */
+  TIMx->CCMR2 = tmpccmr2;
+  TIMx->CCER = tmpccer ;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/src/lib/stm32f4xx_tim.h
+++ b/src/lib/stm32f4xx_tim.h
@@ -1,0 +1,1150 @@
+/**
+  ******************************************************************************
+  * @file    stm32f4xx_tim.h
+  * @author  MCD Application Team
+  * @version V1.0.2
+  * @date    05-March-2012
+  * @brief   This file contains all the functions prototypes for the TIM firmware 
+  *          library.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT 2012 STMicroelectronics</center></h2>
+  *
+  * Licensed under MCD-ST Liberty SW License Agreement V2, (the "License");
+  * You may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at:
+  *
+  *        http://www.st.com/software_license_agreement_liberty_v2
+  *
+  * Unless required by applicable law or agreed to in writing, software 
+  * distributed under the License is distributed on an "AS IS" BASIS, 
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32F4xx_TIM_H
+#define __STM32F4xx_TIM_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f4xx.h"
+
+/** @addtogroup STM32F4xx_StdPeriph_Driver
+  * @{
+  */
+
+/** @addtogroup TIM
+  * @{
+  */ 
+
+/* Exported types ------------------------------------------------------------*/
+
+/** 
+  * @brief  TIM Time Base Init structure definition  
+  * @note   This structure is used with all TIMx except for TIM6 and TIM7.  
+  */
+
+typedef struct
+{
+  uint16_t TIM_Prescaler;         /*!< Specifies the prescaler value used to divide the TIM clock.
+                                       This parameter can be a number between 0x0000 and 0xFFFF */
+
+  uint16_t TIM_CounterMode;       /*!< Specifies the counter mode.
+                                       This parameter can be a value of @ref TIM_Counter_Mode */
+
+  uint32_t TIM_Period;            /*!< Specifies the period value to be loaded into the active
+                                       Auto-Reload Register at the next update event.
+                                       This parameter must be a number between 0x0000 and 0xFFFF.  */ 
+
+  uint16_t TIM_ClockDivision;     /*!< Specifies the clock division.
+                                      This parameter can be a value of @ref TIM_Clock_Division_CKD */
+
+  uint8_t TIM_RepetitionCounter;  /*!< Specifies the repetition counter value. Each time the RCR downcounter
+                                       reaches zero, an update event is generated and counting restarts
+                                       from the RCR value (N).
+                                       This means in PWM mode that (N+1) corresponds to:
+                                          - the number of PWM periods in edge-aligned mode
+                                          - the number of half PWM period in center-aligned mode
+                                       This parameter must be a number between 0x00 and 0xFF. 
+                                       @note This parameter is valid only for TIM1 and TIM8. */
+} TIM_TimeBaseInitTypeDef; 
+
+/** 
+  * @brief  TIM Output Compare Init structure definition  
+  */
+
+typedef struct
+{
+  uint16_t TIM_OCMode;        /*!< Specifies the TIM mode.
+                                   This parameter can be a value of @ref TIM_Output_Compare_and_PWM_modes */
+
+  uint16_t TIM_OutputState;   /*!< Specifies the TIM Output Compare state.
+                                   This parameter can be a value of @ref TIM_Output_Compare_State */
+
+  uint16_t TIM_OutputNState;  /*!< Specifies the TIM complementary Output Compare state.
+                                   This parameter can be a value of @ref TIM_Output_Compare_N_State
+                                   @note This parameter is valid only for TIM1 and TIM8. */
+
+  uint32_t TIM_Pulse;         /*!< Specifies the pulse value to be loaded into the Capture Compare Register. 
+                                   This parameter can be a number between 0x0000 and 0xFFFF */
+
+  uint16_t TIM_OCPolarity;    /*!< Specifies the output polarity.
+                                   This parameter can be a value of @ref TIM_Output_Compare_Polarity */
+
+  uint16_t TIM_OCNPolarity;   /*!< Specifies the complementary output polarity.
+                                   This parameter can be a value of @ref TIM_Output_Compare_N_Polarity
+                                   @note This parameter is valid only for TIM1 and TIM8. */
+
+  uint16_t TIM_OCIdleState;   /*!< Specifies the TIM Output Compare pin state during Idle state.
+                                   This parameter can be a value of @ref TIM_Output_Compare_Idle_State
+                                   @note This parameter is valid only for TIM1 and TIM8. */
+
+  uint16_t TIM_OCNIdleState;  /*!< Specifies the TIM Output Compare pin state during Idle state.
+                                   This parameter can be a value of @ref TIM_Output_Compare_N_Idle_State
+                                   @note This parameter is valid only for TIM1 and TIM8. */
+} TIM_OCInitTypeDef;
+
+/** 
+  * @brief  TIM Input Capture Init structure definition  
+  */
+
+typedef struct
+{
+
+  uint16_t TIM_Channel;      /*!< Specifies the TIM channel.
+                                  This parameter can be a value of @ref TIM_Channel */
+
+  uint16_t TIM_ICPolarity;   /*!< Specifies the active edge of the input signal.
+                                  This parameter can be a value of @ref TIM_Input_Capture_Polarity */
+
+  uint16_t TIM_ICSelection;  /*!< Specifies the input.
+                                  This parameter can be a value of @ref TIM_Input_Capture_Selection */
+
+  uint16_t TIM_ICPrescaler;  /*!< Specifies the Input Capture Prescaler.
+                                  This parameter can be a value of @ref TIM_Input_Capture_Prescaler */
+
+  uint16_t TIM_ICFilter;     /*!< Specifies the input capture filter.
+                                  This parameter can be a number between 0x0 and 0xF */
+} TIM_ICInitTypeDef;
+
+/** 
+  * @brief  BDTR structure definition 
+  * @note   This structure is used only with TIM1 and TIM8.    
+  */
+
+typedef struct
+{
+
+  uint16_t TIM_OSSRState;        /*!< Specifies the Off-State selection used in Run mode.
+                                      This parameter can be a value of @ref TIM_OSSR_Off_State_Selection_for_Run_mode_state */
+
+  uint16_t TIM_OSSIState;        /*!< Specifies the Off-State used in Idle state.
+                                      This parameter can be a value of @ref TIM_OSSI_Off_State_Selection_for_Idle_mode_state */
+
+  uint16_t TIM_LOCKLevel;        /*!< Specifies the LOCK level parameters.
+                                      This parameter can be a value of @ref TIM_Lock_level */ 
+
+  uint16_t TIM_DeadTime;         /*!< Specifies the delay time between the switching-off and the
+                                      switching-on of the outputs.
+                                      This parameter can be a number between 0x00 and 0xFF  */
+
+  uint16_t TIM_Break;            /*!< Specifies whether the TIM Break input is enabled or not. 
+                                      This parameter can be a value of @ref TIM_Break_Input_enable_disable */
+
+  uint16_t TIM_BreakPolarity;    /*!< Specifies the TIM Break Input pin polarity.
+                                      This parameter can be a value of @ref TIM_Break_Polarity */
+
+  uint16_t TIM_AutomaticOutput;  /*!< Specifies whether the TIM Automatic Output feature is enabled or not. 
+                                      This parameter can be a value of @ref TIM_AOE_Bit_Set_Reset */
+} TIM_BDTRInitTypeDef;
+
+/* Exported constants --------------------------------------------------------*/
+
+/** @defgroup TIM_Exported_constants 
+  * @{
+  */
+
+#define IS_TIM_ALL_PERIPH(PERIPH) (((PERIPH) == TIM1) || \
+                                   ((PERIPH) == TIM2) || \
+                                   ((PERIPH) == TIM3) || \
+                                   ((PERIPH) == TIM4) || \
+                                   ((PERIPH) == TIM5) || \
+                                   ((PERIPH) == TIM6) || \
+                                   ((PERIPH) == TIM7) || \
+                                   ((PERIPH) == TIM8) || \
+                                   ((PERIPH) == TIM9) || \
+                                   ((PERIPH) == TIM10) || \
+                                   ((PERIPH) == TIM11) || \
+                                   ((PERIPH) == TIM12) || \
+                                   (((PERIPH) == TIM13) || \
+                                   ((PERIPH) == TIM14)))
+/* LIST1: TIM1, TIM2, TIM3, TIM4, TIM5, TIM8, TIM9, TIM10, TIM11, TIM12, TIM13 and TIM14 */                                         
+#define IS_TIM_LIST1_PERIPH(PERIPH) (((PERIPH) == TIM1) || \
+                                     ((PERIPH) == TIM2) || \
+                                     ((PERIPH) == TIM3) || \
+                                     ((PERIPH) == TIM4) || \
+                                     ((PERIPH) == TIM5) || \
+                                     ((PERIPH) == TIM8) || \
+                                     ((PERIPH) == TIM9) || \
+                                     ((PERIPH) == TIM10) || \
+                                     ((PERIPH) == TIM11) || \
+                                     ((PERIPH) == TIM12) || \
+                                     ((PERIPH) == TIM13) || \
+                                     ((PERIPH) == TIM14))
+                                     
+/* LIST2: TIM1, TIM2, TIM3, TIM4, TIM5, TIM8, TIM9 and TIM12 */
+#define IS_TIM_LIST2_PERIPH(PERIPH) (((PERIPH) == TIM1) || \
+                                     ((PERIPH) == TIM2) || \
+                                     ((PERIPH) == TIM3) || \
+                                     ((PERIPH) == TIM4) || \
+                                     ((PERIPH) == TIM5) || \
+                                     ((PERIPH) == TIM8) || \
+                                     ((PERIPH) == TIM9) || \
+                                     ((PERIPH) == TIM12))
+/* LIST3: TIM1, TIM2, TIM3, TIM4, TIM5 and TIM8 */
+#define IS_TIM_LIST3_PERIPH(PERIPH) (((PERIPH) == TIM1) || \
+                                     ((PERIPH) == TIM2) || \
+                                     ((PERIPH) == TIM3) || \
+                                     ((PERIPH) == TIM4) || \
+                                     ((PERIPH) == TIM5) || \
+                                     ((PERIPH) == TIM8))
+/* LIST4: TIM1 and TIM8 */
+#define IS_TIM_LIST4_PERIPH(PERIPH) (((PERIPH) == TIM1) || \
+                                     ((PERIPH) == TIM8))
+/* LIST5: TIM1, TIM2, TIM3, TIM4, TIM5, TIM6, TIM7 and TIM8 */
+#define IS_TIM_LIST5_PERIPH(PERIPH) (((PERIPH) == TIM1) || \
+                                     ((PERIPH) == TIM2) || \
+                                     ((PERIPH) == TIM3) || \
+                                     ((PERIPH) == TIM4) || \
+                                     ((PERIPH) == TIM5) || \
+                                     ((PERIPH) == TIM6) || \
+                                     ((PERIPH) == TIM7) || \
+                                     ((PERIPH) == TIM8))
+/* LIST6: TIM2, TIM5 and TIM11 */                               
+#define IS_TIM_LIST6_PERIPH(TIMx)(((TIMx) == TIM2) || \
+                                 ((TIMx) == TIM5) || \
+                                 ((TIMx) == TIM11))
+
+/** @defgroup TIM_Output_Compare_and_PWM_modes 
+  * @{
+  */
+
+#define TIM_OCMode_Timing                  ((uint16_t)0x0000)
+#define TIM_OCMode_Active                  ((uint16_t)0x0010)
+#define TIM_OCMode_Inactive                ((uint16_t)0x0020)
+#define TIM_OCMode_Toggle                  ((uint16_t)0x0030)
+#define TIM_OCMode_PWM1                    ((uint16_t)0x0060)
+#define TIM_OCMode_PWM2                    ((uint16_t)0x0070)
+#define IS_TIM_OC_MODE(MODE) (((MODE) == TIM_OCMode_Timing) || \
+                              ((MODE) == TIM_OCMode_Active) || \
+                              ((MODE) == TIM_OCMode_Inactive) || \
+                              ((MODE) == TIM_OCMode_Toggle)|| \
+                              ((MODE) == TIM_OCMode_PWM1) || \
+                              ((MODE) == TIM_OCMode_PWM2))
+#define IS_TIM_OCM(MODE) (((MODE) == TIM_OCMode_Timing) || \
+                          ((MODE) == TIM_OCMode_Active) || \
+                          ((MODE) == TIM_OCMode_Inactive) || \
+                          ((MODE) == TIM_OCMode_Toggle)|| \
+                          ((MODE) == TIM_OCMode_PWM1) || \
+                          ((MODE) == TIM_OCMode_PWM2) ||	\
+                          ((MODE) == TIM_ForcedAction_Active) || \
+                          ((MODE) == TIM_ForcedAction_InActive))
+/**
+  * @}
+  */
+
+/** @defgroup TIM_One_Pulse_Mode 
+  * @{
+  */
+
+#define TIM_OPMode_Single                  ((uint16_t)0x0008)
+#define TIM_OPMode_Repetitive              ((uint16_t)0x0000)
+#define IS_TIM_OPM_MODE(MODE) (((MODE) == TIM_OPMode_Single) || \
+                               ((MODE) == TIM_OPMode_Repetitive))
+/**
+  * @}
+  */ 
+
+/** @defgroup TIM_Channel 
+  * @{
+  */
+
+#define TIM_Channel_1                      ((uint16_t)0x0000)
+#define TIM_Channel_2                      ((uint16_t)0x0004)
+#define TIM_Channel_3                      ((uint16_t)0x0008)
+#define TIM_Channel_4                      ((uint16_t)0x000C)
+                                 
+#define IS_TIM_CHANNEL(CHANNEL) (((CHANNEL) == TIM_Channel_1) || \
+                                 ((CHANNEL) == TIM_Channel_2) || \
+                                 ((CHANNEL) == TIM_Channel_3) || \
+                                 ((CHANNEL) == TIM_Channel_4))
+                                 
+#define IS_TIM_PWMI_CHANNEL(CHANNEL) (((CHANNEL) == TIM_Channel_1) || \
+                                      ((CHANNEL) == TIM_Channel_2))
+#define IS_TIM_COMPLEMENTARY_CHANNEL(CHANNEL) (((CHANNEL) == TIM_Channel_1) || \
+                                               ((CHANNEL) == TIM_Channel_2) || \
+                                               ((CHANNEL) == TIM_Channel_3))
+/**
+  * @}
+  */ 
+
+/** @defgroup TIM_Clock_Division_CKD 
+  * @{
+  */
+
+#define TIM_CKD_DIV1                       ((uint16_t)0x0000)
+#define TIM_CKD_DIV2                       ((uint16_t)0x0100)
+#define TIM_CKD_DIV4                       ((uint16_t)0x0200)
+#define IS_TIM_CKD_DIV(DIV) (((DIV) == TIM_CKD_DIV1) || \
+                             ((DIV) == TIM_CKD_DIV2) || \
+                             ((DIV) == TIM_CKD_DIV4))
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Counter_Mode 
+  * @{
+  */
+
+#define TIM_CounterMode_Up                 ((uint16_t)0x0000)
+#define TIM_CounterMode_Down               ((uint16_t)0x0010)
+#define TIM_CounterMode_CenterAligned1     ((uint16_t)0x0020)
+#define TIM_CounterMode_CenterAligned2     ((uint16_t)0x0040)
+#define TIM_CounterMode_CenterAligned3     ((uint16_t)0x0060)
+#define IS_TIM_COUNTER_MODE(MODE) (((MODE) == TIM_CounterMode_Up) ||  \
+                                   ((MODE) == TIM_CounterMode_Down) || \
+                                   ((MODE) == TIM_CounterMode_CenterAligned1) || \
+                                   ((MODE) == TIM_CounterMode_CenterAligned2) || \
+                                   ((MODE) == TIM_CounterMode_CenterAligned3))
+/**
+  * @}
+  */ 
+
+/** @defgroup TIM_Output_Compare_Polarity 
+  * @{
+  */
+
+#define TIM_OCPolarity_High                ((uint16_t)0x0000)
+#define TIM_OCPolarity_Low                 ((uint16_t)0x0002)
+#define IS_TIM_OC_POLARITY(POLARITY) (((POLARITY) == TIM_OCPolarity_High) || \
+                                      ((POLARITY) == TIM_OCPolarity_Low))
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Output_Compare_N_Polarity 
+  * @{
+  */
+  
+#define TIM_OCNPolarity_High               ((uint16_t)0x0000)
+#define TIM_OCNPolarity_Low                ((uint16_t)0x0008)
+#define IS_TIM_OCN_POLARITY(POLARITY) (((POLARITY) == TIM_OCNPolarity_High) || \
+                                       ((POLARITY) == TIM_OCNPolarity_Low))
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Output_Compare_State 
+  * @{
+  */
+
+#define TIM_OutputState_Disable            ((uint16_t)0x0000)
+#define TIM_OutputState_Enable             ((uint16_t)0x0001)
+#define IS_TIM_OUTPUT_STATE(STATE) (((STATE) == TIM_OutputState_Disable) || \
+                                    ((STATE) == TIM_OutputState_Enable))
+/**
+  * @}
+  */ 
+
+/** @defgroup TIM_Output_Compare_N_State
+  * @{
+  */
+
+#define TIM_OutputNState_Disable           ((uint16_t)0x0000)
+#define TIM_OutputNState_Enable            ((uint16_t)0x0004)
+#define IS_TIM_OUTPUTN_STATE(STATE) (((STATE) == TIM_OutputNState_Disable) || \
+                                     ((STATE) == TIM_OutputNState_Enable))
+/**
+  * @}
+  */ 
+
+/** @defgroup TIM_Capture_Compare_State
+  * @{
+  */
+
+#define TIM_CCx_Enable                      ((uint16_t)0x0001)
+#define TIM_CCx_Disable                     ((uint16_t)0x0000)
+#define IS_TIM_CCX(CCX) (((CCX) == TIM_CCx_Enable) || \
+                         ((CCX) == TIM_CCx_Disable))
+/**
+  * @}
+  */ 
+
+/** @defgroup TIM_Capture_Compare_N_State
+  * @{
+  */
+
+#define TIM_CCxN_Enable                     ((uint16_t)0x0004)
+#define TIM_CCxN_Disable                    ((uint16_t)0x0000)
+#define IS_TIM_CCXN(CCXN) (((CCXN) == TIM_CCxN_Enable) || \
+                           ((CCXN) == TIM_CCxN_Disable))
+/**
+  * @}
+  */ 
+
+/** @defgroup TIM_Break_Input_enable_disable 
+  * @{
+  */
+
+#define TIM_Break_Enable                   ((uint16_t)0x1000)
+#define TIM_Break_Disable                  ((uint16_t)0x0000)
+#define IS_TIM_BREAK_STATE(STATE) (((STATE) == TIM_Break_Enable) || \
+                                   ((STATE) == TIM_Break_Disable))
+/**
+  * @}
+  */ 
+
+/** @defgroup TIM_Break_Polarity 
+  * @{
+  */
+
+#define TIM_BreakPolarity_Low              ((uint16_t)0x0000)
+#define TIM_BreakPolarity_High             ((uint16_t)0x2000)
+#define IS_TIM_BREAK_POLARITY(POLARITY) (((POLARITY) == TIM_BreakPolarity_Low) || \
+                                         ((POLARITY) == TIM_BreakPolarity_High))
+/**
+  * @}
+  */ 
+
+/** @defgroup TIM_AOE_Bit_Set_Reset 
+  * @{
+  */
+
+#define TIM_AutomaticOutput_Enable         ((uint16_t)0x4000)
+#define TIM_AutomaticOutput_Disable        ((uint16_t)0x0000)
+#define IS_TIM_AUTOMATIC_OUTPUT_STATE(STATE) (((STATE) == TIM_AutomaticOutput_Enable) || \
+                                              ((STATE) == TIM_AutomaticOutput_Disable))
+/**
+  * @}
+  */ 
+
+/** @defgroup TIM_Lock_level
+  * @{
+  */
+
+#define TIM_LOCKLevel_OFF                  ((uint16_t)0x0000)
+#define TIM_LOCKLevel_1                    ((uint16_t)0x0100)
+#define TIM_LOCKLevel_2                    ((uint16_t)0x0200)
+#define TIM_LOCKLevel_3                    ((uint16_t)0x0300)
+#define IS_TIM_LOCK_LEVEL(LEVEL) (((LEVEL) == TIM_LOCKLevel_OFF) || \
+                                  ((LEVEL) == TIM_LOCKLevel_1) || \
+                                  ((LEVEL) == TIM_LOCKLevel_2) || \
+                                  ((LEVEL) == TIM_LOCKLevel_3))
+/**
+  * @}
+  */ 
+
+/** @defgroup TIM_OSSI_Off_State_Selection_for_Idle_mode_state 
+  * @{
+  */
+
+#define TIM_OSSIState_Enable               ((uint16_t)0x0400)
+#define TIM_OSSIState_Disable              ((uint16_t)0x0000)
+#define IS_TIM_OSSI_STATE(STATE) (((STATE) == TIM_OSSIState_Enable) || \
+                                  ((STATE) == TIM_OSSIState_Disable))
+/**
+  * @}
+  */
+
+/** @defgroup TIM_OSSR_Off_State_Selection_for_Run_mode_state
+  * @{
+  */
+
+#define TIM_OSSRState_Enable               ((uint16_t)0x0800)
+#define TIM_OSSRState_Disable              ((uint16_t)0x0000)
+#define IS_TIM_OSSR_STATE(STATE) (((STATE) == TIM_OSSRState_Enable) || \
+                                  ((STATE) == TIM_OSSRState_Disable))
+/**
+  * @}
+  */ 
+
+/** @defgroup TIM_Output_Compare_Idle_State 
+  * @{
+  */
+
+#define TIM_OCIdleState_Set                ((uint16_t)0x0100)
+#define TIM_OCIdleState_Reset              ((uint16_t)0x0000)
+#define IS_TIM_OCIDLE_STATE(STATE) (((STATE) == TIM_OCIdleState_Set) || \
+                                    ((STATE) == TIM_OCIdleState_Reset))
+/**
+  * @}
+  */ 
+
+/** @defgroup TIM_Output_Compare_N_Idle_State 
+  * @{
+  */
+
+#define TIM_OCNIdleState_Set               ((uint16_t)0x0200)
+#define TIM_OCNIdleState_Reset             ((uint16_t)0x0000)
+#define IS_TIM_OCNIDLE_STATE(STATE) (((STATE) == TIM_OCNIdleState_Set) || \
+                                     ((STATE) == TIM_OCNIdleState_Reset))
+/**
+  * @}
+  */ 
+
+/** @defgroup TIM_Input_Capture_Polarity 
+  * @{
+  */
+
+#define  TIM_ICPolarity_Rising             ((uint16_t)0x0000)
+#define  TIM_ICPolarity_Falling            ((uint16_t)0x0002)
+#define  TIM_ICPolarity_BothEdge           ((uint16_t)0x000A)
+#define IS_TIM_IC_POLARITY(POLARITY) (((POLARITY) == TIM_ICPolarity_Rising) || \
+                                      ((POLARITY) == TIM_ICPolarity_Falling)|| \
+                                      ((POLARITY) == TIM_ICPolarity_BothEdge))
+/**
+  * @}
+  */ 
+
+/** @defgroup TIM_Input_Capture_Selection 
+  * @{
+  */
+
+#define TIM_ICSelection_DirectTI           ((uint16_t)0x0001) /*!< TIM Input 1, 2, 3 or 4 is selected to be 
+                                                                   connected to IC1, IC2, IC3 or IC4, respectively */
+#define TIM_ICSelection_IndirectTI         ((uint16_t)0x0002) /*!< TIM Input 1, 2, 3 or 4 is selected to be
+                                                                   connected to IC2, IC1, IC4 or IC3, respectively. */
+#define TIM_ICSelection_TRC                ((uint16_t)0x0003) /*!< TIM Input 1, 2, 3 or 4 is selected to be connected to TRC. */
+#define IS_TIM_IC_SELECTION(SELECTION) (((SELECTION) == TIM_ICSelection_DirectTI) || \
+                                        ((SELECTION) == TIM_ICSelection_IndirectTI) || \
+                                        ((SELECTION) == TIM_ICSelection_TRC))
+/**
+  * @}
+  */ 
+
+/** @defgroup TIM_Input_Capture_Prescaler 
+  * @{
+  */
+
+#define TIM_ICPSC_DIV1                     ((uint16_t)0x0000) /*!< Capture performed each time an edge is detected on the capture input. */
+#define TIM_ICPSC_DIV2                     ((uint16_t)0x0004) /*!< Capture performed once every 2 events. */
+#define TIM_ICPSC_DIV4                     ((uint16_t)0x0008) /*!< Capture performed once every 4 events. */
+#define TIM_ICPSC_DIV8                     ((uint16_t)0x000C) /*!< Capture performed once every 8 events. */
+#define IS_TIM_IC_PRESCALER(PRESCALER) (((PRESCALER) == TIM_ICPSC_DIV1) || \
+                                        ((PRESCALER) == TIM_ICPSC_DIV2) || \
+                                        ((PRESCALER) == TIM_ICPSC_DIV4) || \
+                                        ((PRESCALER) == TIM_ICPSC_DIV8))
+/**
+  * @}
+  */ 
+
+/** @defgroup TIM_interrupt_sources 
+  * @{
+  */
+
+#define TIM_IT_Update                      ((uint16_t)0x0001)
+#define TIM_IT_CC1                         ((uint16_t)0x0002)
+#define TIM_IT_CC2                         ((uint16_t)0x0004)
+#define TIM_IT_CC3                         ((uint16_t)0x0008)
+#define TIM_IT_CC4                         ((uint16_t)0x0010)
+#define TIM_IT_COM                         ((uint16_t)0x0020)
+#define TIM_IT_Trigger                     ((uint16_t)0x0040)
+#define TIM_IT_Break                       ((uint16_t)0x0080)
+#define IS_TIM_IT(IT) ((((IT) & (uint16_t)0xFF00) == 0x0000) && ((IT) != 0x0000))
+
+#define IS_TIM_GET_IT(IT) (((IT) == TIM_IT_Update) || \
+                           ((IT) == TIM_IT_CC1) || \
+                           ((IT) == TIM_IT_CC2) || \
+                           ((IT) == TIM_IT_CC3) || \
+                           ((IT) == TIM_IT_CC4) || \
+                           ((IT) == TIM_IT_COM) || \
+                           ((IT) == TIM_IT_Trigger) || \
+                           ((IT) == TIM_IT_Break))
+/**
+  * @}
+  */ 
+
+/** @defgroup TIM_DMA_Base_address 
+  * @{
+  */
+
+#define TIM_DMABase_CR1                    ((uint16_t)0x0000)
+#define TIM_DMABase_CR2                    ((uint16_t)0x0001)
+#define TIM_DMABase_SMCR                   ((uint16_t)0x0002)
+#define TIM_DMABase_DIER                   ((uint16_t)0x0003)
+#define TIM_DMABase_SR                     ((uint16_t)0x0004)
+#define TIM_DMABase_EGR                    ((uint16_t)0x0005)
+#define TIM_DMABase_CCMR1                  ((uint16_t)0x0006)
+#define TIM_DMABase_CCMR2                  ((uint16_t)0x0007)
+#define TIM_DMABase_CCER                   ((uint16_t)0x0008)
+#define TIM_DMABase_CNT                    ((uint16_t)0x0009)
+#define TIM_DMABase_PSC                    ((uint16_t)0x000A)
+#define TIM_DMABase_ARR                    ((uint16_t)0x000B)
+#define TIM_DMABase_RCR                    ((uint16_t)0x000C)
+#define TIM_DMABase_CCR1                   ((uint16_t)0x000D)
+#define TIM_DMABase_CCR2                   ((uint16_t)0x000E)
+#define TIM_DMABase_CCR3                   ((uint16_t)0x000F)
+#define TIM_DMABase_CCR4                   ((uint16_t)0x0010)
+#define TIM_DMABase_BDTR                   ((uint16_t)0x0011)
+#define TIM_DMABase_DCR                    ((uint16_t)0x0012)
+#define TIM_DMABase_OR                     ((uint16_t)0x0013)
+#define IS_TIM_DMA_BASE(BASE) (((BASE) == TIM_DMABase_CR1) || \
+                               ((BASE) == TIM_DMABase_CR2) || \
+                               ((BASE) == TIM_DMABase_SMCR) || \
+                               ((BASE) == TIM_DMABase_DIER) || \
+                               ((BASE) == TIM_DMABase_SR) || \
+                               ((BASE) == TIM_DMABase_EGR) || \
+                               ((BASE) == TIM_DMABase_CCMR1) || \
+                               ((BASE) == TIM_DMABase_CCMR2) || \
+                               ((BASE) == TIM_DMABase_CCER) || \
+                               ((BASE) == TIM_DMABase_CNT) || \
+                               ((BASE) == TIM_DMABase_PSC) || \
+                               ((BASE) == TIM_DMABase_ARR) || \
+                               ((BASE) == TIM_DMABase_RCR) || \
+                               ((BASE) == TIM_DMABase_CCR1) || \
+                               ((BASE) == TIM_DMABase_CCR2) || \
+                               ((BASE) == TIM_DMABase_CCR3) || \
+                               ((BASE) == TIM_DMABase_CCR4) || \
+                               ((BASE) == TIM_DMABase_BDTR) || \
+                               ((BASE) == TIM_DMABase_DCR) || \
+                               ((BASE) == TIM_DMABase_OR))                     
+/**
+  * @}
+  */ 
+
+/** @defgroup TIM_DMA_Burst_Length 
+  * @{
+  */
+
+#define TIM_DMABurstLength_1Transfer           ((uint16_t)0x0000)
+#define TIM_DMABurstLength_2Transfers          ((uint16_t)0x0100)
+#define TIM_DMABurstLength_3Transfers          ((uint16_t)0x0200)
+#define TIM_DMABurstLength_4Transfers          ((uint16_t)0x0300)
+#define TIM_DMABurstLength_5Transfers          ((uint16_t)0x0400)
+#define TIM_DMABurstLength_6Transfers          ((uint16_t)0x0500)
+#define TIM_DMABurstLength_7Transfers          ((uint16_t)0x0600)
+#define TIM_DMABurstLength_8Transfers          ((uint16_t)0x0700)
+#define TIM_DMABurstLength_9Transfers          ((uint16_t)0x0800)
+#define TIM_DMABurstLength_10Transfers         ((uint16_t)0x0900)
+#define TIM_DMABurstLength_11Transfers         ((uint16_t)0x0A00)
+#define TIM_DMABurstLength_12Transfers         ((uint16_t)0x0B00)
+#define TIM_DMABurstLength_13Transfers         ((uint16_t)0x0C00)
+#define TIM_DMABurstLength_14Transfers         ((uint16_t)0x0D00)
+#define TIM_DMABurstLength_15Transfers         ((uint16_t)0x0E00)
+#define TIM_DMABurstLength_16Transfers         ((uint16_t)0x0F00)
+#define TIM_DMABurstLength_17Transfers         ((uint16_t)0x1000)
+#define TIM_DMABurstLength_18Transfers         ((uint16_t)0x1100)
+#define IS_TIM_DMA_LENGTH(LENGTH) (((LENGTH) == TIM_DMABurstLength_1Transfer) || \
+                                   ((LENGTH) == TIM_DMABurstLength_2Transfers) || \
+                                   ((LENGTH) == TIM_DMABurstLength_3Transfers) || \
+                                   ((LENGTH) == TIM_DMABurstLength_4Transfers) || \
+                                   ((LENGTH) == TIM_DMABurstLength_5Transfers) || \
+                                   ((LENGTH) == TIM_DMABurstLength_6Transfers) || \
+                                   ((LENGTH) == TIM_DMABurstLength_7Transfers) || \
+                                   ((LENGTH) == TIM_DMABurstLength_8Transfers) || \
+                                   ((LENGTH) == TIM_DMABurstLength_9Transfers) || \
+                                   ((LENGTH) == TIM_DMABurstLength_10Transfers) || \
+                                   ((LENGTH) == TIM_DMABurstLength_11Transfers) || \
+                                   ((LENGTH) == TIM_DMABurstLength_12Transfers) || \
+                                   ((LENGTH) == TIM_DMABurstLength_13Transfers) || \
+                                   ((LENGTH) == TIM_DMABurstLength_14Transfers) || \
+                                   ((LENGTH) == TIM_DMABurstLength_15Transfers) || \
+                                   ((LENGTH) == TIM_DMABurstLength_16Transfers) || \
+                                   ((LENGTH) == TIM_DMABurstLength_17Transfers) || \
+                                   ((LENGTH) == TIM_DMABurstLength_18Transfers))
+/**
+  * @}
+  */ 
+
+/** @defgroup TIM_DMA_sources 
+  * @{
+  */
+
+#define TIM_DMA_Update                     ((uint16_t)0x0100)
+#define TIM_DMA_CC1                        ((uint16_t)0x0200)
+#define TIM_DMA_CC2                        ((uint16_t)0x0400)
+#define TIM_DMA_CC3                        ((uint16_t)0x0800)
+#define TIM_DMA_CC4                        ((uint16_t)0x1000)
+#define TIM_DMA_COM                        ((uint16_t)0x2000)
+#define TIM_DMA_Trigger                    ((uint16_t)0x4000)
+#define IS_TIM_DMA_SOURCE(SOURCE) ((((SOURCE) & (uint16_t)0x80FF) == 0x0000) && ((SOURCE) != 0x0000))
+
+/**
+  * @}
+  */ 
+
+/** @defgroup TIM_External_Trigger_Prescaler 
+  * @{
+  */
+
+#define TIM_ExtTRGPSC_OFF                  ((uint16_t)0x0000)
+#define TIM_ExtTRGPSC_DIV2                 ((uint16_t)0x1000)
+#define TIM_ExtTRGPSC_DIV4                 ((uint16_t)0x2000)
+#define TIM_ExtTRGPSC_DIV8                 ((uint16_t)0x3000)
+#define IS_TIM_EXT_PRESCALER(PRESCALER) (((PRESCALER) == TIM_ExtTRGPSC_OFF) || \
+                                         ((PRESCALER) == TIM_ExtTRGPSC_DIV2) || \
+                                         ((PRESCALER) == TIM_ExtTRGPSC_DIV4) || \
+                                         ((PRESCALER) == TIM_ExtTRGPSC_DIV8))
+/**
+  * @}
+  */ 
+
+/** @defgroup TIM_Internal_Trigger_Selection 
+  * @{
+  */
+
+#define TIM_TS_ITR0                        ((uint16_t)0x0000)
+#define TIM_TS_ITR1                        ((uint16_t)0x0010)
+#define TIM_TS_ITR2                        ((uint16_t)0x0020)
+#define TIM_TS_ITR3                        ((uint16_t)0x0030)
+#define TIM_TS_TI1F_ED                     ((uint16_t)0x0040)
+#define TIM_TS_TI1FP1                      ((uint16_t)0x0050)
+#define TIM_TS_TI2FP2                      ((uint16_t)0x0060)
+#define TIM_TS_ETRF                        ((uint16_t)0x0070)
+#define IS_TIM_TRIGGER_SELECTION(SELECTION) (((SELECTION) == TIM_TS_ITR0) || \
+                                             ((SELECTION) == TIM_TS_ITR1) || \
+                                             ((SELECTION) == TIM_TS_ITR2) || \
+                                             ((SELECTION) == TIM_TS_ITR3) || \
+                                             ((SELECTION) == TIM_TS_TI1F_ED) || \
+                                             ((SELECTION) == TIM_TS_TI1FP1) || \
+                                             ((SELECTION) == TIM_TS_TI2FP2) || \
+                                             ((SELECTION) == TIM_TS_ETRF))
+#define IS_TIM_INTERNAL_TRIGGER_SELECTION(SELECTION) (((SELECTION) == TIM_TS_ITR0) || \
+                                                      ((SELECTION) == TIM_TS_ITR1) || \
+                                                      ((SELECTION) == TIM_TS_ITR2) || \
+                                                      ((SELECTION) == TIM_TS_ITR3))
+/**
+  * @}
+  */ 
+
+/** @defgroup TIM_TIx_External_Clock_Source 
+  * @{
+  */
+
+#define TIM_TIxExternalCLK1Source_TI1      ((uint16_t)0x0050)
+#define TIM_TIxExternalCLK1Source_TI2      ((uint16_t)0x0060)
+#define TIM_TIxExternalCLK1Source_TI1ED    ((uint16_t)0x0040)
+
+/**
+  * @}
+  */ 
+
+/** @defgroup TIM_External_Trigger_Polarity 
+  * @{
+  */ 
+#define TIM_ExtTRGPolarity_Inverted        ((uint16_t)0x8000)
+#define TIM_ExtTRGPolarity_NonInverted     ((uint16_t)0x0000)
+#define IS_TIM_EXT_POLARITY(POLARITY) (((POLARITY) == TIM_ExtTRGPolarity_Inverted) || \
+                                       ((POLARITY) == TIM_ExtTRGPolarity_NonInverted))
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Prescaler_Reload_Mode 
+  * @{
+  */
+
+#define TIM_PSCReloadMode_Update           ((uint16_t)0x0000)
+#define TIM_PSCReloadMode_Immediate        ((uint16_t)0x0001)
+#define IS_TIM_PRESCALER_RELOAD(RELOAD) (((RELOAD) == TIM_PSCReloadMode_Update) || \
+                                         ((RELOAD) == TIM_PSCReloadMode_Immediate))
+/**
+  * @}
+  */ 
+
+/** @defgroup TIM_Forced_Action 
+  * @{
+  */
+
+#define TIM_ForcedAction_Active            ((uint16_t)0x0050)
+#define TIM_ForcedAction_InActive          ((uint16_t)0x0040)
+#define IS_TIM_FORCED_ACTION(ACTION) (((ACTION) == TIM_ForcedAction_Active) || \
+                                      ((ACTION) == TIM_ForcedAction_InActive))
+/**
+  * @}
+  */ 
+
+/** @defgroup TIM_Encoder_Mode 
+  * @{
+  */
+
+#define TIM_EncoderMode_TI1                ((uint16_t)0x0001)
+#define TIM_EncoderMode_TI2                ((uint16_t)0x0002)
+#define TIM_EncoderMode_TI12               ((uint16_t)0x0003)
+#define IS_TIM_ENCODER_MODE(MODE) (((MODE) == TIM_EncoderMode_TI1) || \
+                                   ((MODE) == TIM_EncoderMode_TI2) || \
+                                   ((MODE) == TIM_EncoderMode_TI12))
+/**
+  * @}
+  */ 
+
+
+/** @defgroup TIM_Event_Source 
+  * @{
+  */
+
+#define TIM_EventSource_Update             ((uint16_t)0x0001)
+#define TIM_EventSource_CC1                ((uint16_t)0x0002)
+#define TIM_EventSource_CC2                ((uint16_t)0x0004)
+#define TIM_EventSource_CC3                ((uint16_t)0x0008)
+#define TIM_EventSource_CC4                ((uint16_t)0x0010)
+#define TIM_EventSource_COM                ((uint16_t)0x0020)
+#define TIM_EventSource_Trigger            ((uint16_t)0x0040)
+#define TIM_EventSource_Break              ((uint16_t)0x0080)
+#define IS_TIM_EVENT_SOURCE(SOURCE) ((((SOURCE) & (uint16_t)0xFF00) == 0x0000) && ((SOURCE) != 0x0000))                                          
+  
+/**
+  * @}
+  */ 
+
+/** @defgroup TIM_Update_Source 
+  * @{
+  */
+
+#define TIM_UpdateSource_Global            ((uint16_t)0x0000) /*!< Source of update is the counter overflow/underflow
+                                                                   or the setting of UG bit, or an update generation
+                                                                   through the slave mode controller. */
+#define TIM_UpdateSource_Regular           ((uint16_t)0x0001) /*!< Source of update is counter overflow/underflow. */
+#define IS_TIM_UPDATE_SOURCE(SOURCE) (((SOURCE) == TIM_UpdateSource_Global) || \
+                                      ((SOURCE) == TIM_UpdateSource_Regular))
+/**
+  * @}
+  */ 
+
+/** @defgroup TIM_Output_Compare_Preload_State 
+  * @{
+  */
+
+#define TIM_OCPreload_Enable               ((uint16_t)0x0008)
+#define TIM_OCPreload_Disable              ((uint16_t)0x0000)
+#define IS_TIM_OCPRELOAD_STATE(STATE) (((STATE) == TIM_OCPreload_Enable) || \
+                                       ((STATE) == TIM_OCPreload_Disable))
+/**
+  * @}
+  */ 
+
+/** @defgroup TIM_Output_Compare_Fast_State 
+  * @{
+  */
+
+#define TIM_OCFast_Enable                  ((uint16_t)0x0004)
+#define TIM_OCFast_Disable                 ((uint16_t)0x0000)
+#define IS_TIM_OCFAST_STATE(STATE) (((STATE) == TIM_OCFast_Enable) || \
+                                    ((STATE) == TIM_OCFast_Disable))
+                                     
+/**
+  * @}
+  */ 
+
+/** @defgroup TIM_Output_Compare_Clear_State 
+  * @{
+  */
+
+#define TIM_OCClear_Enable                 ((uint16_t)0x0080)
+#define TIM_OCClear_Disable                ((uint16_t)0x0000)
+#define IS_TIM_OCCLEAR_STATE(STATE) (((STATE) == TIM_OCClear_Enable) || \
+                                     ((STATE) == TIM_OCClear_Disable))
+/**
+  * @}
+  */ 
+
+/** @defgroup TIM_Trigger_Output_Source 
+  * @{
+  */
+
+#define TIM_TRGOSource_Reset               ((uint16_t)0x0000)
+#define TIM_TRGOSource_Enable              ((uint16_t)0x0010)
+#define TIM_TRGOSource_Update              ((uint16_t)0x0020)
+#define TIM_TRGOSource_OC1                 ((uint16_t)0x0030)
+#define TIM_TRGOSource_OC1Ref              ((uint16_t)0x0040)
+#define TIM_TRGOSource_OC2Ref              ((uint16_t)0x0050)
+#define TIM_TRGOSource_OC3Ref              ((uint16_t)0x0060)
+#define TIM_TRGOSource_OC4Ref              ((uint16_t)0x0070)
+#define IS_TIM_TRGO_SOURCE(SOURCE) (((SOURCE) == TIM_TRGOSource_Reset) || \
+                                    ((SOURCE) == TIM_TRGOSource_Enable) || \
+                                    ((SOURCE) == TIM_TRGOSource_Update) || \
+                                    ((SOURCE) == TIM_TRGOSource_OC1) || \
+                                    ((SOURCE) == TIM_TRGOSource_OC1Ref) || \
+                                    ((SOURCE) == TIM_TRGOSource_OC2Ref) || \
+                                    ((SOURCE) == TIM_TRGOSource_OC3Ref) || \
+                                    ((SOURCE) == TIM_TRGOSource_OC4Ref))
+/**
+  * @}
+  */ 
+
+/** @defgroup TIM_Slave_Mode 
+  * @{
+  */
+
+#define TIM_SlaveMode_Reset                ((uint16_t)0x0004)
+#define TIM_SlaveMode_Gated                ((uint16_t)0x0005)
+#define TIM_SlaveMode_Trigger              ((uint16_t)0x0006)
+#define TIM_SlaveMode_External1            ((uint16_t)0x0007)
+#define IS_TIM_SLAVE_MODE(MODE) (((MODE) == TIM_SlaveMode_Reset) || \
+                                 ((MODE) == TIM_SlaveMode_Gated) || \
+                                 ((MODE) == TIM_SlaveMode_Trigger) || \
+                                 ((MODE) == TIM_SlaveMode_External1))
+/**
+  * @}
+  */ 
+
+/** @defgroup TIM_Master_Slave_Mode 
+  * @{
+  */
+
+#define TIM_MasterSlaveMode_Enable         ((uint16_t)0x0080)
+#define TIM_MasterSlaveMode_Disable        ((uint16_t)0x0000)
+#define IS_TIM_MSM_STATE(STATE) (((STATE) == TIM_MasterSlaveMode_Enable) || \
+                                 ((STATE) == TIM_MasterSlaveMode_Disable))
+/**
+  * @}
+  */ 
+/** @defgroup TIM_Remap 
+  * @{
+  */
+
+#define TIM2_TIM8_TRGO                     ((uint16_t)0x0000)
+#define TIM2_ETH_PTP                       ((uint16_t)0x0400)
+#define TIM2_USBFS_SOF                     ((uint16_t)0x0800)
+#define TIM2_USBHS_SOF                     ((uint16_t)0x0C00)
+
+#define TIM5_GPIO                          ((uint16_t)0x0000)
+#define TIM5_LSI                           ((uint16_t)0x0040)
+#define TIM5_LSE                           ((uint16_t)0x0080)
+#define TIM5_RTC                           ((uint16_t)0x00C0)
+
+#define TIM11_GPIO                         ((uint16_t)0x0000)
+#define TIM11_HSE                          ((uint16_t)0x0002)
+
+#define IS_TIM_REMAP(TIM_REMAP)	 (((TIM_REMAP) == TIM2_TIM8_TRGO)||\
+                                  ((TIM_REMAP) == TIM2_ETH_PTP)||\
+                                  ((TIM_REMAP) == TIM2_USBFS_SOF)||\
+                                  ((TIM_REMAP) == TIM2_USBHS_SOF)||\
+                                  ((TIM_REMAP) == TIM5_GPIO)||\
+                                  ((TIM_REMAP) == TIM5_LSI)||\
+                                  ((TIM_REMAP) == TIM5_LSE)||\
+                                  ((TIM_REMAP) == TIM5_RTC)||\
+                                  ((TIM_REMAP) == TIM11_GPIO)||\
+                                  ((TIM_REMAP) == TIM11_HSE))
+
+/**
+  * @}
+  */ 
+/** @defgroup TIM_Flags 
+  * @{
+  */
+
+#define TIM_FLAG_Update                    ((uint16_t)0x0001)
+#define TIM_FLAG_CC1                       ((uint16_t)0x0002)
+#define TIM_FLAG_CC2                       ((uint16_t)0x0004)
+#define TIM_FLAG_CC3                       ((uint16_t)0x0008)
+#define TIM_FLAG_CC4                       ((uint16_t)0x0010)
+#define TIM_FLAG_COM                       ((uint16_t)0x0020)
+#define TIM_FLAG_Trigger                   ((uint16_t)0x0040)
+#define TIM_FLAG_Break                     ((uint16_t)0x0080)
+#define TIM_FLAG_CC1OF                     ((uint16_t)0x0200)
+#define TIM_FLAG_CC2OF                     ((uint16_t)0x0400)
+#define TIM_FLAG_CC3OF                     ((uint16_t)0x0800)
+#define TIM_FLAG_CC4OF                     ((uint16_t)0x1000)
+#define IS_TIM_GET_FLAG(FLAG) (((FLAG) == TIM_FLAG_Update) || \
+                               ((FLAG) == TIM_FLAG_CC1) || \
+                               ((FLAG) == TIM_FLAG_CC2) || \
+                               ((FLAG) == TIM_FLAG_CC3) || \
+                               ((FLAG) == TIM_FLAG_CC4) || \
+                               ((FLAG) == TIM_FLAG_COM) || \
+                               ((FLAG) == TIM_FLAG_Trigger) || \
+                               ((FLAG) == TIM_FLAG_Break) || \
+                               ((FLAG) == TIM_FLAG_CC1OF) || \
+                               ((FLAG) == TIM_FLAG_CC2OF) || \
+                               ((FLAG) == TIM_FLAG_CC3OF) || \
+                               ((FLAG) == TIM_FLAG_CC4OF))
+
+/**
+  * @}
+  */ 
+
+/** @defgroup TIM_Input_Capture_Filer_Value 
+  * @{
+  */
+
+#define IS_TIM_IC_FILTER(ICFILTER) ((ICFILTER) <= 0xF) 
+/**
+  * @}
+  */ 
+
+/** @defgroup TIM_External_Trigger_Filter 
+  * @{
+  */
+
+#define IS_TIM_EXT_FILTER(EXTFILTER) ((EXTFILTER) <= 0xF)
+/**
+  * @}
+  */ 
+
+/** @defgroup TIM_Legacy 
+  * @{
+  */
+
+#define TIM_DMABurstLength_1Byte           TIM_DMABurstLength_1Transfer
+#define TIM_DMABurstLength_2Bytes          TIM_DMABurstLength_2Transfers
+#define TIM_DMABurstLength_3Bytes          TIM_DMABurstLength_3Transfers
+#define TIM_DMABurstLength_4Bytes          TIM_DMABurstLength_4Transfers
+#define TIM_DMABurstLength_5Bytes          TIM_DMABurstLength_5Transfers
+#define TIM_DMABurstLength_6Bytes          TIM_DMABurstLength_6Transfers
+#define TIM_DMABurstLength_7Bytes          TIM_DMABurstLength_7Transfers
+#define TIM_DMABurstLength_8Bytes          TIM_DMABurstLength_8Transfers
+#define TIM_DMABurstLength_9Bytes          TIM_DMABurstLength_9Transfers
+#define TIM_DMABurstLength_10Bytes         TIM_DMABurstLength_10Transfers
+#define TIM_DMABurstLength_11Bytes         TIM_DMABurstLength_11Transfers
+#define TIM_DMABurstLength_12Bytes         TIM_DMABurstLength_12Transfers
+#define TIM_DMABurstLength_13Bytes         TIM_DMABurstLength_13Transfers
+#define TIM_DMABurstLength_14Bytes         TIM_DMABurstLength_14Transfers
+#define TIM_DMABurstLength_15Bytes         TIM_DMABurstLength_15Transfers
+#define TIM_DMABurstLength_16Bytes         TIM_DMABurstLength_16Transfers
+#define TIM_DMABurstLength_17Bytes         TIM_DMABurstLength_17Transfers
+#define TIM_DMABurstLength_18Bytes         TIM_DMABurstLength_18Transfers
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Exported macro ------------------------------------------------------------*/
+/* Exported functions --------------------------------------------------------*/ 
+
+/* TimeBase management ********************************************************/
+void TIM_DeInit(TIM_TypeDef* TIMx);
+void TIM_TimeBaseInit(TIM_TypeDef* TIMx, TIM_TimeBaseInitTypeDef* TIM_TimeBaseInitStruct);
+void TIM_TimeBaseStructInit(TIM_TimeBaseInitTypeDef* TIM_TimeBaseInitStruct);
+void TIM_PrescalerConfig(TIM_TypeDef* TIMx, uint16_t Prescaler, uint16_t TIM_PSCReloadMode);
+void TIM_CounterModeConfig(TIM_TypeDef* TIMx, uint16_t TIM_CounterMode);
+void TIM_SetCounter(TIM_TypeDef* TIMx, uint32_t Counter);
+void TIM_SetAutoreload(TIM_TypeDef* TIMx, uint32_t Autoreload);
+uint32_t TIM_GetCounter(TIM_TypeDef* TIMx);
+uint16_t TIM_GetPrescaler(TIM_TypeDef* TIMx);
+void TIM_UpdateDisableConfig(TIM_TypeDef* TIMx, FunctionalState NewState);
+void TIM_UpdateRequestConfig(TIM_TypeDef* TIMx, uint16_t TIM_UpdateSource);
+void TIM_ARRPreloadConfig(TIM_TypeDef* TIMx, FunctionalState NewState);
+void TIM_SelectOnePulseMode(TIM_TypeDef* TIMx, uint16_t TIM_OPMode);
+void TIM_SetClockDivision(TIM_TypeDef* TIMx, uint16_t TIM_CKD);
+void TIM_Cmd(TIM_TypeDef* TIMx, FunctionalState NewState);
+
+/* Output Compare management **************************************************/
+void TIM_OC1Init(TIM_TypeDef* TIMx, TIM_OCInitTypeDef* TIM_OCInitStruct);
+void TIM_OC2Init(TIM_TypeDef* TIMx, TIM_OCInitTypeDef* TIM_OCInitStruct);
+void TIM_OC3Init(TIM_TypeDef* TIMx, TIM_OCInitTypeDef* TIM_OCInitStruct);
+void TIM_OC4Init(TIM_TypeDef* TIMx, TIM_OCInitTypeDef* TIM_OCInitStruct);
+void TIM_OCStructInit(TIM_OCInitTypeDef* TIM_OCInitStruct);
+void TIM_SelectOCxM(TIM_TypeDef* TIMx, uint16_t TIM_Channel, uint16_t TIM_OCMode);
+void TIM_SetCompare1(TIM_TypeDef* TIMx, uint32_t Compare1);
+void TIM_SetCompare2(TIM_TypeDef* TIMx, uint32_t Compare2);
+void TIM_SetCompare3(TIM_TypeDef* TIMx, uint32_t Compare3);
+void TIM_SetCompare4(TIM_TypeDef* TIMx, uint32_t Compare4);
+void TIM_ForcedOC1Config(TIM_TypeDef* TIMx, uint16_t TIM_ForcedAction);
+void TIM_ForcedOC2Config(TIM_TypeDef* TIMx, uint16_t TIM_ForcedAction);
+void TIM_ForcedOC3Config(TIM_TypeDef* TIMx, uint16_t TIM_ForcedAction);
+void TIM_ForcedOC4Config(TIM_TypeDef* TIMx, uint16_t TIM_ForcedAction);
+void TIM_OC1PreloadConfig(TIM_TypeDef* TIMx, uint16_t TIM_OCPreload);
+void TIM_OC2PreloadConfig(TIM_TypeDef* TIMx, uint16_t TIM_OCPreload);
+void TIM_OC3PreloadConfig(TIM_TypeDef* TIMx, uint16_t TIM_OCPreload);
+void TIM_OC4PreloadConfig(TIM_TypeDef* TIMx, uint16_t TIM_OCPreload);
+void TIM_OC1FastConfig(TIM_TypeDef* TIMx, uint16_t TIM_OCFast);
+void TIM_OC2FastConfig(TIM_TypeDef* TIMx, uint16_t TIM_OCFast);
+void TIM_OC3FastConfig(TIM_TypeDef* TIMx, uint16_t TIM_OCFast);
+void TIM_OC4FastConfig(TIM_TypeDef* TIMx, uint16_t TIM_OCFast);
+void TIM_ClearOC1Ref(TIM_TypeDef* TIMx, uint16_t TIM_OCClear);
+void TIM_ClearOC2Ref(TIM_TypeDef* TIMx, uint16_t TIM_OCClear);
+void TIM_ClearOC3Ref(TIM_TypeDef* TIMx, uint16_t TIM_OCClear);
+void TIM_ClearOC4Ref(TIM_TypeDef* TIMx, uint16_t TIM_OCClear);
+void TIM_OC1PolarityConfig(TIM_TypeDef* TIMx, uint16_t TIM_OCPolarity);
+void TIM_OC1NPolarityConfig(TIM_TypeDef* TIMx, uint16_t TIM_OCNPolarity);
+void TIM_OC2PolarityConfig(TIM_TypeDef* TIMx, uint16_t TIM_OCPolarity);
+void TIM_OC2NPolarityConfig(TIM_TypeDef* TIMx, uint16_t TIM_OCNPolarity);
+void TIM_OC3PolarityConfig(TIM_TypeDef* TIMx, uint16_t TIM_OCPolarity);
+void TIM_OC3NPolarityConfig(TIM_TypeDef* TIMx, uint16_t TIM_OCNPolarity);
+void TIM_OC4PolarityConfig(TIM_TypeDef* TIMx, uint16_t TIM_OCPolarity);
+void TIM_CCxCmd(TIM_TypeDef* TIMx, uint16_t TIM_Channel, uint16_t TIM_CCx);
+void TIM_CCxNCmd(TIM_TypeDef* TIMx, uint16_t TIM_Channel, uint16_t TIM_CCxN);
+
+/* Input Capture management ***************************************************/
+void TIM_ICInit(TIM_TypeDef* TIMx, TIM_ICInitTypeDef* TIM_ICInitStruct);
+void TIM_ICStructInit(TIM_ICInitTypeDef* TIM_ICInitStruct);
+void TIM_PWMIConfig(TIM_TypeDef* TIMx, TIM_ICInitTypeDef* TIM_ICInitStruct);
+uint32_t TIM_GetCapture1(TIM_TypeDef* TIMx);
+uint32_t TIM_GetCapture2(TIM_TypeDef* TIMx);
+uint32_t TIM_GetCapture3(TIM_TypeDef* TIMx);
+uint32_t TIM_GetCapture4(TIM_TypeDef* TIMx);
+void TIM_SetIC1Prescaler(TIM_TypeDef* TIMx, uint16_t TIM_ICPSC);
+void TIM_SetIC2Prescaler(TIM_TypeDef* TIMx, uint16_t TIM_ICPSC);
+void TIM_SetIC3Prescaler(TIM_TypeDef* TIMx, uint16_t TIM_ICPSC);
+void TIM_SetIC4Prescaler(TIM_TypeDef* TIMx, uint16_t TIM_ICPSC);
+
+/* Advanced-control timers (TIM1 and TIM8) specific features ******************/
+void TIM_BDTRConfig(TIM_TypeDef* TIMx, TIM_BDTRInitTypeDef *TIM_BDTRInitStruct);
+void TIM_BDTRStructInit(TIM_BDTRInitTypeDef* TIM_BDTRInitStruct);
+void TIM_CtrlPWMOutputs(TIM_TypeDef* TIMx, FunctionalState NewState);
+void TIM_SelectCOM(TIM_TypeDef* TIMx, FunctionalState NewState);
+void TIM_CCPreloadControl(TIM_TypeDef* TIMx, FunctionalState NewState);
+
+/* Interrupts, DMA and flags management ***************************************/
+void TIM_ITConfig(TIM_TypeDef* TIMx, uint16_t TIM_IT, FunctionalState NewState);
+void TIM_GenerateEvent(TIM_TypeDef* TIMx, uint16_t TIM_EventSource);
+FlagStatus TIM_GetFlagStatus(TIM_TypeDef* TIMx, uint16_t TIM_FLAG);
+void TIM_ClearFlag(TIM_TypeDef* TIMx, uint16_t TIM_FLAG);
+ITStatus TIM_GetITStatus(TIM_TypeDef* TIMx, uint16_t TIM_IT);
+void TIM_ClearITPendingBit(TIM_TypeDef* TIMx, uint16_t TIM_IT);
+void TIM_DMAConfig(TIM_TypeDef* TIMx, uint16_t TIM_DMABase, uint16_t TIM_DMABurstLength);
+void TIM_DMACmd(TIM_TypeDef* TIMx, uint16_t TIM_DMASource, FunctionalState NewState);
+void TIM_SelectCCDMA(TIM_TypeDef* TIMx, FunctionalState NewState);
+
+/* Clocks management **********************************************************/
+void TIM_InternalClockConfig(TIM_TypeDef* TIMx);
+void TIM_ITRxExternalClockConfig(TIM_TypeDef* TIMx, uint16_t TIM_InputTriggerSource);
+void TIM_TIxExternalClockConfig(TIM_TypeDef* TIMx, uint16_t TIM_TIxExternalCLKSource,
+                                uint16_t TIM_ICPolarity, uint16_t ICFilter);
+void TIM_ETRClockMode1Config(TIM_TypeDef* TIMx, uint16_t TIM_ExtTRGPrescaler, uint16_t TIM_ExtTRGPolarity,
+                             uint16_t ExtTRGFilter);
+void TIM_ETRClockMode2Config(TIM_TypeDef* TIMx, uint16_t TIM_ExtTRGPrescaler, 
+                             uint16_t TIM_ExtTRGPolarity, uint16_t ExtTRGFilter);
+
+/* Synchronization management *************************************************/
+void TIM_SelectInputTrigger(TIM_TypeDef* TIMx, uint16_t TIM_InputTriggerSource);
+void TIM_SelectOutputTrigger(TIM_TypeDef* TIMx, uint16_t TIM_TRGOSource);
+void TIM_SelectSlaveMode(TIM_TypeDef* TIMx, uint16_t TIM_SlaveMode);
+void TIM_SelectMasterSlaveMode(TIM_TypeDef* TIMx, uint16_t TIM_MasterSlaveMode);
+void TIM_ETRConfig(TIM_TypeDef* TIMx, uint16_t TIM_ExtTRGPrescaler, uint16_t TIM_ExtTRGPolarity,
+                   uint16_t ExtTRGFilter);
+
+/* Specific interface management **********************************************/   
+void TIM_EncoderInterfaceConfig(TIM_TypeDef* TIMx, uint16_t TIM_EncoderMode,
+                                uint16_t TIM_IC1Polarity, uint16_t TIM_IC2Polarity);
+void TIM_SelectHallSensor(TIM_TypeDef* TIMx, FunctionalState NewState);
+
+/* Specific remapping management **********************************************/
+void TIM_RemapConfig(TIM_TypeDef* TIMx, uint16_t TIM_Remap);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /*__STM32F4xx_TIM_H */
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/src/lib/stm32fxxx_it.c
+++ b/src/lib/stm32fxxx_it.c
@@ -1,0 +1,219 @@
+/**
+  ******************************************************************************
+  * @file    stm32fxxx_it.c
+  * @author  MCD Application Team
+  * @version V2.1.0
+  * @date    19-March-2012
+  * @brief   This file includes the interrupt handlers for the application
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT 2012 STMicroelectronics</center></h2>
+  *
+  * Licensed under MCD-ST Liberty SW License Agreement V2, (the "License");
+  * You may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at:
+  *
+  *        http://www.st.com/software_license_agreement_liberty_v2
+  *
+  * Unless required by applicable law or agreed to in writing, software 
+  * distributed under the License is distributed on an "AS IS" BASIS, 
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "usb_bsp.h"
+#include "usb_hcd_int.h"
+#include "usbh_core.h"
+#include "stm32f4xx_conf.h"
+#include "stm32fxxx_it.h"
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+extern USB_OTG_CORE_HANDLE          USB_OTG_Core;
+extern USB_OTG_CORE_HANDLE          USB_OTG_FS_Core;
+extern USBH_HOST                    USB_Host;
+__IO uint32_t icc_tot = 0;
+__IO uint32_t icc_cnt = 0;
+__IO uint32_t icc_max = 0;
+
+/* Private function prototypes -----------------------------------------------*/
+extern void USB_OTG_BSP_TimerIRQ (void);
+
+/* Private functions ---------------------------------------------------------*/
+
+/******************************************************************************/
+/*             Cortex-M Processor Exceptions Handlers                         */
+/******************************************************************************/
+/**
+  * @brief  NMI_Handler
+  *         This function handles NMI exception.
+  * @param  None
+  * @retval None
+  */
+void NMI_Handler(void)
+{
+}
+
+/**
+  * @brief  EXTI1_IRQHandler
+  *         This function handles External line 1 interrupt request.
+  * @param  None
+  * @retval None
+  */
+void EXTI1_IRQHandler(void)
+{
+  /*
+  if(EXTI_GetITStatus(EXTI_Line1) != RESET)
+  {
+      USB_Host.usr_cb->OverCurrentDetected();
+      EXTI_ClearITPendingBit(EXTI_Line1);
+  }
+  */
+}
+
+/**
+  * @brief  HardFault_Handler
+  *         This function handles Hard Fault exception.
+  * @param  None
+  * @retval None
+  */
+void HardFault_Handler(void)
+{
+  /* Go to infinite loop when Hard Fault exception occurs */
+  while (1)
+  {
+  }
+}
+
+/**
+  * @brief  MemManage_Handler
+  *         This function handles Memory Manage exception.
+  * @param  None
+  * @retval None
+  */
+void MemManage_Handler(void)
+{
+  /* Go to infinite loop when Memory Manage exception occurs */
+  while (1)
+  {
+  }
+}
+
+/**
+  * @brief  BusFault_Handler
+  *         This function handles Bus Fault exception.
+  * @param  None
+  * @retval None
+  */
+void BusFault_Handler(void)
+{
+  /* Go to infinite loop when Bus Fault exception occurs */
+  while (1)
+  {
+  }
+}
+
+/**
+  * @brief  UsageFault_Handler
+  *         This function handles Usage Fault exception.
+  * @param  None
+  * @retval None
+  */
+void UsageFault_Handler(void)
+{
+  /* Go to infinite loop when Usage Fault exception occurs */
+  while (1)
+  {
+  }
+}
+
+/**
+  * @brief  SVC_Handler
+  *         This function handles SVCall exception.
+  * @param  None
+  * @retval None
+  */
+void SVC_Handler(void)
+{
+}
+
+/**
+  * @brief  DebugMon_Handler
+  *         This function handles Debug Monitor exception.
+  * @param  None
+  * @retval None
+  */
+void DebugMon_Handler(void)
+{
+}
+
+
+/**
+  * @brief  PendSV_Handler
+  *         This function handles PendSVC exception.
+  * @param  None
+  * @retval None
+  */
+void PendSV_Handler(void)
+{
+}
+
+/**
+  * @brief  TIM2_IRQHandler
+  *         This function handles Timer2 Handler.
+  * @param  None
+  * @retval None
+  */
+void TIM2_IRQHandler(void)
+{
+  USB_OTG_BSP_TimerIRQ();
+}
+
+/**
+  * @brief  OTG_FS_IRQHandler
+  *          This function handles USB-On-The-Go FS global interrupt request.
+  *          requests.
+  * @param  None
+  * @retval None
+  */
+#ifdef USE_USB_OTG_FS  
+void OTG_FS_IRQHandler(void)
+{
+  uint32_t icc = DWT->CYCCNT;
+  USBH_OTG_ISR_Handler(&USB_OTG_FS_Core);
+  icc = DWT->CYCCNT - icc;
+  if (icc_cnt > 5000 && icc > icc_max) icc_max = icc;
+  icc_tot = icc_tot + icc;
+  icc_cnt++;
+}
+#endif
+
+/**
+  * @brief  OTG_FS_IRQHandler
+  *          This function handles USB-On-The-Go FS global interrupt request.
+  *          requests.
+  * @param  None
+  * @retval None
+  */
+#ifdef USE_USB_OTG_HS  
+void OTG_HS_IRQHandler(void)
+{
+  USBH_OTG_ISR_Handler(&USB_OTG_Core);
+}
+#endif
+
+/******************************************************************************/
+/*                 STM32Fxxx Peripherals Interrupt Handlers                   */
+/*  Add here the Interrupt Handler for the used peripheral(s) (PPP), for the  */
+/*  available peripheral interrupt handler's name please refer to the startup */
+/*  file (startup_stm32fxxx.s).                                                */
+/******************************************************************************/
+
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/src/lib/stm32fxxx_it.h
+++ b/src/lib/stm32fxxx_it.h
@@ -1,0 +1,60 @@
+/**
+  ******************************************************************************
+  * @file    stm32fxxx_it.h
+  * @author  MCD Application Team
+  * @version V2.1.0
+  * @date    19-March-2012
+  * @brief   This file contains the headers of the interrupt handlers.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT 2012 STMicroelectronics</center></h2>
+  *
+  * Licensed under MCD-ST Liberty SW License Agreement V2, (the "License");
+  * You may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at:
+  *
+  *        http://www.st.com/software_license_agreement_liberty_v2
+  *
+  * Unless required by applicable law or agreed to in writing, software 
+  * distributed under the License is distributed on an "AS IS" BASIS, 
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  *
+  ******************************************************************************
+  */ 
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32Fxxx_IT_H
+#define __STM32Fxxx_IT_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif 
+
+/* Includes ------------------------------------------------------------------*/
+#include "usb_conf.h"
+
+/* Exported types ------------------------------------------------------------*/
+/* Exported constants --------------------------------------------------------*/
+/* Exported macro ------------------------------------------------------------*/
+/* Exported functions ------------------------------------------------------- */
+
+void NMI_Handler(void);
+void HardFault_Handler(void);
+void MemManage_Handler(void);
+void BusFault_Handler(void);
+void UsageFault_Handler(void);
+void SVC_Handler(void);
+void DebugMon_Handler(void);
+void PendSV_Handler(void);
+void SysTick_Handler(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32Fxxx_IT_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/src/lib/system.c
+++ b/src/lib/system.c
@@ -1,11 +1,11 @@
 #include "system.h"
 
 // PLL_VCO = (HSE_VALUE or HSI_VALUE / PLL_M) * PLL_N
-#define PLL_M 8
 #ifdef OVERCLOCK
-#define PLL_N 352
-// overclock a bit 168->176 to have 25.15 MHz
+#define PLL_M 4
+#define PLL_N 192
 #else
+#define PLL_M 8
 #define PLL_N 336
 #endif
 
@@ -13,11 +13,13 @@
 #define PLL_P 2
 
 // USB OTG FS, SDIO and RNG Clock =  PLL_VCO / PLLQ
-#define PLL_Q 7
+// #define PLL_Q 7
+#define PLL_Q 8
 
 // PLLI2S_VCO = (HSE_VALUE Or HSI_VALUE / PLL_M) * PLLI2S_N
 // I2SCLK = PLLI2S_VCO / PLLI2S_R
-#define PLLI2S_N 192
+// #define PLLI2S_N 192
+#define PLLI2S_N 96
 #define PLLI2S_R 5
 
 static void InitializeClocks();

--- a/src/lib/usb_bsp.c
+++ b/src/lib/usb_bsp.c
@@ -1,0 +1,502 @@
+/**
+  ******************************************************************************
+  * @file    Audio_playback_and_record/src/usb_bsp.c
+  * @author  MCD Application Team
+  * @version V1.0.0
+  * @date    28-October-2011
+  * @brief   This file implements the board support package for the USB host library
+  ******************************************************************************
+  * @attention
+  *
+  * THE PRESENT FIRMWARE WHICH IS FOR GUIDANCE ONLY AIMS AT PROVIDING CUSTOMERS
+  * WITH CODING INFORMATION REGARDING THEIR PRODUCTS IN ORDER FOR THEM TO SAVE
+  * TIME. AS A RESULT, STMICROELECTRONICS SHALL NOT BE HELD LIABLE FOR ANY
+  * DIRECT, INDIRECT OR CONSEQUENTIAL DAMAGES WITH RESPECT TO ANY CLAIMS ARISING
+  * FROM THE CONTENT OF SUCH FIRMWARE AND/OR THE USE MADE BY CUSTOMERS OF THE
+  * CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
+  *
+  * <h2><center>&copy; COPYRIGHT 2011 STMicroelectronics</center></h2>
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "usb_bsp.h"
+#include "stm32f4xx.h"
+// #include "stm32f4xx_syscfg.h"
+
+/** @addtogroup STM32F4-Discovery_Audio_Player_Recorder
+  * @{
+  */
+
+/* External variables --------------------------------------------------------*/
+/* Private typedef -----------------------------------------------------------*/
+/* Private defines -----------------------------------------------------------*/
+
+// #define USE_ACCURATE_TIME
+#define TIM_MSEC_DELAY                     0x01
+#define TIM_USEC_DELAY                     0x02
+#define HOST_OVRCURR_PORT                  GPIOD
+#define HOST_OVRCURR_LINE                  GPIO_Pin_5
+#define HOST_OVRCURR_PORT_SOURCE           GPIO_PortSourceGPIOD
+#define HOST_OVRCURR_PIN_SOURCE            GPIO_PinSourceD
+#define HOST_OVRCURR_PORT_RCC              RCC_APB2Periph_GPIOD
+#define HOST_OVRCURR_EXTI_LINE             EXTI_Line5
+#define HOST_OVRCURR_IRQn                  EXTI9_5_IRQn 
+
+
+#define HOST_POWERSW_PORT_RCC              RCC_AHB1Periph_GPIOC
+#define HOST_POWERSW_PORT                  GPIOC
+#define HOST_POWERSW_VBUS                  GPIO_Pin_0
+
+/* Private macros ------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+ErrorStatus HSEStartUpStatus;
+#ifdef USE_ACCURATE_TIME
+ __IO uint32_t BSP_delay = 0;
+#endif
+
+/* Private function prototypes -----------------------------------------------*/
+/* Private functions ---------------------------------------------------------*/
+#ifdef USE_ACCURATE_TIME
+ static void BSP_SetTime(uint8_t Unit);
+ static void BSP_Delay(uint32_t nTime, uint8_t Unit);
+ static void USB_OTG_BSP_TimeInit ( void );
+#endif
+
+/**
+  * @brief  BSP_Init
+  *         board user initializations
+  * @param  None
+  * @retval None
+  */
+void BSP_Init(void)
+{
+  /* Configure PA0 pin: User Key pin */
+  // STM_EVAL_PBInit(BUTTON_USER, BUTTON_MODE_GPIO);
+}
+
+
+/**
+  * @brief  USB_OTG_BSP_Init
+  *         Initilizes BSP configurations
+  * @param  None
+  * @retval None
+  */
+void USB_OTG_BSP_Init(USB_OTG_CORE_HANDLE *pdev)
+{
+ /* Note: On STM32F4-Discovery board only USB OTG FS core is supported. */
+
+  GPIO_InitTypeDef GPIO_InitStructure;
+ #ifdef USE_USB_OTG_FS 
+
+  RCC_AHB1PeriphClockCmd( RCC_AHB1Periph_GPIOA , ENABLE);  
+  
+  /* Configure SOF VBUS ID DM DP Pins */
+  GPIO_InitStructure.GPIO_Pin = GPIO_Pin_9  | 
+      GPIO_Pin_11 | 
+        GPIO_Pin_12;
+  
+  GPIO_InitStructure.GPIO_Speed = GPIO_Speed_100MHz;
+  GPIO_InitStructure.GPIO_Mode = GPIO_Mode_AF;
+  GPIO_InitStructure.GPIO_OType = GPIO_OType_PP;
+  GPIO_InitStructure.GPIO_PuPd = GPIO_PuPd_NOPULL ;
+  GPIO_Init(GPIOA, &GPIO_InitStructure);  
+  
+  GPIO_PinAFConfig(GPIOA,GPIO_PinSource9,GPIO_AF_OTG1_FS) ; 
+  GPIO_PinAFConfig(GPIOA,GPIO_PinSource11,GPIO_AF_OTG1_FS) ; 
+  GPIO_PinAFConfig(GPIOA,GPIO_PinSource12,GPIO_AF_OTG1_FS) ;
+  
+  /* this for ID line debug */
+  
+  
+  GPIO_InitStructure.GPIO_Pin =  GPIO_Pin_10;
+  GPIO_InitStructure.GPIO_OType = GPIO_OType_OD;
+  GPIO_InitStructure.GPIO_PuPd = GPIO_PuPd_UP ;  
+  GPIO_InitStructure.GPIO_Speed = GPIO_Speed_100MHz;
+  GPIO_Init(GPIOA, &GPIO_InitStructure);  
+  GPIO_PinAFConfig(GPIOA,GPIO_PinSource10,GPIO_AF_OTG1_FS) ;   
+
+
+  RCC_APB2PeriphClockCmd(RCC_APB2Periph_SYSCFG, ENABLE);
+  RCC_AHB2PeriphClockCmd(RCC_AHB2Periph_OTG_FS, ENABLE) ; 
+ #endif
+ #ifdef USE_USB_OTG_HS  // USE_USB_OTG_HS 
+
+  #ifdef USE_ULPI_PHY // ULPI
+  RCC_AHB1PeriphClockCmd( RCC_AHB1Periph_GPIOA | RCC_AHB1Periph_GPIOB | 
+                         RCC_AHB1Periph_GPIOC | RCC_AHB1Periph_GPIOH | 
+                           RCC_AHB1Periph_GPIOI, ENABLE);    
+  
+  
+  GPIO_PinAFConfig(GPIOA,GPIO_PinSource3, GPIO_AF_OTG2_HS) ; // D0
+  GPIO_PinAFConfig(GPIOA,GPIO_PinSource5, GPIO_AF_OTG2_HS) ; // CLK
+  GPIO_PinAFConfig(GPIOB,GPIO_PinSource0, GPIO_AF_OTG2_HS) ; // D1
+  GPIO_PinAFConfig(GPIOB,GPIO_PinSource1, GPIO_AF_OTG2_HS) ; // D2
+  GPIO_PinAFConfig(GPIOB,GPIO_PinSource5, GPIO_AF_OTG2_HS) ; // D7
+  GPIO_PinAFConfig(GPIOB,GPIO_PinSource10,GPIO_AF_OTG2_HS) ; // D3
+  GPIO_PinAFConfig(GPIOB,GPIO_PinSource11,GPIO_AF_OTG2_HS) ; // D4
+  GPIO_PinAFConfig(GPIOB,GPIO_PinSource12,GPIO_AF_OTG2_HS) ; // D5
+  GPIO_PinAFConfig(GPIOB,GPIO_PinSource13,GPIO_AF_OTG2_HS) ; // D6
+  GPIO_PinAFConfig(GPIOH,GPIO_PinSource4, GPIO_AF_OTG2_HS) ; // NXT
+  GPIO_PinAFConfig(GPIOI,GPIO_PinSource11,GPIO_AF_OTG2_HS) ; // DIR
+  GPIO_PinAFConfig(GPIOC,GPIO_PinSource0, GPIO_AF_OTG2_HS) ; // STP
+  
+  // CLK
+  GPIO_InitStructure.GPIO_Pin = GPIO_Pin_5 ; 
+  GPIO_InitStructure.GPIO_Speed = GPIO_Speed_100MHz;
+  GPIO_InitStructure.GPIO_Mode = GPIO_Mode_AF;
+  GPIO_Init(GPIOA, &GPIO_InitStructure);  
+  
+  // D0
+  GPIO_InitStructure.GPIO_Pin = GPIO_Pin_3  ; 
+  GPIO_InitStructure.GPIO_Speed = GPIO_Speed_100MHz;
+  GPIO_InitStructure.GPIO_Mode = GPIO_Mode_AF;
+  GPIO_InitStructure.GPIO_OType = GPIO_OType_PP;
+  GPIO_InitStructure.GPIO_PuPd = GPIO_PuPd_NOPULL ;
+  GPIO_Init(GPIOA, &GPIO_InitStructure);  
+  
+  
+  
+  // D1 D2 D3 D4 D5 D6 D7
+  GPIO_InitStructure.GPIO_Pin = GPIO_Pin_0 | GPIO_Pin_1  |
+    GPIO_Pin_5 | GPIO_Pin_10 | 
+      GPIO_Pin_11| GPIO_Pin_12 | 
+        GPIO_Pin_13 ;
+  
+  GPIO_InitStructure.GPIO_Speed = GPIO_Speed_100MHz;
+  GPIO_InitStructure.GPIO_Mode = GPIO_Mode_AF;
+  GPIO_InitStructure.GPIO_OType = GPIO_OType_PP;
+  GPIO_InitStructure.GPIO_PuPd = GPIO_PuPd_NOPULL ;
+  GPIO_Init(GPIOB, &GPIO_InitStructure);  
+  
+  
+  // STP
+  GPIO_InitStructure.GPIO_Pin = GPIO_Pin_0  ;
+  GPIO_InitStructure.GPIO_Speed = GPIO_Speed_100MHz;
+  GPIO_InitStructure.GPIO_Mode = GPIO_Mode_AF;
+  GPIO_Init(GPIOC, &GPIO_InitStructure);  
+  
+  //NXT  
+  GPIO_InitStructure.GPIO_Pin = GPIO_Pin_4;
+  GPIO_InitStructure.GPIO_Speed = GPIO_Speed_100MHz;
+  GPIO_InitStructure.GPIO_Mode = GPIO_Mode_AF;
+  GPIO_Init(GPIOH, &GPIO_InitStructure);  
+  
+  
+  //DIR
+  GPIO_InitStructure.GPIO_Pin = GPIO_Pin_11 ; 
+  GPIO_InitStructure.GPIO_Speed = GPIO_Speed_100MHz;
+  GPIO_InitStructure.GPIO_Mode = GPIO_Mode_AF;
+  GPIO_Init(GPIOI, &GPIO_InitStructure);  
+  
+  
+  RCC_AHB1PeriphClockCmd( RCC_AHB1Periph_OTG_HS | 
+                         RCC_AHB1Periph_OTG_HS_ULPI, ENABLE) ;    
+   
+  #else
+  
+   #ifdef USE_I2C_PHY    
+  RCC_AHB1PeriphClockCmd( RCC_AHB1Periph_GPIOB , ENABLE);  
+  /* Configure RESET INTN SCL SDA (Phy/I2C) Pins */
+  GPIO_InitStructure.GPIO_Pin = GPIO_Pin_0 | 
+    GPIO_Pin_1 | 
+      GPIO_Pin_10 | 
+        GPIO_Pin_11;
+  
+  GPIO_InitStructure.GPIO_Speed = GPIO_Speed_100MHz;
+  GPIO_InitStructure.GPIO_Mode = GPIO_Mode_AF;
+  GPIO_Init(GPIOB, &GPIO_InitStructure);  
+  
+  GPIO_PinAFConfig(GPIOB,GPIO_PinSource0,GPIO_AF_OTG2_FS) ; 
+  GPIO_PinAFConfig(GPIOB,GPIO_PinSource1,GPIO_AF_OTG2_FS) ; 
+  GPIO_PinAFConfig(GPIOB,GPIO_PinSource10,GPIO_AF_OTG2_FS) ; 
+  GPIO_PinAFConfig(GPIOB,GPIO_PinSource11,GPIO_AF_OTG2_FS);
+  RCC_AHB1PeriphClockCmd( RCC_AHB1Periph_OTG_HS, ENABLE) ;  
+  
+   #else
+
+  RCC_AHB1PeriphClockCmd(RCC_AHB1Periph_GPIOB , ENABLE);
+  
+  GPIO_InitStructure.GPIO_Pin = GPIO_Pin_12  | 
+    GPIO_Pin_13 |
+      GPIO_Pin_14 | 
+        GPIO_Pin_15;
+  
+  GPIO_InitStructure.GPIO_Speed = GPIO_Speed_100MHz;
+  GPIO_InitStructure.GPIO_Mode = GPIO_Mode_AF;
+  GPIO_Init(GPIOB, &GPIO_InitStructure);  
+  
+  GPIO_PinAFConfig(GPIOB,GPIO_PinSource12, GPIO_AF_OTG2_FS) ; 
+  GPIO_PinAFConfig(GPIOB,GPIO_PinSource13,GPIO_AF_OTG2_FS) ; 
+  GPIO_PinAFConfig(GPIOB,GPIO_PinSource14,GPIO_AF_OTG2_FS) ; 
+  GPIO_PinAFConfig(GPIOB,GPIO_PinSource15,GPIO_AF_OTG2_FS) ;
+  RCC_AHB1PeriphClockCmd( RCC_AHB1Periph_OTG_HS, ENABLE) ;  
+   #endif    
+  #endif
+ #endif //USB_OTG_HS
+
+#ifdef USE_ACCURATE_TIME
+  /* Intialize Timer for delay function */
+  USB_OTG_BSP_TimeInit(); 
+#endif
+}
+
+/**
+  * @brief  USB_OTG_BSP_EnableInterrupt
+  *         Configures USB Global interrupt
+  * @param  None
+  * @retval None
+  */
+void USB_OTG_BSP_EnableInterrupt(USB_OTG_CORE_HANDLE *pdev)
+{
+  NVIC_InitTypeDef NVIC_InitStructure; 
+  NVIC_PriorityGroupConfig(NVIC_PriorityGroup_1);
+
+#ifdef USE_USB_OTG_FS
+  NVIC_InitStructure.NVIC_IRQChannel = OTG_FS_IRQn;
+  NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = 1;
+  NVIC_InitStructure.NVIC_IRQChannelSubPriority = 4;
+  NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
+  NVIC_Init(&NVIC_InitStructure);  
+#endif
+
+#ifdef USE_USB_OTG_HS
+  NVIC_InitStructure.NVIC_IRQChannel = OTG_HS_IRQn;
+  NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = 1;
+  NVIC_InitStructure.NVIC_IRQChannelSubPriority = 3;
+  NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
+  NVIC_Init(&NVIC_InitStructure);    
+#endif
+  /* Enable the Overcurrent Interrupt */
+  /*
+  NVIC_InitStructure.NVIC_IRQChannel = HOST_OVRCURR_IRQn;
+  NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = 1;
+  NVIC_InitStructure.NVIC_IRQChannelSubPriority = 2;
+  NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
+  
+  NVIC_Init(&NVIC_InitStructure);
+  */
+}
+
+/**
+  * @brief  BSP_Drive_VBUS
+  *         Drives the Vbus signal through IO
+  * @param  state : VBUS states
+  * @retval None
+  */
+void USB_OTG_BSP_DriveVBUS(USB_OTG_CORE_HANDLE *pdev, uint8_t state)
+{
+  /*
+  On-chip 5 V VBUS generation is not supported. For this reason, a charge pump 
+  or, if 5 V are available on the application board, a basic power switch, must 
+  be added externally to drive the 5 V VBUS line. The external charge pump can 
+  be driven by any GPIO output. When the application decides to power on VBUS 
+  using the chosen GPIO, it must also set the port power bit in the host port 
+  control and status register (PPWR bit in OTG_FS_HPRT).
+
+  Bit 12 PPWR: Port power
+  The application uses this field to control power to this port, and the core 
+  clears this bit on an overcurrent condition.
+  */
+  if (0 == state)
+  {
+    /* DISABLE is needed on output of the Power Switch */
+    GPIO_SetBits(HOST_POWERSW_PORT, HOST_POWERSW_VBUS);
+  }
+  else
+  {
+    /*ENABLE the Power Switch by driving the Enable LOW */
+    GPIO_ResetBits(HOST_POWERSW_PORT, HOST_POWERSW_VBUS);
+  }
+}
+
+/**
+  * @brief  USB_OTG_BSP_ConfigVBUS
+  *         Configures the IO for the Vbus and OverCurrent
+  * @param  None
+  * @retval None
+  */
+void  USB_OTG_BSP_ConfigVBUS(USB_OTG_CORE_HANDLE *pdev)
+{
+  GPIO_InitTypeDef GPIO_InitStructure;
+
+
+  RCC_AHB1PeriphClockCmd(HOST_POWERSW_PORT_RCC, ENABLE);
+
+
+  /* Configure Power Switch Vbus Pin */
+  GPIO_InitStructure.GPIO_Pin = HOST_POWERSW_VBUS;
+  GPIO_InitStructure.GPIO_Speed = GPIO_Speed_50MHz;
+  GPIO_InitStructure.GPIO_Mode = GPIO_Mode_OUT;
+  GPIO_InitStructure.GPIO_OType = GPIO_OType_PP;
+  GPIO_InitStructure.GPIO_PuPd = GPIO_PuPd_NOPULL;  
+  
+  GPIO_Init(HOST_POWERSW_PORT, &GPIO_InitStructure);
+
+  /* By Default, DISABLE is needed on output of the Power Switch */
+  GPIO_SetBits(HOST_POWERSW_PORT, HOST_POWERSW_VBUS);
+
+  USB_OTG_BSP_mDelay(200);   /* Delay is need for stabilising the Vbus Low
+      in Reset Condition, when Vbus=1 and Reset-button is pressed by user */
+
+}
+
+#ifdef USE_ACCURATE_TIME
+/**
+  * @brief  USB_OTG_BSP_TimeInit
+  *         Initializes delay unit using Timer2
+  * @param  None
+  * @retval None
+  */
+static void USB_OTG_BSP_TimeInit (void)
+{
+  NVIC_InitTypeDef NVIC_InitStructure;
+
+  /* Set the Vector Table base address at 0x08000000 */
+  NVIC_SetVectorTable(NVIC_VectTab_FLASH, 0x00);
+
+  /* Configure the Priority Group to 2 bits */
+  NVIC_PriorityGroupConfig(NVIC_PriorityGroup_2);
+
+  /* Enable the TIM2 gloabal Interrupt */
+  NVIC_InitStructure.NVIC_IRQChannel = TIM2_IRQn;
+  NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = 0;
+  NVIC_InitStructure.NVIC_IRQChannelSubPriority = 1;
+  NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
+
+  NVIC_Init(&NVIC_InitStructure);
+
+  RCC_APB1PeriphClockCmd(RCC_APB1Periph_TIM2, ENABLE);
+}
+#endif
+
+/**
+  * @brief  USB_OTG_BSP_uDelay
+  *         This function provides delay time in micro sec
+  * @param  usec : Value of delay required in micro sec
+  * @retval None
+  */
+void USB_OTG_BSP_uDelay (const uint32_t usec)
+{
+
+#ifdef USE_ACCURATE_TIME
+  BSP_Delay(usec, TIM_USEC_DELAY);
+#else
+  __IO uint32_t count = 0;
+  const uint32_t utime = (120 * usec / 7);
+  do
+  {
+    if ( ++count > utime )
+    {
+      return ;
+    }
+  }
+  while (1);
+#endif
+
+}
+
+/**
+  * @brief  USB_OTG_BSP_mDelay
+  *          This function provides delay time in milli sec
+  * @param  msec : Value of delay required in milli sec
+  * @retval None
+  */
+void USB_OTG_BSP_mDelay (const uint32_t msec)
+{
+#ifdef USE_ACCURATE_TIME
+  BSP_Delay(msec, TIM_MSEC_DELAY);
+#else
+  USB_OTG_BSP_uDelay(msec * 1000);
+#endif
+
+}
+
+/**
+  * @brief  USB_OTG_BSP_TimerIRQ
+  *         Time base IRQ
+  * @param  None
+  * @retval None
+  */
+void USB_OTG_BSP_TimerIRQ (void)
+{
+#ifdef USE_ACCURATE_TIME
+  if (TIM_GetITStatus(TIM2, TIM_IT_Update) != RESET)
+  {
+    TIM_ClearITPendingBit(TIM2, TIM_IT_Update);
+    if (BSP_delay > 0x00)
+    {
+      BSP_delay--;
+    }
+    else
+    {
+      TIM_Cmd(TIM2, DISABLE);
+    }
+  }
+#endif
+}
+
+#ifdef USE_ACCURATE_TIME
+
+/**
+  * @brief  BSP_Delay
+  *         Delay routine based on TIM2
+  * @param  nTime : Delay Time
+  * @param  unit : Delay Time unit : mili sec / micro sec
+  * @retval None
+  */
+static void BSP_Delay(uint32_t nTime, uint8_t unit)
+{
+
+  BSP_delay = nTime;
+  BSP_SetTime(unit);
+  while (BSP_delay != 0);
+  TIM_Cmd(TIM2, DISABLE);
+}
+
+/**
+  * @brief  BSP_SetTime
+  *         Configures TIM2 for delay routine based on TIM2
+  * @param  unit : msec /usec
+  * @retval None
+  */
+static void BSP_SetTime(uint8_t unit)
+{
+  TIM_TimeBaseInitTypeDef  TIM_TimeBaseStructure;
+
+  TIM_Cmd(TIM2, DISABLE);
+  TIM_ITConfig(TIM2, TIM_IT_Update, DISABLE);
+
+
+  if (unit == TIM_USEC_DELAY)
+  {
+    TIM_TimeBaseStructure.TIM_Period = 11;
+  }
+  else if (unit == TIM_MSEC_DELAY)
+  {
+    TIM_TimeBaseStructure.TIM_Period = 11999;
+  }
+  TIM_TimeBaseStructure.TIM_Prescaler = 5;
+  TIM_TimeBaseStructure.TIM_ClockDivision = 0;
+  TIM_TimeBaseStructure.TIM_CounterMode = TIM_CounterMode_Up;
+
+  TIM_TimeBaseInit(TIM2, &TIM_TimeBaseStructure);
+  TIM_ClearITPendingBit(TIM2, TIM_IT_Update);
+
+  TIM_ARRPreloadConfig(TIM2, ENABLE);
+
+  /* TIM IT enable */
+  TIM_ITConfig(TIM2, TIM_IT_Update, ENABLE);
+
+  /* TIM2 enable counter */
+  TIM_Cmd(TIM2, ENABLE);
+}
+
+#endif
+
+/**
+* @}
+*/
+
+
+/******************* (C) COPYRIGHT 2011 STMicroelectronics *****END OF FILE****/

--- a/src/lib/usb_bsp.h
+++ b/src/lib/usb_bsp.h
@@ -1,0 +1,103 @@
+/**
+  ******************************************************************************
+  * @file    usb_bsp.h
+  * @author  MCD Application Team
+  * @version V2.1.0
+  * @date    19-March-2012
+  * @brief   Specific api's relative to the used hardware platform
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT 2012 STMicroelectronics</center></h2>
+  *
+  * Licensed under MCD-ST Liberty SW License Agreement V2, (the "License");
+  * You may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at:
+  *
+  *        http://www.st.com/software_license_agreement_liberty_v2
+  *
+  * Unless required by applicable law or agreed to in writing, software 
+  * distributed under the License is distributed on an "AS IS" BASIS, 
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __USB_BSP__H__
+#define __USB_BSP__H__
+
+/* Includes ------------------------------------------------------------------*/
+#include "usb_core.h"
+#include "usb_conf.h"
+
+/** @addtogroup USB_OTG_DRIVER
+  * @{
+  */
+  
+/** @defgroup USB_BSP
+  * @brief This file is the 
+  * @{
+  */ 
+
+
+/** @defgroup USB_BSP_Exported_Defines
+  * @{
+  */ 
+/**
+  * @}
+  */ 
+
+
+/** @defgroup USB_BSP_Exported_Types
+  * @{
+  */ 
+/**
+  * @}
+  */ 
+
+
+/** @defgroup USB_BSP_Exported_Macros
+  * @{
+  */ 
+/**
+  * @}
+  */ 
+
+/** @defgroup USB_BSP_Exported_Variables
+  * @{
+  */ 
+/**
+  * @}
+  */ 
+
+/** @defgroup USB_BSP_Exported_FunctionsPrototype
+  * @{
+  */ 
+void BSP_Init(void);
+
+void USB_OTG_BSP_Init (USB_OTG_CORE_HANDLE *pdev);
+void USB_OTG_BSP_uDelay (const uint32_t usec);
+void USB_OTG_BSP_mDelay (const uint32_t msec);
+void USB_OTG_BSP_EnableInterrupt (USB_OTG_CORE_HANDLE *pdev);
+#ifdef USE_HOST_MODE
+void USB_OTG_BSP_ConfigVBUS(USB_OTG_CORE_HANDLE *pdev);
+void USB_OTG_BSP_DriveVBUS(USB_OTG_CORE_HANDLE *pdev,uint8_t state);
+#endif
+/**
+  * @}
+  */ 
+
+#endif //__USB_BSP__H__
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
+

--- a/src/lib/usb_conf.h
+++ b/src/lib/usb_conf.h
@@ -1,0 +1,269 @@
+/**
+  ******************************************************************************
+  * @file    usb_conf.h
+  * @author  MCD Application Team
+  * @version V2.1.0
+  * @date    19-March-2012
+  * @brief   General low level driver configuration
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT 2012 STMicroelectronics</center></h2>
+  *
+  * Licensed under MCD-ST Liberty SW License Agreement V2, (the "License");
+  * You may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at:
+  *
+  *        http://www.st.com/software_license_agreement_liberty_v2
+  *
+  * Unless required by applicable law or agreed to in writing, software 
+  * distributed under the License is distributed on an "AS IS" BASIS, 
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __USB_CONF__H__
+#define __USB_CONF__H__
+
+/* Includes ------------------------------------------------------------------*/
+
+ #include "stm32f4xx.h"
+ #include "stm32f4xx_conf.h"
+// #include "stm32f4_discovery.h"
+ //#include "stm324xg_eval_lcd.h"
+// #include "stm324xg_eval_ioe.h"
+// #include "stm324xg_eval_sdio_sd.h"
+
+
+/** @addtogroup USB_OTG_DRIVER
+  * @{
+  */
+  
+/** @defgroup USB_CONF
+  * @brief USB low level driver configuration file
+  * @{
+  */ 
+
+/** @defgroup USB_CONF_Exported_Defines
+  * @{
+  */ 
+
+/* USB Core and PHY interface configuration.
+   Tip: To avoid modifying these defines each time you need to change the USB
+        configuration, you can declare the needed define in your toolchain
+        compiler preprocessor.
+   */
+/****************** USB OTG FS PHY CONFIGURATION *******************************
+*  The USB OTG FS Core supports one on-chip Full Speed PHY.
+*  
+*  The USE_EMBEDDED_PHY symbol is defined in the project compiler preprocessor 
+*  when FS core is used.
+*******************************************************************************/
+#ifndef USE_USB_OTG_FS
+ //#define USE_USB_OTG_FS
+#endif /* USE_USB_OTG_FS */
+
+#ifdef USE_USB_OTG_HS 
+// #define USB_OTG_HS_CORE
+#endif
+
+/****************** USB OTG HS PHY CONFIGURATION *******************************
+*  The USB OTG HS Core supports two PHY interfaces:
+*   (i)  An ULPI interface for the external High Speed PHY: the USB HS Core will 
+*        operate in High speed mode
+*   (ii) An on-chip Full Speed PHY: the USB HS Core will operate in Full speed mode
+*
+*  You can select the PHY to be used using one of these two defines:
+*   (i)  USE_ULPI_PHY: if the USB OTG HS Core is to be used in High speed mode 
+*   (ii) USE_EMBEDDED_PHY: if the USB OTG HS Core is to be used in Full speed mode
+*
+*  Notes: 
+*   - The USE_ULPI_PHY symbol is defined in the project compiler preprocessor as 
+*     default PHY when HS core is used.
+*   - On STM322xG-EVAL and STM324xG-EVAL boards, only configuration(i) is available.
+*     Configuration (ii) need a different hardware, for more details refer to your
+*     STM32 device datasheet.
+*******************************************************************************/
+#ifndef USE_USB_OTG_HS
+ //#define USE_USB_OTG_HS
+#endif /* USE_USB_OTG_HS */
+
+#ifndef USE_ULPI_PHY
+ //#define USE_ULPI_PHY
+#endif /* USE_ULPI_PHY */
+
+#ifndef USE_EMBEDDED_PHY
+ //#define USE_EMBEDDED_PHY
+#endif /* USE_EMBEDDED_PHY */
+
+#ifdef USE_USB_OTG_HS 
+ #define USB_OTG_HS_CORE
+#endif
+
+#ifdef USE_USB_OTG_FS 
+ #define USB_OTG_FS_CORE
+#endif
+/*******************************************************************************
+*                     FIFO Size Configuration in Host mode
+*  
+*  (i) Receive data FIFO size = (Largest Packet Size / 4) + 1 or 
+*                             2x (Largest Packet Size / 4) + 1,  If a 
+*                             high-bandwidth channel or multiple isochronous 
+*                             channels are enabled
+*
+*  (ii) For the host nonperiodic Transmit FIFO is the largest maximum packet size 
+*      for all supported nonperiodic OUT channels. Typically, a space 
+*      corresponding to two Largest Packet Size is recommended.
+*
+*  (iii) The minimum amount of RAM required for Host periodic Transmit FIFO is 
+*        the largest maximum packet size for all supported periodic OUT channels.
+*        If there is at least one High Bandwidth Isochronous OUT endpoint, 
+*        then the space must be at least two times the maximum packet size for 
+*        that channel.
+*******************************************************************************/
+
+/****************** USB OTG HS CONFIGURATION **********************************/
+#ifdef USB_OTG_HS_CORE
+ #define RX_FIFO_HS_SIZE                          512
+ #define TXH_NP_HS_FIFOSIZ                        256
+ #define TXH_P_HS_FIFOSIZ                         256
+
+// #define USB_OTG_HS_LOW_PWR_MGMT_SUPPORT
+// #define USB_OTG_HS_SOF_OUTPUT_ENABLED
+
+// #define USB_OTG_INTERNAL_VBUS_ENABLED
+#define USB_OTG_EXTERNAL_VBUS_ENABLED
+
+ #ifdef USE_ULPI_PHY
+  #define USB_OTG_ULPI_PHY_ENABLED
+ #endif
+ #ifdef USE_EMBEDDED_PHY
+   #define USB_OTG_EMBEDDED_PHY_ENABLED
+ #endif
+ // #define USB_OTG_HS_INTERNAL_DMA_ENABLED
+// #define USB_OTG_HS_DEDICATED_EP1_ENABLED
+#endif
+
+/****************** USB OTG FS CONFIGURATION **********************************/
+#ifdef USB_OTG_FS_CORE
+ #define RX_FIFO_FS_SIZE                          128
+ #define TXH_NP_FS_FIFOSIZ                         96
+ #define TXH_P_FS_FIFOSIZ                          96
+
+// #define USB_OTG_FS_LOW_PWR_MGMT_SUPPORT
+// #define USB_OTG_FS_SOF_OUTPUT_ENABLED
+#endif
+
+/****************** USB OTG MODE CONFIGURATION ********************************/
+#define USE_HOST_MODE
+//#define USE_DEVICE_MODE
+//#define USE_OTG_MODE
+
+#ifndef USB_OTG_FS_CORE
+ #ifndef USB_OTG_HS_CORE
+    #error  "USB_OTG_HS_CORE or USB_OTG_FS_CORE should be defined"
+ #endif
+#endif
+
+#ifndef USE_DEVICE_MODE
+ #ifndef USE_HOST_MODE
+    #error  "USE_DEVICE_MODE or USE_HOST_MODE should be defined"
+ #endif
+#endif
+
+#ifndef USE_USB_OTG_HS
+ #ifndef USE_USB_OTG_FS
+    #error  "USE_USB_OTG_HS or USE_USB_OTG_FS should be defined"
+ #endif
+#else //USE_USB_OTG_HS
+ #ifndef USE_ULPI_PHY
+  #ifndef USE_EMBEDDED_PHY
+     #error  "USE_ULPI_PHY or USE_EMBEDDED_PHY should be defined"
+  #endif
+ #endif
+#endif
+
+/****************** C Compilers dependant keywords ****************************/
+/* In HS mode and when the DMA is used, all variables and data structures dealing
+   with the DMA during the transaction process should be 4-bytes aligned */    
+#ifdef USB_OTG_HS_INTERNAL_DMA_ENABLED
+  #if defined   (__GNUC__)        /* GNU Compiler */
+    #define __ALIGN_END    __attribute__ ((aligned (4)))
+    #define __ALIGN_BEGIN         
+  #else                           
+    #define __ALIGN_END
+    #if defined   (__CC_ARM)      /* ARM Compiler */
+      #define __ALIGN_BEGIN    __align(4)  
+    #elif defined (__ICCARM__)    /* IAR Compiler */
+      #define __ALIGN_BEGIN 
+    #elif defined  (__TASKING__)  /* TASKING Compiler */
+      #define __ALIGN_BEGIN    __align(4) 
+    #endif /* __CC_ARM */  
+  #endif /* __GNUC__ */ 
+#else
+  #define __ALIGN_BEGIN
+  #define __ALIGN_END   
+#endif /* USB_OTG_HS_INTERNAL_DMA_ENABLED */
+
+/* __packed keyword used to decrease the data type alignment to 1-byte */
+#if defined (__CC_ARM)         /* ARM Compiler */
+  #define __packed    __packed
+#elif defined (__ICCARM__)     /* IAR Compiler */
+  #define __packed    __packed
+#elif defined   ( __GNUC__ )   /* GNU Compiler */                        
+  #define __packed    __attribute__ ((__packed__))
+#elif defined   (__TASKING__)  /* TASKING Compiler */
+  #define __packed    __unaligned
+#endif /* __CC_ARM */
+
+/**
+  * @}
+  */ 
+
+
+/** @defgroup USB_CONF_Exported_Types
+  * @{
+  */ 
+/**
+  * @}
+  */ 
+
+
+/** @defgroup USB_CONF_Exported_Macros
+  * @{
+  */ 
+/**
+  * @}
+  */ 
+
+/** @defgroup USB_CONF_Exported_Variables
+  * @{
+  */ 
+/**
+  * @}
+  */ 
+
+/** @defgroup USB_CONF_Exported_FunctionsPrototype
+  * @{
+  */ 
+/**
+  * @}
+  */ 
+
+
+#endif //__USB_CONF__H__
+
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
+

--- a/src/lib/usb_core.c
+++ b/src/lib/usb_core.c
@@ -1,0 +1,2162 @@
+/**
+  ******************************************************************************
+  * @file    usb_core.c
+  * @author  MCD Application Team
+  * @version V2.1.0
+  * @date    19-March-2012
+  * @brief   USB-OTG Core Layer
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT 2012 STMicroelectronics</center></h2>
+  *
+  * Licensed under MCD-ST Liberty SW License Agreement V2, (the "License");
+  * You may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at:
+  *
+  *        http://www.st.com/software_license_agreement_liberty_v2
+  *
+  * Unless required by applicable law or agreed to in writing, software 
+  * distributed under the License is distributed on an "AS IS" BASIS, 
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "usb_core.h"
+#include "usb_bsp.h"
+
+
+/** @addtogroup USB_OTG_DRIVER
+* @{
+*/
+
+/** @defgroup USB_CORE 
+* @brief This file includes the USB-OTG Core Layer
+* @{
+*/
+
+
+/** @defgroup USB_CORE_Private_Defines
+* @{
+*/ 
+
+/**
+* @}
+*/ 
+
+
+/** @defgroup USB_CORE_Private_TypesDefinitions
+* @{
+*/ 
+/**
+* @}
+*/ 
+
+
+
+/** @defgroup USB_CORE_Private_Macros
+* @{
+*/ 
+/**
+* @}
+*/ 
+
+
+/** @defgroup USB_CORE_Private_Variables
+* @{
+*/ 
+/**
+* @}
+*/ 
+
+
+/** @defgroup USB_CORE_Private_FunctionPrototypes
+* @{
+*/ 
+/**
+* @}
+*/ 
+
+
+/** @defgroup USB_CORE_Private_Functions
+* @{
+*/ 
+
+/**
+* @brief  USB_OTG_EnableCommonInt
+*         Initializes the commmon interrupts, used in both device and modes
+* @param  pdev : Selected device
+* @retval None
+*/
+static void USB_OTG_EnableCommonInt(USB_OTG_CORE_HANDLE *pdev)
+{
+  USB_OTG_GINTMSK_TypeDef  int_mask;
+  
+  int_mask.d32 = 0;
+  /* Clear any pending USB_OTG Interrupts */
+#ifndef USE_OTG_MODE
+  USB_OTG_WRITE_REG32( &pdev->regs.GREGS->GOTGINT, 0xFFFFFFFF);
+#endif
+  /* Clear any pending interrupts */
+  USB_OTG_WRITE_REG32( &pdev->regs.GREGS->GINTSTS, 0xBFFFFFFF);
+  /* Enable the interrupts in the INTMSK */
+  int_mask.b.wkupintr = 1;
+  int_mask.b.usbsuspend = 1; 
+  
+#ifdef USE_OTG_MODE
+  int_mask.b.otgintr = 1;
+  int_mask.b.sessreqintr = 1;
+  int_mask.b.conidstschng = 1;
+#endif
+  USB_OTG_WRITE_REG32( &pdev->regs.GREGS->GINTMSK, int_mask.d32);
+}
+
+/**
+* @brief  USB_OTG_CoreReset : Soft reset of the core
+* @param  pdev : Selected device
+* @retval USB_OTG_STS : status
+*/
+static USB_OTG_STS USB_OTG_CoreReset(USB_OTG_CORE_HANDLE *pdev)
+{
+  USB_OTG_STS status = USB_OTG_OK;
+  __IO USB_OTG_GRSTCTL_TypeDef  greset;
+  uint32_t count = 0;
+  
+  greset.d32 = 0;
+  /* Wait for AHB master IDLE state. */
+  do
+  {
+    USB_OTG_BSP_uDelay(3);
+    greset.d32 = USB_OTG_READ_REG32(&pdev->regs.GREGS->GRSTCTL);
+    if (++count > 200000)
+    {
+      return USB_OTG_OK;
+    }
+  }
+  while (greset.b.ahbidle == 0);
+  /* Core Soft Reset */
+  count = 0;
+  greset.b.csftrst = 1;
+  USB_OTG_WRITE_REG32(&pdev->regs.GREGS->GRSTCTL, greset.d32 );
+  do
+  {
+    greset.d32 = USB_OTG_READ_REG32(&pdev->regs.GREGS->GRSTCTL);
+    if (++count > 200000)
+    {
+      break;
+    }
+  }
+  while (greset.b.csftrst == 1);
+  /* Wait for 3 PHY Clocks*/
+  USB_OTG_BSP_uDelay(3);
+  return status;
+}
+
+/**
+* @brief  USB_OTG_WritePacket : Writes a packet into the Tx FIFO associated 
+*         with the EP
+* @param  pdev : Selected device
+* @param  src : source pointer
+* @param  ch_ep_num : end point number
+* @param  bytes : No. of bytes
+* @retval USB_OTG_STS : status
+*/
+USB_OTG_STS USB_OTG_WritePacket(USB_OTG_CORE_HANDLE *pdev, 
+                                uint8_t             *src, 
+                                uint8_t             ch_ep_num, 
+                                uint16_t            len)
+{
+  USB_OTG_STS status = USB_OTG_OK;
+  if (pdev->cfg.dma_enable == 0)
+  {
+    uint32_t count32b= 0 , i= 0;
+    __IO uint32_t *fifo;
+    
+    count32b =  (len + 3) / 4;
+    fifo = pdev->regs.DFIFO[ch_ep_num];
+    for (i = 0; i < count32b; i++, src+=4)
+    {
+      USB_OTG_WRITE_REG32( fifo, *((__packed uint32_t *)src) );
+    }
+  }
+  return status;
+}
+
+
+/**
+* @brief  USB_OTG_ReadPacket : Reads a packet from the Rx FIFO
+* @param  pdev : Selected device
+* @param  dest : Destination Pointer
+* @param  bytes : No. of bytes
+* @retval None
+*/
+void *USB_OTG_ReadPacket(USB_OTG_CORE_HANDLE *pdev, 
+                         uint8_t *dest, 
+                         uint16_t len)
+{
+  uint32_t i=0;
+  uint32_t count32b = (len + 3) / 4;
+  
+  __IO uint32_t *fifo = pdev->regs.DFIFO[0];
+  
+  for ( i = 0; i < count32b; i++, dest += 4 )
+  {
+    *(__packed uint32_t *)dest = USB_OTG_READ_REG32(fifo);
+    
+  }
+  return ((void *)dest);
+}
+
+/**
+* @brief  USB_OTG_SelectCore 
+*         Initialize core registers address.
+* @param  pdev : Selected device
+* @param  coreID : USB OTG Core ID
+* @retval USB_OTG_STS : status
+*/
+USB_OTG_STS USB_OTG_SelectCore(USB_OTG_CORE_HANDLE *pdev, 
+                               USB_OTG_CORE_ID_TypeDef coreID)
+{
+  uint32_t i , baseAddress = 0;
+  USB_OTG_STS status = USB_OTG_OK;
+  
+  pdev->cfg.dma_enable       = 0;
+  
+  /* at startup the core is in FS mode */
+  pdev->cfg.speed            = USB_OTG_SPEED_FULL;
+  pdev->cfg.mps              = USB_OTG_FS_MAX_PACKET_SIZE ;    
+  
+  /* initialize device cfg following its address */
+  if (coreID == USB_OTG_FS_CORE_ID)
+  {
+    baseAddress                = USB_OTG_FS_BASE_ADDR;
+    pdev->cfg.coreID           = USB_OTG_FS_CORE_ID;
+    pdev->cfg.host_channels    = 8 ;
+    pdev->cfg.dev_endpoints    = 4 ;
+    pdev->cfg.TotalFifoSize    = 320; /* in 32-bits */
+    pdev->cfg.phy_itface       = USB_OTG_EMBEDDED_PHY;     
+    
+#ifdef USB_OTG_FS_SOF_OUTPUT_ENABLED    
+    pdev->cfg.Sof_output       = 1;    
+#endif 
+    
+#ifdef USB_OTG_FS_LOW_PWR_MGMT_SUPPORT    
+    pdev->cfg.low_power        = 1;    
+#endif     
+  }
+  else if (coreID == USB_OTG_HS_CORE_ID)
+  {
+    baseAddress                = USB_OTG_HS_BASE_ADDR;
+    pdev->cfg.coreID           = USB_OTG_HS_CORE_ID;    
+    pdev->cfg.host_channels    = 12 ;
+    pdev->cfg.dev_endpoints    = 6 ;
+    pdev->cfg.TotalFifoSize    = 1280;/* in 32-bits */
+    
+#ifdef USB_OTG_ULPI_PHY_ENABLED
+    pdev->cfg.phy_itface       = USB_OTG_ULPI_PHY;
+#else    
+#ifdef USB_OTG_EMBEDDED_PHY_ENABLED
+    pdev->cfg.phy_itface       = USB_OTG_EMBEDDED_PHY;
+#endif  
+#endif      
+    
+#ifdef USB_OTG_HS_INTERNAL_DMA_ENABLED    
+    pdev->cfg.dma_enable       = 1;    
+#endif
+    
+#ifdef USB_OTG_HS_SOF_OUTPUT_ENABLED    
+    pdev->cfg.Sof_output       = 1;    
+#endif 
+    
+#ifdef USB_OTG_HS_LOW_PWR_MGMT_SUPPORT    
+    pdev->cfg.low_power        = 1;    
+#endif 
+    
+  }
+  
+  pdev->regs.GREGS = (USB_OTG_GREGS *)(baseAddress + \
+    USB_OTG_CORE_GLOBAL_REGS_OFFSET);
+  pdev->regs.DREGS =  (USB_OTG_DREGS  *)  (baseAddress + \
+    USB_OTG_DEV_GLOBAL_REG_OFFSET);
+  
+  for (i = 0; i < pdev->cfg.dev_endpoints; i++)
+  {
+    pdev->regs.INEP_REGS[i]  = (USB_OTG_INEPREGS *)  \
+      (baseAddress + USB_OTG_DEV_IN_EP_REG_OFFSET + \
+        (i * USB_OTG_EP_REG_OFFSET));
+    pdev->regs.OUTEP_REGS[i] = (USB_OTG_OUTEPREGS *) \
+      (baseAddress + USB_OTG_DEV_OUT_EP_REG_OFFSET + \
+        (i * USB_OTG_EP_REG_OFFSET));
+  }
+  pdev->regs.HREGS = (USB_OTG_HREGS *)(baseAddress + \
+    USB_OTG_HOST_GLOBAL_REG_OFFSET);
+  pdev->regs.HPRT0 = (uint32_t *)(baseAddress + USB_OTG_HOST_PORT_REGS_OFFSET);
+  
+  for (i = 0; i < pdev->cfg.host_channels; i++)
+  {
+    pdev->regs.HC_REGS[i] = (USB_OTG_HC_REGS *)(baseAddress + \
+      USB_OTG_HOST_CHAN_REGS_OFFSET + \
+        (i * USB_OTG_CHAN_REGS_OFFSET));
+  }
+  for (i = 0; i < pdev->cfg.host_channels; i++)
+  {
+    pdev->regs.DFIFO[i] = (uint32_t *)(baseAddress + USB_OTG_DATA_FIFO_OFFSET +\
+      (i * USB_OTG_DATA_FIFO_SIZE));
+  }
+  pdev->regs.PCGCCTL = (uint32_t *)(baseAddress + USB_OTG_PCGCCTL_OFFSET);
+  
+  return status;
+}
+
+
+/**
+* @brief  USB_OTG_CoreInit
+*         Initializes the USB_OTG controller registers and prepares the core
+*         device mode or host mode operation.
+* @param  pdev : Selected device
+* @retval USB_OTG_STS : status
+*/
+USB_OTG_STS USB_OTG_CoreInit(USB_OTG_CORE_HANDLE *pdev)
+{
+  USB_OTG_STS status = USB_OTG_OK;
+  USB_OTG_GUSBCFG_TypeDef  usbcfg;
+  USB_OTG_GCCFG_TypeDef    gccfg;
+  USB_OTG_GAHBCFG_TypeDef  ahbcfg;
+  
+  usbcfg.d32 = 0;
+  gccfg.d32 = 0;
+  ahbcfg.d32 = 0;
+  
+  
+  
+  if (pdev->cfg.phy_itface == USB_OTG_ULPI_PHY)
+  {
+    gccfg.d32 = USB_OTG_READ_REG32(&pdev->regs.GREGS->GCCFG);
+    gccfg.b.pwdn = 0;
+    
+    if (pdev->cfg.Sof_output)
+    {
+      gccfg.b.sofouten = 1;   
+    }
+    USB_OTG_WRITE_REG32 (&pdev->regs.GREGS->GCCFG, gccfg.d32);
+    
+    /* Init The ULPI Interface */
+    usbcfg.d32 = 0;
+    usbcfg.d32 = USB_OTG_READ_REG32(&pdev->regs.GREGS->GUSBCFG);
+    
+    usbcfg.b.physel            = 0; /* HS Interface */
+#ifdef USB_OTG_INTERNAL_VBUS_ENABLED
+    usbcfg.b.ulpi_ext_vbus_drv = 0; /* Use internal VBUS */
+#else
+#ifdef USB_OTG_EXTERNAL_VBUS_ENABLED    
+    usbcfg.b.ulpi_ext_vbus_drv = 1; /* Use external VBUS */
+#endif
+#endif 
+    usbcfg.b.term_sel_dl_pulse = 0; /* Data line pulsing using utmi_txvalid */    
+    
+    usbcfg.b.ulpi_fsls = 0;
+    usbcfg.b.ulpi_clk_sus_m = 0;
+    USB_OTG_WRITE_REG32 (&pdev->regs.GREGS->GUSBCFG, usbcfg.d32);
+    
+    /* Reset after a PHY select  */
+    USB_OTG_CoreReset(pdev);
+    
+    if(pdev->cfg.dma_enable == 1)
+    {
+      
+      ahbcfg.b.hburstlen = 5; /* 64 x 32-bits*/
+      ahbcfg.b.dmaenable = 1;
+      USB_OTG_WRITE_REG32(&pdev->regs.GREGS->GAHBCFG, ahbcfg.d32);
+      
+    }    
+  }
+  else /* FS interface (embedded Phy) */
+  {
+    
+    usbcfg.d32 = USB_OTG_READ_REG32(&pdev->regs.GREGS->GUSBCFG);;
+    usbcfg.b.physel  = 1; /* FS Interface */
+    USB_OTG_WRITE_REG32 (&pdev->regs.GREGS->GUSBCFG, usbcfg.d32);
+    /* Reset after a PHY select and set Host mode */
+    USB_OTG_CoreReset(pdev);
+    /* Deactivate the power down*/
+    gccfg.d32 = 0;
+    gccfg.b.pwdn = 1;
+    
+    gccfg.b.vbussensingA = 1 ;
+    gccfg.b.vbussensingB = 1 ;     
+#ifndef VBUS_SENSING_ENABLED
+    gccfg.b.disablevbussensing = 1; 
+#endif    
+    
+    if(pdev->cfg.Sof_output)
+    {
+      gccfg.b.sofouten = 1;  
+    }
+    
+    USB_OTG_WRITE_REG32 (&pdev->regs.GREGS->GCCFG, gccfg.d32);
+    USB_OTG_BSP_mDelay(20);
+  }
+  /* case the HS core is working in FS mode */
+  if(pdev->cfg.dma_enable == 1)
+  {
+    
+    ahbcfg.d32 = USB_OTG_READ_REG32(&pdev->regs.GREGS->GAHBCFG);
+    ahbcfg.b.hburstlen = 5; /* 64 x 32-bits*/
+    ahbcfg.b.dmaenable = 1;
+    USB_OTG_WRITE_REG32(&pdev->regs.GREGS->GAHBCFG, ahbcfg.d32);
+    
+  }
+  /* initialize OTG features */
+#ifdef  USE_OTG_MODE
+  usbcfg.d32 = USB_OTG_READ_REG32(&pdev->regs.GREGS->GUSBCFG);
+  usbcfg.b.hnpcap = 1;
+  usbcfg.b.srpcap = 1;
+  USB_OTG_WRITE_REG32(&pdev->regs.GREGS->GUSBCFG, usbcfg.d32);
+  USB_OTG_EnableCommonInt(pdev);
+#endif
+  return status;
+}
+/**
+* @brief  USB_OTG_EnableGlobalInt
+*         Enables the controller's Global Int in the AHB Config reg
+* @param  pdev : Selected device
+* @retval USB_OTG_STS : status
+*/
+USB_OTG_STS USB_OTG_EnableGlobalInt(USB_OTG_CORE_HANDLE *pdev)
+{
+  USB_OTG_STS status = USB_OTG_OK;
+  USB_OTG_GAHBCFG_TypeDef  ahbcfg;
+  
+  ahbcfg.d32 = 0;
+  ahbcfg.b.glblintrmsk = 1; /* Enable interrupts */
+  USB_OTG_MODIFY_REG32(&pdev->regs.GREGS->GAHBCFG, 0, ahbcfg.d32);
+  return status;
+}
+
+
+/**
+* @brief  USB_OTG_DisableGlobalInt
+*         Enables the controller's Global Int in the AHB Config reg
+* @param  pdev : Selected device
+* @retval USB_OTG_STS : status
+*/
+USB_OTG_STS USB_OTG_DisableGlobalInt(USB_OTG_CORE_HANDLE *pdev)
+{
+  USB_OTG_STS status = USB_OTG_OK;
+  USB_OTG_GAHBCFG_TypeDef  ahbcfg;
+  ahbcfg.d32 = 0;
+  ahbcfg.b.glblintrmsk = 1; /* Enable interrupts */
+  USB_OTG_MODIFY_REG32(&pdev->regs.GREGS->GAHBCFG, ahbcfg.d32, 0);
+  return status;
+}
+
+
+/**
+* @brief  USB_OTG_FlushTxFifo : Flush a Tx FIFO
+* @param  pdev : Selected device
+* @param  num : FO num
+* @retval USB_OTG_STS : status
+*/
+USB_OTG_STS USB_OTG_FlushTxFifo (USB_OTG_CORE_HANDLE *pdev , uint32_t num )
+{
+  USB_OTG_STS status = USB_OTG_OK;
+  __IO USB_OTG_GRSTCTL_TypeDef  greset;
+  
+  uint32_t count = 0;
+  greset.d32 = 0;
+  greset.b.txfflsh = 1;
+  greset.b.txfnum  = num;
+  USB_OTG_WRITE_REG32( &pdev->regs.GREGS->GRSTCTL, greset.d32 );
+  do
+  {
+    greset.d32 = USB_OTG_READ_REG32( &pdev->regs.GREGS->GRSTCTL);
+    if (++count > 200000)
+    {
+      break;
+    }
+  }
+  while (greset.b.txfflsh == 1);
+  /* Wait for 3 PHY Clocks*/
+  USB_OTG_BSP_uDelay(3);
+  return status;
+}
+
+
+/**
+* @brief  USB_OTG_FlushRxFifo : Flush a Rx FIFO
+* @param  pdev : Selected device
+* @retval USB_OTG_STS : status
+*/
+USB_OTG_STS USB_OTG_FlushRxFifo( USB_OTG_CORE_HANDLE *pdev )
+{
+  USB_OTG_STS status = USB_OTG_OK;
+  __IO USB_OTG_GRSTCTL_TypeDef  greset;
+  uint32_t count = 0;
+  
+  greset.d32 = 0;
+  greset.b.rxfflsh = 1;
+  USB_OTG_WRITE_REG32( &pdev->regs.GREGS->GRSTCTL, greset.d32 );
+  do
+  {
+    greset.d32 = USB_OTG_READ_REG32( &pdev->regs.GREGS->GRSTCTL);
+    if (++count > 200000)
+    {
+      break;
+    }
+  }
+  while (greset.b.rxfflsh == 1);
+  /* Wait for 3 PHY Clocks*/
+  USB_OTG_BSP_uDelay(3);
+  return status;
+}
+
+
+/**
+* @brief  USB_OTG_SetCurrentMode : Set ID line
+* @param  pdev : Selected device
+* @param  mode :  (Host/device)
+* @retval USB_OTG_STS : status
+*/
+USB_OTG_STS USB_OTG_SetCurrentMode(USB_OTG_CORE_HANDLE *pdev , uint8_t mode)
+{
+  USB_OTG_STS status = USB_OTG_OK;
+  USB_OTG_GUSBCFG_TypeDef  usbcfg;
+  
+  usbcfg.d32 = USB_OTG_READ_REG32(&pdev->regs.GREGS->GUSBCFG);
+  
+  usbcfg.b.force_host = 0;
+  usbcfg.b.force_dev = 0;
+  
+  if ( mode == HOST_MODE)
+  {
+    usbcfg.b.force_host = 1;
+  }
+  else if ( mode == DEVICE_MODE)
+  {
+    usbcfg.b.force_dev = 1;
+  }
+  
+  USB_OTG_WRITE_REG32(&pdev->regs.GREGS->GUSBCFG, usbcfg.d32);
+  USB_OTG_BSP_mDelay(50);
+  return status;
+}
+
+
+/**
+* @brief  USB_OTG_GetMode : Get current mode
+* @param  pdev : Selected device
+* @retval current mode
+*/
+uint32_t USB_OTG_GetMode(USB_OTG_CORE_HANDLE *pdev)
+{
+  return (USB_OTG_READ_REG32(&pdev->regs.GREGS->GINTSTS ) & 0x1);
+}
+
+
+/**
+* @brief  USB_OTG_IsDeviceMode : Check if it is device mode
+* @param  pdev : Selected device
+* @retval num_in_ep
+*/
+uint8_t USB_OTG_IsDeviceMode(USB_OTG_CORE_HANDLE *pdev)
+{
+  return (USB_OTG_GetMode(pdev) != HOST_MODE);
+}
+
+
+/**
+* @brief  USB_OTG_IsHostMode : Check if it is host mode
+* @param  pdev : Selected device
+* @retval num_in_ep
+*/
+uint8_t USB_OTG_IsHostMode(USB_OTG_CORE_HANDLE *pdev)
+{
+  return (USB_OTG_GetMode(pdev) == HOST_MODE);
+}
+
+
+/**
+* @brief  USB_OTG_ReadCoreItr : returns the Core Interrupt register
+* @param  pdev : Selected device
+* @retval Status
+*/
+uint32_t USB_OTG_ReadCoreItr(USB_OTG_CORE_HANDLE *pdev)
+{
+  uint32_t v = 0;
+  v = USB_OTG_READ_REG32(&pdev->regs.GREGS->GINTSTS);
+  v &= USB_OTG_READ_REG32(&pdev->regs.GREGS->GINTMSK);
+  return v;
+}
+
+
+/**
+* @brief  USB_OTG_ReadOtgItr : returns the USB_OTG Interrupt register
+* @param  pdev : Selected device
+* @retval Status
+*/
+uint32_t USB_OTG_ReadOtgItr (USB_OTG_CORE_HANDLE *pdev)
+{
+  return (USB_OTG_READ_REG32 (&pdev->regs.GREGS->GOTGINT));
+}
+
+#ifdef USE_HOST_MODE
+/**
+* @brief  USB_OTG_CoreInitHost : Initializes USB_OTG controller for host mode
+* @param  pdev : Selected device
+* @retval status
+*/
+USB_OTG_STS USB_OTG_CoreInitHost(USB_OTG_CORE_HANDLE *pdev)
+{
+  USB_OTG_STS                     status = USB_OTG_OK;
+  USB_OTG_FSIZ_TypeDef            nptxfifosize;
+  USB_OTG_FSIZ_TypeDef            ptxfifosize;  
+  USB_OTG_HCFG_TypeDef            hcfg;
+  
+#ifdef USE_OTG_MODE
+  USB_OTG_OTGCTL_TypeDef          gotgctl;
+#endif
+  
+  uint32_t                        i = 0;
+  
+  nptxfifosize.d32 = 0;  
+  ptxfifosize.d32 = 0;
+#ifdef USE_OTG_MODE
+  gotgctl.d32 = 0;
+#endif
+  hcfg.d32 = 0;
+  
+  
+  /* configure charge pump IO */
+  USB_OTG_BSP_ConfigVBUS(pdev);
+  
+  /* Restart the Phy Clock */
+  USB_OTG_WRITE_REG32(pdev->regs.PCGCCTL, 0);
+  
+  /* Initialize Host Configuration Register */
+  if (pdev->cfg.phy_itface == USB_OTG_ULPI_PHY)
+  {
+    USB_OTG_InitFSLSPClkSel(pdev , HCFG_30_60_MHZ); 
+  }
+  else
+  {
+    USB_OTG_InitFSLSPClkSel(pdev , HCFG_48_MHZ); 
+  }
+  USB_OTG_ResetPort(pdev);
+  
+  hcfg.d32 = USB_OTG_READ_REG32(&pdev->regs.HREGS->HCFG);
+  hcfg.b.fslssupp = 0;
+  USB_OTG_WRITE_REG32(&pdev->regs.HREGS->HCFG, hcfg.d32);
+  
+  /* Configure data FIFO sizes */
+  /* Rx FIFO */
+#ifdef USB_OTG_FS_CORE
+  if(pdev->cfg.coreID == USB_OTG_FS_CORE_ID)
+  {
+    /* set Rx FIFO size */
+    USB_OTG_WRITE_REG32(&pdev->regs.GREGS->GRXFSIZ, RX_FIFO_FS_SIZE);
+    nptxfifosize.b.startaddr = RX_FIFO_FS_SIZE;   
+    nptxfifosize.b.depth = TXH_NP_FS_FIFOSIZ;  
+    USB_OTG_WRITE_REG32(&pdev->regs.GREGS->DIEPTXF0_HNPTXFSIZ, nptxfifosize.d32);
+    
+    ptxfifosize.b.startaddr = RX_FIFO_FS_SIZE + TXH_NP_FS_FIFOSIZ;
+    ptxfifosize.b.depth     = TXH_P_FS_FIFOSIZ;
+    USB_OTG_WRITE_REG32(&pdev->regs.GREGS->HPTXFSIZ, ptxfifosize.d32);      
+  }
+#endif
+#ifdef USB_OTG_HS_CORE  
+  if (pdev->cfg.coreID == USB_OTG_HS_CORE_ID)
+  {
+    /* set Rx FIFO size */
+    USB_OTG_WRITE_REG32(&pdev->regs.GREGS->GRXFSIZ, RX_FIFO_HS_SIZE);
+    nptxfifosize.b.startaddr = RX_FIFO_HS_SIZE;   
+    nptxfifosize.b.depth = TXH_NP_HS_FIFOSIZ;  
+    USB_OTG_WRITE_REG32(&pdev->regs.GREGS->DIEPTXF0_HNPTXFSIZ, nptxfifosize.d32);
+    
+    ptxfifosize.b.startaddr = RX_FIFO_HS_SIZE + TXH_NP_HS_FIFOSIZ;
+    ptxfifosize.b.depth     = TXH_P_HS_FIFOSIZ;
+    USB_OTG_WRITE_REG32(&pdev->regs.GREGS->HPTXFSIZ, ptxfifosize.d32);      
+  }
+#endif  
+  
+#ifdef USE_OTG_MODE
+  /* Clear Host Set HNP Enable in the USB_OTG Control Register */
+  gotgctl.b.hstsethnpen = 1;
+  USB_OTG_MODIFY_REG32( &pdev->regs.GREGS->GOTGCTL, gotgctl.d32, 0);
+#endif
+  
+  /* Make sure the FIFOs are flushed. */
+  USB_OTG_FlushTxFifo(pdev, 0x10 );         /* all Tx FIFOs */
+  USB_OTG_FlushRxFifo(pdev);
+  
+  
+  /* Clear all pending HC Interrupts */
+  for (i = 0; i < pdev->cfg.host_channels; i++)
+  {
+    USB_OTG_WRITE_REG32( &pdev->regs.HC_REGS[i]->HCINT, 0xFFFFFFFF );
+    USB_OTG_WRITE_REG32( &pdev->regs.HC_REGS[i]->HCINTMSK, 0 );
+  }
+#ifndef USE_OTG_MODE
+  USB_OTG_DriveVbus(pdev, 1);
+#endif
+  
+  USB_OTG_EnableHostInt(pdev);
+  return status;
+}
+
+/**
+* @brief  USB_OTG_IsEvenFrame 
+*         This function returns the frame number for sof packet
+* @param  pdev : Selected device
+* @retval Frame number
+*/
+uint8_t USB_OTG_IsEvenFrame (USB_OTG_CORE_HANDLE *pdev) 
+{
+  return !(USB_OTG_READ_REG32(&pdev->regs.HREGS->HFNUM) & 0x1);
+}
+
+/**
+* @brief  USB_OTG_DriveVbus : set/reset vbus
+* @param  pdev : Selected device
+* @param  state : VBUS state
+* @retval None
+*/
+void USB_OTG_DriveVbus (USB_OTG_CORE_HANDLE *pdev, uint8_t state)
+{
+  USB_OTG_HPRT0_TypeDef     hprt0;
+  
+  hprt0.d32 = 0;
+  
+  /* enable disable the external charge pump */
+  USB_OTG_BSP_DriveVBUS(pdev, state);
+  
+  /* Turn on the Host port power. */
+  hprt0.d32 = USB_OTG_ReadHPRT0(pdev);
+  if ((hprt0.b.prtpwr == 0 ) && (state == 1 ))
+  {
+    hprt0.b.prtpwr = 1;
+    USB_OTG_WRITE_REG32(pdev->regs.HPRT0, hprt0.d32);
+  }
+  if ((hprt0.b.prtpwr == 1 ) && (state == 0 ))
+  {
+    hprt0.b.prtpwr = 0;
+    USB_OTG_WRITE_REG32(pdev->regs.HPRT0, hprt0.d32);
+  }
+  
+  USB_OTG_BSP_mDelay(200);
+}
+/**
+* @brief  USB_OTG_EnableHostInt: Enables the Host mode interrupts
+* @param  pdev : Selected device
+* @retval USB_OTG_STS : status
+*/
+USB_OTG_STS USB_OTG_EnableHostInt(USB_OTG_CORE_HANDLE *pdev)
+{
+  USB_OTG_STS       status = USB_OTG_OK;
+  USB_OTG_GINTMSK_TypeDef  intmsk;
+  intmsk.d32 = 0;
+  /* Disable all interrupts. */
+  USB_OTG_WRITE_REG32(&pdev->regs.GREGS->GINTMSK, 0);
+  
+  /* Clear any pending interrupts. */
+  USB_OTG_WRITE_REG32(&pdev->regs.GREGS->GINTSTS, 0xFFFFFFFF);
+  
+  /* Enable the common interrupts */
+  USB_OTG_EnableCommonInt(pdev);
+  
+  if (pdev->cfg.dma_enable == 0)
+  {  
+    intmsk.b.rxstsqlvl  = 1;
+  }  
+  intmsk.b.portintr   = 1;
+  intmsk.b.hcintr     = 1;
+  intmsk.b.disconnect = 1;  
+  intmsk.b.sofintr    = 1;  
+  intmsk.b.incomplisoout  = 1; 
+  USB_OTG_MODIFY_REG32(&pdev->regs.GREGS->GINTMSK, intmsk.d32, intmsk.d32);
+  return status;
+}
+
+/**
+* @brief  USB_OTG_InitFSLSPClkSel : Initializes the FSLSPClkSel field of the 
+*         HCFG register on the PHY type
+* @param  pdev : Selected device
+* @param  freq : clock frequency
+* @retval None
+*/
+void USB_OTG_InitFSLSPClkSel(USB_OTG_CORE_HANDLE *pdev , uint8_t freq)
+{
+  USB_OTG_HCFG_TypeDef   hcfg;
+  
+  hcfg.d32 = USB_OTG_READ_REG32(&pdev->regs.HREGS->HCFG);
+  hcfg.b.fslspclksel = freq;
+  USB_OTG_WRITE_REG32(&pdev->regs.HREGS->HCFG, hcfg.d32);
+}
+
+
+/**
+* @brief  USB_OTG_ReadHPRT0 : Reads HPRT0 to modify later
+* @param  pdev : Selected device
+* @retval HPRT0 value
+*/
+uint32_t USB_OTG_ReadHPRT0(USB_OTG_CORE_HANDLE *pdev)
+{
+  USB_OTG_HPRT0_TypeDef  hprt0;
+  
+  hprt0.d32 = USB_OTG_READ_REG32(pdev->regs.HPRT0);
+  hprt0.b.prtena = 0;
+  hprt0.b.prtconndet = 0;
+  hprt0.b.prtenchng = 0;
+  hprt0.b.prtovrcurrchng = 0;
+  return hprt0.d32;
+}
+
+
+/**
+* @brief  USB_OTG_ReadHostAllChannels_intr : Register PCD Callbacks
+* @param  pdev : Selected device
+* @retval Status
+*/
+uint32_t USB_OTG_ReadHostAllChannels_intr (USB_OTG_CORE_HANDLE *pdev)
+{
+  return (USB_OTG_READ_REG32 (&pdev->regs.HREGS->HAINT));
+}
+
+
+/**
+* @brief  USB_OTG_ResetPort : Reset Host Port
+* @param  pdev : Selected device
+* @retval status
+* @note : (1)The application must wait at least 10 ms (+ 10 ms security)
+*   before clearing the reset bit.
+*/
+uint32_t USB_OTG_ResetPort(USB_OTG_CORE_HANDLE *pdev)
+{
+  USB_OTG_HPRT0_TypeDef  hprt0;
+  
+  hprt0.d32 = USB_OTG_ReadHPRT0(pdev);
+  hprt0.b.prtrst = 1;
+  USB_OTG_WRITE_REG32(pdev->regs.HPRT0, hprt0.d32);
+  USB_OTG_BSP_mDelay (10);                                /* See Note #1 */
+  hprt0.b.prtrst = 0;
+  USB_OTG_WRITE_REG32(pdev->regs.HPRT0, hprt0.d32);
+  USB_OTG_BSP_mDelay (20);   
+  return 1;
+}
+
+
+/**
+* @brief  USB_OTG_HC_Init : Prepares a host channel for transferring packets
+* @param  pdev : Selected device
+* @param  hc_num : channel number
+* @retval USB_OTG_STS : status
+*/
+USB_OTG_STS USB_OTG_HC_Init(USB_OTG_CORE_HANDLE *pdev , uint8_t hc_num)
+{
+  USB_OTG_STS status = USB_OTG_OK;
+  uint32_t intr_enable = 0;
+  USB_OTG_HCINTMSK_TypeDef  hcintmsk;
+  USB_OTG_GINTMSK_TypeDef    gintmsk;
+  USB_OTG_HCCHAR_TypeDef     hcchar;
+  USB_OTG_HCINTn_TypeDef     hcint;
+  
+  
+  gintmsk.d32 = 0;
+  hcintmsk.d32 = 0;
+  hcchar.d32 = 0;
+  
+  /* Clear old interrupt conditions for this host channel. */
+  hcint.d32 = 0xFFFFFFFF;
+  USB_OTG_WRITE_REG32(&pdev->regs.HC_REGS[hc_num]->HCINT, hcint.d32);
+  
+  /* Enable channel interrupts required for this transfer. */
+  hcintmsk.d32 = 0;
+  
+  if (pdev->cfg.dma_enable == 1)
+  {
+    hcintmsk.b.ahberr = 1;
+  }
+  
+  switch (pdev->host.hc[hc_num].ep_type) 
+  {
+  case EP_TYPE_CTRL:
+  case EP_TYPE_BULK:
+    hcintmsk.b.xfercompl = 1;
+    hcintmsk.b.stall = 1;
+    hcintmsk.b.xacterr = 1;
+    hcintmsk.b.datatglerr = 1;
+    hcintmsk.b.nak = 1;  
+    if (pdev->host.hc[hc_num].ep_is_in) 
+    {
+      hcintmsk.b.bblerr = 1;
+    } 
+    else 
+    {
+      hcintmsk.b.nyet = 1;
+      if (pdev->host.hc[hc_num].do_ping) 
+      {
+        hcintmsk.b.ack = 1;
+      }
+    }
+    break;
+  case EP_TYPE_INTR:
+    hcintmsk.b.xfercompl = 1;
+    hcintmsk.b.nak = 1;
+    hcintmsk.b.stall = 1;
+    hcintmsk.b.xacterr = 1;
+    hcintmsk.b.datatglerr = 1;
+    hcintmsk.b.frmovrun = 1;
+    
+    if (pdev->host.hc[hc_num].ep_is_in) 
+    {
+      hcintmsk.b.bblerr = 1;
+    }
+    
+    break;
+  case EP_TYPE_ISOC:
+    hcintmsk.b.xfercompl = 1;
+    hcintmsk.b.frmovrun = 1;
+    hcintmsk.b.ack = 1;
+    
+    if (pdev->host.hc[hc_num].ep_is_in) 
+    {
+      hcintmsk.b.xacterr = 1;
+      hcintmsk.b.bblerr = 1;
+    }
+    break;
+  }
+  
+  
+  USB_OTG_WRITE_REG32(&pdev->regs.HC_REGS[hc_num]->HCINTMSK, hcintmsk.d32);
+  
+  
+  /* Enable the top level host channel interrupt. */
+  intr_enable = (1 << hc_num);
+  USB_OTG_MODIFY_REG32(&pdev->regs.HREGS->HAINTMSK, 0, intr_enable);
+  
+  /* Make sure host channel interrupts are enabled. */
+  gintmsk.b.hcintr = 1;
+  USB_OTG_MODIFY_REG32(&pdev->regs.GREGS->GINTMSK, 0, gintmsk.d32);
+  
+  /* Program the HCCHAR register */
+  hcchar.d32 = 0;
+  hcchar.b.devaddr = pdev->host.hc[hc_num].dev_addr;
+  hcchar.b.epnum   = pdev->host.hc[hc_num].ep_num;
+  hcchar.b.epdir   = pdev->host.hc[hc_num].ep_is_in;
+  hcchar.b.lspddev = (pdev->host.hc[hc_num].speed == HPRT0_PRTSPD_LOW_SPEED);
+  hcchar.b.eptype  = pdev->host.hc[hc_num].ep_type;
+  hcchar.b.mps     = pdev->host.hc[hc_num].max_packet;
+  if (pdev->host.hc[hc_num].ep_type == HCCHAR_INTR)
+  {
+    hcchar.b.oddfrm  = 1;
+  }
+  USB_OTG_WRITE_REG32(&pdev->regs.HC_REGS[hc_num]->HCCHAR, hcchar.d32);
+  return status;
+}
+
+
+/**
+* @brief  USB_OTG_HC_StartXfer : Start transfer
+* @param  pdev : Selected device
+* @param  hc_num : channel number
+* @retval USB_OTG_STS : status
+*/
+USB_OTG_STS USB_OTG_HC_StartXfer(USB_OTG_CORE_HANDLE *pdev , uint8_t hc_num)
+{
+  USB_OTG_STS status = USB_OTG_OK;
+  USB_OTG_HCCHAR_TypeDef   hcchar;
+  USB_OTG_HCTSIZn_TypeDef  hctsiz;
+  USB_OTG_HNPTXSTS_TypeDef hnptxsts; 
+  USB_OTG_HPTXSTS_TypeDef  hptxsts; 
+  USB_OTG_GINTMSK_TypeDef  intmsk;
+  uint16_t                 len_words = 0;   
+  
+  uint16_t num_packets;
+  uint16_t max_hc_pkt_count;
+  
+  max_hc_pkt_count = 256;
+  hctsiz.d32 = 0;
+  hcchar.d32 = 0;
+  intmsk.d32 = 0;
+  
+  /* Compute the expected number of packets associated to the transfer */
+  if (pdev->host.hc[hc_num].xfer_len > 0)
+  {
+    num_packets = (pdev->host.hc[hc_num].xfer_len + \
+      pdev->host.hc[hc_num].max_packet - 1) / pdev->host.hc[hc_num].max_packet;
+    
+    if (num_packets > max_hc_pkt_count)
+    {
+      num_packets = max_hc_pkt_count;
+      pdev->host.hc[hc_num].xfer_len = num_packets * \
+        pdev->host.hc[hc_num].max_packet;
+    }
+  }
+  else
+  {
+    num_packets = 1;
+  }
+  if (pdev->host.hc[hc_num].ep_is_in)
+  {
+    pdev->host.hc[hc_num].xfer_len = num_packets * \
+      pdev->host.hc[hc_num].max_packet;
+  }
+  /* Initialize the HCTSIZn register */
+  hctsiz.b.xfersize = pdev->host.hc[hc_num].xfer_len;
+  hctsiz.b.pktcnt = num_packets;
+  hctsiz.b.pid = pdev->host.hc[hc_num].data_pid;
+  USB_OTG_WRITE_REG32(&pdev->regs.HC_REGS[hc_num]->HCTSIZ, hctsiz.d32);
+  
+  if (pdev->cfg.dma_enable == 1)
+  {
+    USB_OTG_WRITE_REG32(&pdev->regs.HC_REGS[hc_num]->HCDMA, (unsigned int)pdev->host.hc[hc_num].xfer_buff);
+  }
+  
+  
+  hcchar.d32 = USB_OTG_READ_REG32(&pdev->regs.HC_REGS[hc_num]->HCCHAR);
+  hcchar.b.oddfrm = USB_OTG_IsEvenFrame(pdev);
+  
+  /* Set host channel enable */
+  hcchar.b.chen = 1;
+  hcchar.b.chdis = 0;
+  USB_OTG_WRITE_REG32(&pdev->regs.HC_REGS[hc_num]->HCCHAR, hcchar.d32);
+  
+  if (pdev->cfg.dma_enable == 0) /* Slave mode */
+  {  
+    if((pdev->host.hc[hc_num].ep_is_in == 0) && 
+       (pdev->host.hc[hc_num].xfer_len > 0))
+    {
+      switch(pdev->host.hc[hc_num].ep_type) 
+      {
+        /* Non periodic transfer */
+      case EP_TYPE_CTRL:
+      case EP_TYPE_BULK:
+        
+        hnptxsts.d32 = USB_OTG_READ_REG32(&pdev->regs.GREGS->HNPTXSTS);
+        len_words = (pdev->host.hc[hc_num].xfer_len + 3) / 4;
+        
+        /* check if there is enough space in FIFO space */
+        if(len_words > hnptxsts.b.nptxfspcavail)
+        {
+          /* need to process data in nptxfempty interrupt */
+          intmsk.b.nptxfempty = 1;
+          USB_OTG_MODIFY_REG32( &pdev->regs.GREGS->GINTMSK, 0, intmsk.d32);  
+        }
+        
+        break;
+        /* Periodic transfer */
+      case EP_TYPE_INTR:
+      case EP_TYPE_ISOC:
+        hptxsts.d32 = USB_OTG_READ_REG32(&pdev->regs.HREGS->HPTXSTS);
+        len_words = (pdev->host.hc[hc_num].xfer_len + 3) / 4;
+        /* check if there is enough space in FIFO space */
+        if(len_words > hptxsts.b.ptxfspcavail) /* split the transfer */
+        {
+          /* need to process data in ptxfempty interrupt */
+          intmsk.b.ptxfempty = 1;
+          USB_OTG_MODIFY_REG32( &pdev->regs.GREGS->GINTMSK, 0, intmsk.d32);  
+        }
+        break;
+        
+      default:
+        break;
+      }
+      
+      /* Write packet into the Tx FIFO. */
+      USB_OTG_WritePacket(pdev, 
+                          pdev->host.hc[hc_num].xfer_buff , 
+                          hc_num, pdev->host.hc[hc_num].xfer_len);
+    }
+  }
+  return status;
+}
+
+
+/**
+* @brief  USB_OTG_HC_Halt : Halt channel
+* @param  pdev : Selected device
+* @param  hc_num : channel number
+* @retval USB_OTG_STS : status
+*/
+USB_OTG_STS USB_OTG_HC_Halt(USB_OTG_CORE_HANDLE *pdev , uint8_t hc_num)
+{
+  USB_OTG_STS status = USB_OTG_OK;
+  USB_OTG_HNPTXSTS_TypeDef            nptxsts;
+  USB_OTG_HPTXSTS_TypeDef             hptxsts;
+  USB_OTG_HCCHAR_TypeDef              hcchar;
+  
+  nptxsts.d32 = 0;
+  hptxsts.d32 = 0;
+  hcchar.d32 = USB_OTG_READ_REG32(&pdev->regs.HC_REGS[hc_num]->HCCHAR);
+  hcchar.b.chen = 1;
+  hcchar.b.chdis = 1;
+  
+  /* Check for space in the request queue to issue the halt. */
+  if (hcchar.b.eptype == HCCHAR_CTRL || hcchar.b.eptype == HCCHAR_BULK)
+  {
+    nptxsts.d32 = USB_OTG_READ_REG32(&pdev->regs.GREGS->HNPTXSTS);
+    if (nptxsts.b.nptxqspcavail == 0)
+    {
+      hcchar.b.chen = 0;
+    }
+  }
+  else
+  {
+    hptxsts.d32 = USB_OTG_READ_REG32(&pdev->regs.HREGS->HPTXSTS);
+    if (hptxsts.b.ptxqspcavail == 0)
+    {
+      hcchar.b.chen = 0;
+    }
+  }
+  USB_OTG_WRITE_REG32(&pdev->regs.HC_REGS[hc_num]->HCCHAR, hcchar.d32);
+  return status;
+}
+
+/**
+* @brief  Issue a ping token
+* @param  None
+* @retval : None
+*/
+USB_OTG_STS USB_OTG_HC_DoPing(USB_OTG_CORE_HANDLE *pdev , uint8_t hc_num)
+{
+  USB_OTG_STS               status = USB_OTG_OK;
+  USB_OTG_HCCHAR_TypeDef    hcchar;
+  USB_OTG_HCTSIZn_TypeDef   hctsiz;  
+  
+  hctsiz.d32 = 0;
+  hctsiz.b.dopng = 1;
+  hctsiz.b.pktcnt = 1;
+  USB_OTG_WRITE_REG32(&pdev->regs.HC_REGS[hc_num]->HCTSIZ, hctsiz.d32);
+  
+  hcchar.d32 = USB_OTG_READ_REG32(&pdev->regs.HC_REGS[hc_num]->HCCHAR);
+  hcchar.b.chen = 1;
+  hcchar.b.chdis = 0;
+  USB_OTG_WRITE_REG32(&pdev->regs.HC_REGS[hc_num]->HCCHAR, hcchar.d32);
+  return status;  
+}
+
+/**
+* @brief  Stop the device and clean up fifo's
+* @param  None
+* @retval : None
+*/
+void USB_OTG_StopHost(USB_OTG_CORE_HANDLE *pdev)
+{
+  USB_OTG_HCCHAR_TypeDef  hcchar;
+  uint32_t                i;
+  
+  USB_OTG_WRITE_REG32(&pdev->regs.HREGS->HAINTMSK , 0);
+  USB_OTG_WRITE_REG32(&pdev->regs.HREGS->HAINT,      0xFFFFFFFF);
+  /* Flush out any leftover queued requests. */
+  
+  for (i = 0; i < pdev->cfg.host_channels; i++)
+  {
+    hcchar.d32 = USB_OTG_READ_REG32(&pdev->regs.HC_REGS[i]->HCCHAR);
+    hcchar.b.chen = 0;
+    hcchar.b.chdis = 1;
+    hcchar.b.epdir = 0;
+    USB_OTG_WRITE_REG32(&pdev->regs.HC_REGS[i]->HCCHAR, hcchar.d32);
+  }
+  
+  /* Flush the FIFO */
+  USB_OTG_FlushRxFifo(pdev);
+  USB_OTG_FlushTxFifo(pdev ,  0x10 );  
+}
+#endif
+#ifdef USE_DEVICE_MODE
+/*         PCD Core Layer       */
+
+/**
+* @brief  USB_OTG_InitDevSpeed :Initializes the DevSpd field of DCFG register 
+*         depending the PHY type and the enumeration speed of the device.
+* @param  pdev : Selected device
+* @retval : None
+*/
+void USB_OTG_InitDevSpeed(USB_OTG_CORE_HANDLE *pdev , uint8_t speed)
+{
+  USB_OTG_DCFG_TypeDef   dcfg;
+  
+  dcfg.d32 = USB_OTG_READ_REG32(&pdev->regs.DREGS->DCFG);
+  dcfg.b.devspd = speed;
+  USB_OTG_WRITE_REG32(&pdev->regs.DREGS->DCFG, dcfg.d32);
+}
+
+
+/**
+* @brief  USB_OTG_CoreInitDev : Initializes the USB_OTG controller registers 
+*         for device mode
+* @param  pdev : Selected device
+* @retval USB_OTG_STS : status
+*/
+USB_OTG_STS USB_OTG_CoreInitDev (USB_OTG_CORE_HANDLE *pdev)
+{
+  USB_OTG_STS             status       = USB_OTG_OK;
+  USB_OTG_DEPCTL_TypeDef  depctl;
+  uint32_t i;
+  USB_OTG_DCFG_TypeDef    dcfg;
+  USB_OTG_FSIZ_TypeDef    nptxfifosize;
+  USB_OTG_FSIZ_TypeDef    txfifosize;
+  USB_OTG_DIEPMSK_TypeDef msk;
+  USB_OTG_DTHRCTL_TypeDef dthrctl;  
+  
+  depctl.d32 = 0;
+  dcfg.d32 = 0;
+  nptxfifosize.d32 = 0;
+  txfifosize.d32 = 0;
+  msk.d32 = 0;
+  
+  /* Restart the Phy Clock */
+  USB_OTG_WRITE_REG32(pdev->regs.PCGCCTL, 0);
+  /* Device configuration register */
+  dcfg.d32 = USB_OTG_READ_REG32( &pdev->regs.DREGS->DCFG);
+  dcfg.b.perfrint = DCFG_FRAME_INTERVAL_80;
+  USB_OTG_WRITE_REG32( &pdev->regs.DREGS->DCFG, dcfg.d32 );
+  
+#ifdef USB_OTG_FS_CORE
+  if(pdev->cfg.coreID == USB_OTG_FS_CORE_ID  )
+  {  
+    
+    /* Set Full speed phy */
+    USB_OTG_InitDevSpeed (pdev , USB_OTG_SPEED_PARAM_FULL);
+    
+    /* set Rx FIFO size */
+    USB_OTG_WRITE_REG32(&pdev->regs.GREGS->GRXFSIZ, RX_FIFO_FS_SIZE);
+    
+    /* EP0 TX*/
+    nptxfifosize.b.depth     = TX0_FIFO_FS_SIZE;
+    nptxfifosize.b.startaddr = RX_FIFO_FS_SIZE;
+    USB_OTG_WRITE_REG32( &pdev->regs.GREGS->DIEPTXF0_HNPTXFSIZ, nptxfifosize.d32 );
+    
+    
+    /* EP1 TX*/
+    txfifosize.b.startaddr = nptxfifosize.b.startaddr + nptxfifosize.b.depth;
+    txfifosize.b.depth = TX1_FIFO_FS_SIZE;
+    USB_OTG_WRITE_REG32( &pdev->regs.GREGS->DIEPTXF[0], txfifosize.d32 );
+    
+    
+    /* EP2 TX*/
+    txfifosize.b.startaddr += txfifosize.b.depth;
+    txfifosize.b.depth = TX2_FIFO_FS_SIZE;
+    USB_OTG_WRITE_REG32( &pdev->regs.GREGS->DIEPTXF[1], txfifosize.d32 );
+    
+    
+    /* EP3 TX*/  
+    txfifosize.b.startaddr += txfifosize.b.depth;
+    txfifosize.b.depth = TX3_FIFO_FS_SIZE;
+    USB_OTG_WRITE_REG32( &pdev->regs.GREGS->DIEPTXF[2], txfifosize.d32 );
+  }
+#endif
+#ifdef USB_OTG_HS_CORE
+  if(pdev->cfg.coreID == USB_OTG_HS_CORE_ID  )
+  {
+    
+    /* Set High speed phy */
+    
+    if(pdev->cfg.phy_itface  == USB_OTG_ULPI_PHY)
+    {
+      USB_OTG_InitDevSpeed (pdev , USB_OTG_SPEED_PARAM_HIGH);
+    }
+    else /* set High speed phy in Full speed mode */
+    {
+      USB_OTG_InitDevSpeed (pdev , USB_OTG_SPEED_PARAM_HIGH_IN_FULL);
+    }
+    
+    /* set Rx FIFO size */
+    USB_OTG_WRITE_REG32(&pdev->regs.GREGS->GRXFSIZ, RX_FIFO_HS_SIZE);
+    
+    /* EP0 TX*/
+    nptxfifosize.b.depth     = TX0_FIFO_HS_SIZE;
+    nptxfifosize.b.startaddr = RX_FIFO_HS_SIZE;
+    USB_OTG_WRITE_REG32( &pdev->regs.GREGS->DIEPTXF0_HNPTXFSIZ, nptxfifosize.d32 );
+    
+    
+    /* EP1 TX*/
+    txfifosize.b.startaddr = nptxfifosize.b.startaddr + nptxfifosize.b.depth;
+    txfifosize.b.depth = TX1_FIFO_HS_SIZE;
+    USB_OTG_WRITE_REG32( &pdev->regs.GREGS->DIEPTXF[0], txfifosize.d32 );
+    
+    
+    /* EP2 TX*/
+    txfifosize.b.startaddr += txfifosize.b.depth;
+    txfifosize.b.depth = TX2_FIFO_HS_SIZE;
+    USB_OTG_WRITE_REG32( &pdev->regs.GREGS->DIEPTXF[1], txfifosize.d32 );
+    
+    
+    /* EP3 TX*/  
+    txfifosize.b.startaddr += txfifosize.b.depth;
+    txfifosize.b.depth = TX3_FIFO_HS_SIZE;
+    USB_OTG_WRITE_REG32( &pdev->regs.GREGS->DIEPTXF[2], txfifosize.d32 );
+    
+    /* EP4 TX*/
+    txfifosize.b.startaddr += txfifosize.b.depth;
+    txfifosize.b.depth = TX4_FIFO_HS_SIZE;
+    USB_OTG_WRITE_REG32( &pdev->regs.GREGS->DIEPTXF[3], txfifosize.d32 );
+    
+    
+    /* EP5 TX*/  
+    txfifosize.b.startaddr += txfifosize.b.depth;
+    txfifosize.b.depth = TX5_FIFO_HS_SIZE;
+    USB_OTG_WRITE_REG32( &pdev->regs.GREGS->DIEPTXF[4], txfifosize.d32 );
+  }
+#endif  
+  /* Flush the FIFOs */
+  USB_OTG_FlushTxFifo(pdev , 0x10); /* all Tx FIFOs */
+  USB_OTG_FlushRxFifo(pdev);
+  /* Clear all pending Device Interrupts */
+  USB_OTG_WRITE_REG32( &pdev->regs.DREGS->DIEPMSK, 0 );
+  USB_OTG_WRITE_REG32( &pdev->regs.DREGS->DOEPMSK, 0 );
+  USB_OTG_WRITE_REG32( &pdev->regs.DREGS->DAINT, 0xFFFFFFFF );
+  USB_OTG_WRITE_REG32( &pdev->regs.DREGS->DAINTMSK, 0 );
+  
+  for (i = 0; i < pdev->cfg.dev_endpoints; i++)
+  {
+    depctl.d32 = USB_OTG_READ_REG32(&pdev->regs.INEP_REGS[i]->DIEPCTL);
+    if (depctl.b.epena)
+    {
+      depctl.d32 = 0;
+      depctl.b.epdis = 1;
+      depctl.b.snak = 1;
+    }
+    else
+    {
+      depctl.d32 = 0;
+    }
+    USB_OTG_WRITE_REG32( &pdev->regs.INEP_REGS[i]->DIEPCTL, depctl.d32);
+    USB_OTG_WRITE_REG32( &pdev->regs.INEP_REGS[i]->DIEPTSIZ, 0);
+    USB_OTG_WRITE_REG32( &pdev->regs.INEP_REGS[i]->DIEPINT, 0xFF);
+  }
+  for (i = 0; i <  pdev->cfg.dev_endpoints; i++)
+  {
+    USB_OTG_DEPCTL_TypeDef  depctl;
+    depctl.d32 = USB_OTG_READ_REG32(&pdev->regs.OUTEP_REGS[i]->DOEPCTL);
+    if (depctl.b.epena)
+    {
+      depctl.d32 = 0;
+      depctl.b.epdis = 1;
+      depctl.b.snak = 1;
+    }
+    else
+    {
+      depctl.d32 = 0;
+    }
+    USB_OTG_WRITE_REG32( &pdev->regs.OUTEP_REGS[i]->DOEPCTL, depctl.d32);
+    USB_OTG_WRITE_REG32( &pdev->regs.OUTEP_REGS[i]->DOEPTSIZ, 0);
+    USB_OTG_WRITE_REG32( &pdev->regs.OUTEP_REGS[i]->DOEPINT, 0xFF);
+  }
+  msk.d32 = 0;
+  msk.b.txfifoundrn = 1;
+  USB_OTG_MODIFY_REG32(&pdev->regs.DREGS->DIEPMSK, msk.d32, msk.d32);
+  
+  if (pdev->cfg.dma_enable == 1)
+  {
+    dthrctl.d32 = 0;
+    dthrctl.b.non_iso_thr_en = 1;
+    dthrctl.b.iso_thr_en = 1;
+    dthrctl.b.tx_thr_len = 64;
+    dthrctl.b.rx_thr_en = 1;
+    dthrctl.b.rx_thr_len = 64;
+    USB_OTG_WRITE_REG32(&pdev->regs.DREGS->DTHRCTL, dthrctl.d32);  
+  }
+  USB_OTG_EnableDevInt(pdev);
+  return status;
+}
+
+
+/**
+* @brief  USB_OTG_EnableDevInt : Enables the Device mode interrupts
+* @param  pdev : Selected device
+* @retval USB_OTG_STS : status
+*/
+USB_OTG_STS USB_OTG_EnableDevInt(USB_OTG_CORE_HANDLE *pdev)
+{
+  USB_OTG_STS status = USB_OTG_OK;
+  USB_OTG_GINTMSK_TypeDef  intmsk;
+  
+  intmsk.d32 = 0;
+  
+  /* Disable all interrupts. */
+  USB_OTG_WRITE_REG32( &pdev->regs.GREGS->GINTMSK, 0);
+  /* Clear any pending interrupts */
+  USB_OTG_WRITE_REG32( &pdev->regs.GREGS->GINTSTS, 0xBFFFFFFF);
+  /* Enable the common interrupts */
+  USB_OTG_EnableCommonInt(pdev);
+  
+  if (pdev->cfg.dma_enable == 0)
+  {
+    intmsk.b.rxstsqlvl = 1;
+  }
+  
+  /* Enable interrupts matching to the Device mode ONLY */
+  intmsk.b.usbsuspend = 1;
+  intmsk.b.usbreset   = 1;
+  intmsk.b.enumdone   = 1;
+  intmsk.b.inepintr   = 1;
+  intmsk.b.outepintr  = 1;
+  intmsk.b.sofintr    = 1; 
+  
+  intmsk.b.incomplisoin    = 1; 
+  intmsk.b.incomplisoout    = 1;   
+#ifdef VBUS_SENSING_ENABLED
+  intmsk.b.sessreqintr    = 1; 
+  intmsk.b.otgintr    = 1;    
+#endif  
+  USB_OTG_MODIFY_REG32( &pdev->regs.GREGS->GINTMSK, intmsk.d32, intmsk.d32);
+  return status;
+}
+
+
+/**
+* @brief  USB_OTG_GetDeviceSpeed
+*         Get the device speed from the device status register
+* @param  None
+* @retval status
+*/
+enum USB_OTG_SPEED USB_OTG_GetDeviceSpeed (USB_OTG_CORE_HANDLE *pdev)
+{
+  USB_OTG_DSTS_TypeDef  dsts;
+  enum USB_OTG_SPEED speed = USB_SPEED_UNKNOWN;
+  
+  
+  dsts.d32 = USB_OTG_READ_REG32(&pdev->regs.DREGS->DSTS);
+  
+  switch (dsts.b.enumspd)
+  {
+  case DSTS_ENUMSPD_HS_PHY_30MHZ_OR_60MHZ:
+    speed = USB_SPEED_HIGH;
+    break;
+  case DSTS_ENUMSPD_FS_PHY_30MHZ_OR_60MHZ:
+  case DSTS_ENUMSPD_FS_PHY_48MHZ:
+    speed = USB_SPEED_FULL;
+    break;
+    
+  case DSTS_ENUMSPD_LS_PHY_6MHZ:
+    speed = USB_SPEED_LOW;
+    break;
+  }
+  
+  return speed;
+}
+/**
+* @brief  enables EP0 OUT to receive SETUP packets and configures EP0
+*   for transmitting packets
+* @param  None
+* @retval USB_OTG_STS : status
+*/
+USB_OTG_STS  USB_OTG_EP0Activate(USB_OTG_CORE_HANDLE *pdev)
+{
+  USB_OTG_STS             status = USB_OTG_OK;
+  USB_OTG_DSTS_TypeDef    dsts;
+  USB_OTG_DEPCTL_TypeDef  diepctl;
+  USB_OTG_DCTL_TypeDef    dctl;
+  
+  dctl.d32 = 0;
+  /* Read the Device Status and Endpoint 0 Control registers */
+  dsts.d32 = USB_OTG_READ_REG32(&pdev->regs.DREGS->DSTS);
+  diepctl.d32 = USB_OTG_READ_REG32(&pdev->regs.INEP_REGS[0]->DIEPCTL);
+  /* Set the MPS of the IN EP based on the enumeration speed */
+  switch (dsts.b.enumspd)
+  {
+  case DSTS_ENUMSPD_HS_PHY_30MHZ_OR_60MHZ:
+  case DSTS_ENUMSPD_FS_PHY_30MHZ_OR_60MHZ:
+  case DSTS_ENUMSPD_FS_PHY_48MHZ:
+    diepctl.b.mps = DEP0CTL_MPS_64;
+    break;
+  case DSTS_ENUMSPD_LS_PHY_6MHZ:
+    diepctl.b.mps = DEP0CTL_MPS_8;
+    break;
+  }
+  USB_OTG_WRITE_REG32(&pdev->regs.INEP_REGS[0]->DIEPCTL, diepctl.d32);
+  dctl.b.cgnpinnak = 1;
+  USB_OTG_MODIFY_REG32(&pdev->regs.DREGS->DCTL, dctl.d32, dctl.d32);
+  return status;
+}
+
+
+/**
+* @brief  USB_OTG_EPActivate : Activates an EP
+* @param  pdev : Selected device
+* @retval USB_OTG_STS : status
+*/
+USB_OTG_STS USB_OTG_EPActivate(USB_OTG_CORE_HANDLE *pdev , USB_OTG_EP *ep)
+{
+  USB_OTG_STS status = USB_OTG_OK;
+  USB_OTG_DEPCTL_TypeDef  depctl;
+  USB_OTG_DAINT_TypeDef  daintmsk;
+  __IO uint32_t *addr;
+  
+  
+  depctl.d32 = 0;
+  daintmsk.d32 = 0;
+  /* Read DEPCTLn register */
+  if (ep->is_in == 1)
+  {
+    addr = &pdev->regs.INEP_REGS[ep->num]->DIEPCTL;
+    daintmsk.ep.in = 1 << ep->num;
+  }
+  else
+  {
+    addr = &pdev->regs.OUTEP_REGS[ep->num]->DOEPCTL;
+    daintmsk.ep.out = 1 << ep->num;
+  }
+  /* If the EP is already active don't change the EP Control
+  * register. */
+  depctl.d32 = USB_OTG_READ_REG32(addr);
+  if (!depctl.b.usbactep)
+  {
+    depctl.b.mps    = ep->maxpacket;
+    depctl.b.eptype = ep->type;
+    depctl.b.txfnum = ep->tx_fifo_num;
+    depctl.b.setd0pid = 1;
+    depctl.b.usbactep = 1;
+    USB_OTG_WRITE_REG32(addr, depctl.d32);
+  }
+  /* Enable the Interrupt for this EP */
+#ifdef USB_OTG_HS_DEDICATED_EP1_ENABLED
+  if((ep->num == 1)&&(pdev->cfg.coreID == USB_OTG_HS_CORE_ID))
+  {
+    USB_OTG_MODIFY_REG32(&pdev->regs.DREGS->DEACHMSK, 0, daintmsk.d32);
+  }
+  else
+#endif   
+    USB_OTG_MODIFY_REG32(&pdev->regs.DREGS->DAINTMSK, 0, daintmsk.d32);
+  return status;
+}
+
+
+/**
+* @brief  USB_OTG_EPDeactivate : Deactivates an EP
+* @param  pdev : Selected device
+* @retval USB_OTG_STS : status
+*/
+USB_OTG_STS USB_OTG_EPDeactivate(USB_OTG_CORE_HANDLE *pdev , USB_OTG_EP *ep)
+{
+  USB_OTG_STS status = USB_OTG_OK;
+  USB_OTG_DEPCTL_TypeDef  depctl;
+  USB_OTG_DAINT_TypeDef  daintmsk;
+  __IO uint32_t *addr;
+  
+  depctl.d32 = 0;
+  daintmsk.d32 = 0;  
+  /* Read DEPCTLn register */
+  if (ep->is_in == 1)
+  {
+    addr = &pdev->regs.INEP_REGS[ep->num]->DIEPCTL;
+    daintmsk.ep.in = 1 << ep->num;
+  }
+  else
+  {
+    addr = &pdev->regs.OUTEP_REGS[ep->num]->DOEPCTL;
+    daintmsk.ep.out = 1 << ep->num;
+  }
+  depctl.b.usbactep = 0;
+  USB_OTG_WRITE_REG32(addr, depctl.d32);
+  /* Disable the Interrupt for this EP */
+  
+#ifdef USB_OTG_HS_DEDICATED_EP1_ENABLED
+  if((ep->num == 1)&&(pdev->cfg.coreID == USB_OTG_HS_CORE_ID))
+  {
+    USB_OTG_MODIFY_REG32(&pdev->regs.DREGS->DEACHMSK, daintmsk.d32, 0);
+  }
+  else
+#endif    
+    USB_OTG_MODIFY_REG32(&pdev->regs.DREGS->DAINTMSK, daintmsk.d32, 0);
+  return status;
+}
+
+
+/**
+* @brief  USB_OTG_EPStartXfer : Handle the setup for data xfer for an EP and 
+*         starts the xfer
+* @param  pdev : Selected device
+* @retval USB_OTG_STS : status
+*/
+USB_OTG_STS USB_OTG_EPStartXfer(USB_OTG_CORE_HANDLE *pdev , USB_OTG_EP *ep)
+{
+  USB_OTG_STS status = USB_OTG_OK;
+  USB_OTG_DEPCTL_TypeDef     depctl;
+  USB_OTG_DEPXFRSIZ_TypeDef  deptsiz;
+  USB_OTG_DSTS_TypeDef       dsts;    
+  uint32_t fifoemptymsk = 0;  
+  
+  depctl.d32 = 0;
+  deptsiz.d32 = 0;
+  /* IN endpoint */
+  if (ep->is_in == 1)
+  {
+    depctl.d32  = USB_OTG_READ_REG32(&(pdev->regs.INEP_REGS[ep->num]->DIEPCTL));
+    deptsiz.d32 = USB_OTG_READ_REG32(&(pdev->regs.INEP_REGS[ep->num]->DIEPTSIZ));
+    /* Zero Length Packet? */
+    if (ep->xfer_len == 0)
+    {
+      deptsiz.b.xfersize = 0;
+      deptsiz.b.pktcnt = 1;
+    }
+    else
+    {
+      /* Program the transfer size and packet count
+      * as follows: xfersize = N * maxpacket +
+      * short_packet pktcnt = N + (short_packet
+      * exist ? 1 : 0)
+      */
+      deptsiz.b.xfersize = ep->xfer_len;
+      deptsiz.b.pktcnt = (ep->xfer_len - 1 + ep->maxpacket) / ep->maxpacket;
+      
+      if (ep->type == EP_TYPE_ISOC)
+      {
+        deptsiz.b.mc = 1;
+      }       
+    }
+    USB_OTG_WRITE_REG32(&pdev->regs.INEP_REGS[ep->num]->DIEPTSIZ, deptsiz.d32);
+    
+    if (pdev->cfg.dma_enable == 1)
+    {
+      USB_OTG_WRITE_REG32(&pdev->regs.INEP_REGS[ep->num]->DIEPDMA, ep->dma_addr);
+    }
+    else
+    {
+      if (ep->type != EP_TYPE_ISOC)
+      {
+        /* Enable the Tx FIFO Empty Interrupt for this EP */
+        if (ep->xfer_len > 0)
+        {
+          fifoemptymsk = 1 << ep->num;
+          USB_OTG_MODIFY_REG32(&pdev->regs.DREGS->DIEPEMPMSK, 0, fifoemptymsk);
+        }
+      }
+    }
+    
+    
+    if (ep->type == EP_TYPE_ISOC)
+    {
+      dsts.d32 = USB_OTG_READ_REG32(&pdev->regs.DREGS->DSTS);
+      
+      if (((dsts.b.soffn)&0x1) == 0)
+      {
+        depctl.b.setd1pid = 1;
+      }
+      else
+      {
+        depctl.b.setd0pid = 1;
+      }
+    } 
+    
+    /* EP enable, IN data in FIFO */
+    depctl.b.cnak = 1;
+    depctl.b.epena = 1;
+    USB_OTG_WRITE_REG32(&pdev->regs.INEP_REGS[ep->num]->DIEPCTL, depctl.d32);
+    
+    if (ep->type == EP_TYPE_ISOC)
+    {
+      USB_OTG_WritePacket(pdev, ep->xfer_buff, ep->num, ep->xfer_len);   
+    }    
+  }
+  else
+  {
+    /* OUT endpoint */
+    depctl.d32  = USB_OTG_READ_REG32(&(pdev->regs.OUTEP_REGS[ep->num]->DOEPCTL));
+    deptsiz.d32 = USB_OTG_READ_REG32(&(pdev->regs.OUTEP_REGS[ep->num]->DOEPTSIZ));
+    /* Program the transfer size and packet count as follows:
+    * pktcnt = N
+    * xfersize = N * maxpacket
+    */
+    if (ep->xfer_len == 0)
+    {
+      deptsiz.b.xfersize = ep->maxpacket;
+      deptsiz.b.pktcnt = 1;
+    }
+    else
+    {
+      deptsiz.b.pktcnt = (ep->xfer_len + (ep->maxpacket - 1)) / ep->maxpacket;
+      deptsiz.b.xfersize = deptsiz.b.pktcnt * ep->maxpacket;
+    }
+    USB_OTG_WRITE_REG32(&pdev->regs.OUTEP_REGS[ep->num]->DOEPTSIZ, deptsiz.d32);
+    
+    if (pdev->cfg.dma_enable == 1)
+    {
+      USB_OTG_WRITE_REG32(&pdev->regs.OUTEP_REGS[ep->num]->DOEPDMA, ep->dma_addr);
+    }
+    
+    if (ep->type == EP_TYPE_ISOC)
+    {
+      if (ep->even_odd_frame)
+      {
+        depctl.b.setd1pid = 1;
+      }
+      else
+      {
+        depctl.b.setd0pid = 1;
+      }
+    }
+    /* EP enable */
+    depctl.b.cnak = 1;
+    depctl.b.epena = 1;
+    USB_OTG_WRITE_REG32(&pdev->regs.OUTEP_REGS[ep->num]->DOEPCTL, depctl.d32);
+  }
+  return status;
+}
+
+
+/**
+* @brief  USB_OTG_EP0StartXfer : Handle the setup for a data xfer for EP0 and 
+*         starts the xfer
+* @param  pdev : Selected device
+* @retval USB_OTG_STS : status
+*/
+USB_OTG_STS USB_OTG_EP0StartXfer(USB_OTG_CORE_HANDLE *pdev , USB_OTG_EP *ep)
+{
+  USB_OTG_STS                 status = USB_OTG_OK;
+  USB_OTG_DEPCTL_TypeDef      depctl;
+  USB_OTG_DEP0XFRSIZ_TypeDef  deptsiz;
+  USB_OTG_INEPREGS          *in_regs;
+  uint32_t fifoemptymsk = 0;
+  
+  depctl.d32   = 0;
+  deptsiz.d32  = 0;
+  /* IN endpoint */
+  if (ep->is_in == 1)
+  {
+    in_regs = pdev->regs.INEP_REGS[0];
+    depctl.d32  = USB_OTG_READ_REG32(&in_regs->DIEPCTL);
+    deptsiz.d32 = USB_OTG_READ_REG32(&in_regs->DIEPTSIZ);
+    /* Zero Length Packet? */
+    if (ep->xfer_len == 0)
+    {
+      deptsiz.b.xfersize = 0;
+      deptsiz.b.pktcnt = 1;
+      
+    }
+    else
+    {
+      if (ep->xfer_len > ep->maxpacket)
+      {
+        ep->xfer_len = ep->maxpacket;
+        deptsiz.b.xfersize = ep->maxpacket;
+      }
+      else
+      {
+        deptsiz.b.xfersize = ep->xfer_len;
+      }
+      deptsiz.b.pktcnt = 1;
+    }
+    USB_OTG_WRITE_REG32(&in_regs->DIEPTSIZ, deptsiz.d32);
+    
+    if (pdev->cfg.dma_enable == 1)
+    {
+      USB_OTG_WRITE_REG32(&pdev->regs.INEP_REGS[ep->num]->DIEPDMA, ep->dma_addr);  
+    }
+    
+    /* EP enable, IN data in FIFO */
+    depctl.b.cnak = 1;
+    depctl.b.epena = 1;
+    USB_OTG_WRITE_REG32(&in_regs->DIEPCTL, depctl.d32);
+    
+    
+    
+    if (pdev->cfg.dma_enable == 0)
+    {
+      /* Enable the Tx FIFO Empty Interrupt for this EP */
+      if (ep->xfer_len > 0)
+      {
+        {
+          fifoemptymsk |= 1 << ep->num;
+          USB_OTG_MODIFY_REG32(&pdev->regs.DREGS->DIEPEMPMSK, 0, fifoemptymsk);
+        }
+      }
+    }
+  }
+  else
+  {
+    /* OUT endpoint */
+    depctl.d32  = USB_OTG_READ_REG32(&pdev->regs.OUTEP_REGS[ep->num]->DOEPCTL);
+    deptsiz.d32 = USB_OTG_READ_REG32(&pdev->regs.OUTEP_REGS[ep->num]->DOEPTSIZ);
+    /* Program the transfer size and packet count as follows:
+    * xfersize = N * (maxpacket + 4 - (maxpacket % 4))
+    * pktcnt = N           */
+    if (ep->xfer_len == 0)
+    {
+      deptsiz.b.xfersize = ep->maxpacket;
+      deptsiz.b.pktcnt = 1;
+    }
+    else
+    {
+      ep->xfer_len = ep->maxpacket;
+      deptsiz.b.xfersize = ep->maxpacket;
+      deptsiz.b.pktcnt = 1;
+    }
+    USB_OTG_WRITE_REG32(&pdev->regs.OUTEP_REGS[ep->num]->DOEPTSIZ, deptsiz.d32);
+    if (pdev->cfg.dma_enable == 1)
+    {
+      USB_OTG_WRITE_REG32(&pdev->regs.OUTEP_REGS[ep->num]->DOEPDMA, ep->dma_addr);
+    }
+    /* EP enable */
+    depctl.b.cnak = 1;
+    depctl.b.epena = 1;
+    USB_OTG_WRITE_REG32 (&(pdev->regs.OUTEP_REGS[ep->num]->DOEPCTL), depctl.d32);
+    
+  }
+  return status;
+}
+
+
+/**
+* @brief  USB_OTG_EPSetStall : Set the EP STALL
+* @param  pdev : Selected device
+* @retval USB_OTG_STS : status
+*/
+USB_OTG_STS USB_OTG_EPSetStall(USB_OTG_CORE_HANDLE *pdev , USB_OTG_EP *ep)
+{
+  USB_OTG_STS status = USB_OTG_OK;
+  USB_OTG_DEPCTL_TypeDef  depctl;
+  __IO uint32_t *depctl_addr;
+  
+  depctl.d32 = 0;
+  if (ep->is_in == 1)
+  {
+    depctl_addr = &(pdev->regs.INEP_REGS[ep->num]->DIEPCTL);
+    depctl.d32 = USB_OTG_READ_REG32(depctl_addr);
+    /* set the disable and stall bits */
+    if (depctl.b.epena)
+    {
+      depctl.b.epdis = 1;
+    }
+    depctl.b.stall = 1;
+    USB_OTG_WRITE_REG32(depctl_addr, depctl.d32);
+  }
+  else
+  {
+    depctl_addr = &(pdev->regs.OUTEP_REGS[ep->num]->DOEPCTL);
+    depctl.d32 = USB_OTG_READ_REG32(depctl_addr);
+    /* set the stall bit */
+    depctl.b.stall = 1;
+    USB_OTG_WRITE_REG32(depctl_addr, depctl.d32);
+  }
+  return status;
+}
+
+
+/**
+* @brief  Clear the EP STALL
+* @param  pdev : Selected device
+* @retval USB_OTG_STS : status
+*/
+USB_OTG_STS USB_OTG_EPClearStall(USB_OTG_CORE_HANDLE *pdev , USB_OTG_EP *ep)
+{
+  USB_OTG_STS status = USB_OTG_OK;
+  USB_OTG_DEPCTL_TypeDef  depctl;
+  __IO uint32_t *depctl_addr;
+  
+  depctl.d32 = 0;
+  
+  if (ep->is_in == 1)
+  {
+    depctl_addr = &(pdev->regs.INEP_REGS[ep->num]->DIEPCTL);
+  }
+  else
+  {
+    depctl_addr = &(pdev->regs.OUTEP_REGS[ep->num]->DOEPCTL);
+  }
+  depctl.d32 = USB_OTG_READ_REG32(depctl_addr);
+  /* clear the stall bits */
+  depctl.b.stall = 0;
+  if (ep->type == EP_TYPE_INTR || ep->type == EP_TYPE_BULK)
+  {
+    depctl.b.setd0pid = 1; /* DATA0 */
+  }
+  USB_OTG_WRITE_REG32(depctl_addr, depctl.d32);
+  return status;
+}
+
+
+/**
+* @brief  USB_OTG_ReadDevAllOutEp_itr : returns OUT endpoint interrupt bits
+* @param  pdev : Selected device
+* @retval OUT endpoint interrupt bits
+*/
+uint32_t USB_OTG_ReadDevAllOutEp_itr(USB_OTG_CORE_HANDLE *pdev)
+{
+  uint32_t v;
+  v  = USB_OTG_READ_REG32(&pdev->regs.DREGS->DAINT);
+  v &= USB_OTG_READ_REG32(&pdev->regs.DREGS->DAINTMSK);
+  return ((v & 0xffff0000) >> 16);
+}
+
+
+/**
+* @brief  USB_OTG_ReadDevOutEP_itr : returns Device OUT EP Interrupt register
+* @param  pdev : Selected device
+* @param  ep : end point number
+* @retval Device OUT EP Interrupt register
+*/
+uint32_t USB_OTG_ReadDevOutEP_itr(USB_OTG_CORE_HANDLE *pdev , uint8_t epnum)
+{
+  uint32_t v;
+  v  = USB_OTG_READ_REG32(&pdev->regs.OUTEP_REGS[epnum]->DOEPINT);
+  v &= USB_OTG_READ_REG32(&pdev->regs.DREGS->DOEPMSK);
+  return v;
+}
+
+
+/**
+* @brief  USB_OTG_ReadDevAllInEPItr : Get int status register
+* @param  pdev : Selected device
+* @retval int status register
+*/
+uint32_t USB_OTG_ReadDevAllInEPItr(USB_OTG_CORE_HANDLE *pdev)
+{
+  uint32_t v;
+  v = USB_OTG_READ_REG32(&pdev->regs.DREGS->DAINT);
+  v &= USB_OTG_READ_REG32(&pdev->regs.DREGS->DAINTMSK);
+  return (v & 0xffff);
+}
+
+/**
+* @brief  configures EPO to receive SETUP packets
+* @param  None
+* @retval : None
+*/
+void USB_OTG_EP0_OutStart(USB_OTG_CORE_HANDLE *pdev)
+{
+  USB_OTG_DEP0XFRSIZ_TypeDef  doeptsize0;
+  doeptsize0.d32 = 0;
+  doeptsize0.b.supcnt = 3;
+  doeptsize0.b.pktcnt = 1;
+  doeptsize0.b.xfersize = 8 * 3;
+  USB_OTG_WRITE_REG32( &pdev->regs.OUTEP_REGS[0]->DOEPTSIZ, doeptsize0.d32 );
+  
+  if (pdev->cfg.dma_enable == 1)
+  {
+    USB_OTG_DEPCTL_TypeDef  doepctl;
+    doepctl.d32 = 0;
+    USB_OTG_WRITE_REG32( &pdev->regs.OUTEP_REGS[0]->DOEPDMA, 
+                        (uint32_t)&pdev->dev.setup_packet);
+    
+    /* EP enable */
+    doepctl.d32 = USB_OTG_READ_REG32(&pdev->regs.OUTEP_REGS[0]->DOEPCTL);
+    doepctl.b.epena = 1;
+    doepctl.d32 = 0x80008000;
+    USB_OTG_WRITE_REG32( &pdev->regs.OUTEP_REGS[0]->DOEPCTL, doepctl.d32);
+  }
+}
+
+/**
+* @brief  USB_OTG_RemoteWakeup : active remote wakeup signalling
+* @param  None
+* @retval : None
+*/
+void USB_OTG_ActiveRemoteWakeup(USB_OTG_CORE_HANDLE *pdev)
+{
+  
+  USB_OTG_DCTL_TypeDef     dctl;
+  USB_OTG_DSTS_TypeDef     dsts;
+  USB_OTG_PCGCCTL_TypeDef  power;  
+  
+  if (pdev->dev.DevRemoteWakeup) 
+  {
+    dsts.d32 = USB_OTG_READ_REG32(&pdev->regs.DREGS->DSTS);
+    if(dsts.b.suspsts == 1)
+    {
+      if(pdev->cfg.low_power)
+      {
+        /* un-gate USB Core clock */
+        power.d32 = USB_OTG_READ_REG32(&pdev->regs.PCGCCTL);
+        power.b.gatehclk = 0;
+        power.b.stoppclk = 0;
+        USB_OTG_WRITE_REG32(pdev->regs.PCGCCTL, power.d32);
+      }   
+      /* active Remote wakeup signaling */
+      dctl.d32 = 0;
+      dctl.b.rmtwkupsig = 1;
+      USB_OTG_MODIFY_REG32(&pdev->regs.DREGS->DCTL, 0, dctl.d32);
+      USB_OTG_BSP_mDelay(5);
+      USB_OTG_MODIFY_REG32(&pdev->regs.DREGS->DCTL, dctl.d32, 0 );
+    }
+  }
+}
+
+
+/**
+* @brief  USB_OTG_UngateClock : active USB Core clock
+* @param  None
+* @retval : None
+*/
+void USB_OTG_UngateClock(USB_OTG_CORE_HANDLE *pdev)
+{
+  if(pdev->cfg.low_power)
+  {
+    
+    USB_OTG_DSTS_TypeDef     dsts;
+    USB_OTG_PCGCCTL_TypeDef  power; 
+    
+    dsts.d32 = USB_OTG_READ_REG32(&pdev->regs.DREGS->DSTS);
+    
+    if(dsts.b.suspsts == 1)
+    {
+      /* un-gate USB Core clock */
+      power.d32 = USB_OTG_READ_REG32(&pdev->regs.PCGCCTL);
+      power.b.gatehclk = 0;
+      power.b.stoppclk = 0;
+      USB_OTG_WRITE_REG32(pdev->regs.PCGCCTL, power.d32);
+      
+    }
+  }
+}
+
+/**
+* @brief  Stop the device and clean up fifo's
+* @param  None
+* @retval : None
+*/
+void USB_OTG_StopDevice(USB_OTG_CORE_HANDLE *pdev)
+{
+  uint32_t i;
+  
+  pdev->dev.device_status = 1;
+  
+  for (i = 0; i < pdev->cfg.dev_endpoints ; i++)
+  {
+    USB_OTG_WRITE_REG32( &pdev->regs.INEP_REGS[i]->DIEPINT, 0xFF);
+    USB_OTG_WRITE_REG32( &pdev->regs.OUTEP_REGS[i]->DOEPINT, 0xFF);
+  }
+  
+  USB_OTG_WRITE_REG32( &pdev->regs.DREGS->DIEPMSK, 0 );
+  USB_OTG_WRITE_REG32( &pdev->regs.DREGS->DOEPMSK, 0 );
+  USB_OTG_WRITE_REG32( &pdev->regs.DREGS->DAINTMSK, 0 );
+  USB_OTG_WRITE_REG32( &pdev->regs.DREGS->DAINT, 0xFFFFFFFF );  
+  
+  /* Flush the FIFO */
+  USB_OTG_FlushRxFifo(pdev);
+  USB_OTG_FlushTxFifo(pdev ,  0x10 );  
+}
+
+/**
+* @brief  returns the EP Status
+* @param  pdev : Selected device
+*         ep : endpoint structure
+* @retval : EP status
+*/
+
+uint32_t USB_OTG_GetEPStatus(USB_OTG_CORE_HANDLE *pdev ,USB_OTG_EP *ep)
+{
+  USB_OTG_DEPCTL_TypeDef  depctl;
+  __IO uint32_t *depctl_addr;
+  uint32_t Status = 0;  
+  
+  depctl.d32 = 0;
+  if (ep->is_in == 1)
+  {
+    depctl_addr = &(pdev->regs.INEP_REGS[ep->num]->DIEPCTL);
+    depctl.d32 = USB_OTG_READ_REG32(depctl_addr);
+    
+    if (depctl.b.stall == 1)  
+      Status = USB_OTG_EP_TX_STALL;
+    else if (depctl.b.naksts == 1)
+      Status = USB_OTG_EP_TX_NAK;
+    else 
+      Status = USB_OTG_EP_TX_VALID;     
+    
+  }
+  else
+  {
+    depctl_addr = &(pdev->regs.OUTEP_REGS[ep->num]->DOEPCTL);
+    depctl.d32 = USB_OTG_READ_REG32(depctl_addr);
+    if (depctl.b.stall == 1)  
+      Status = USB_OTG_EP_RX_STALL;
+    else if (depctl.b.naksts == 1)
+      Status = USB_OTG_EP_RX_NAK;
+    else 
+      Status = USB_OTG_EP_RX_VALID; 
+  } 
+  
+  /* Return the current status */
+  return Status;
+}
+
+/**
+* @brief  Set the EP Status
+* @param  pdev : Selected device
+*         Status : new Status
+*         ep : EP structure
+* @retval : None
+*/
+void USB_OTG_SetEPStatus (USB_OTG_CORE_HANDLE *pdev , USB_OTG_EP *ep , uint32_t Status)
+{
+  USB_OTG_DEPCTL_TypeDef  depctl;
+  __IO uint32_t *depctl_addr;
+  
+  depctl.d32 = 0;
+  
+  /* Process for IN endpoint */
+  if (ep->is_in == 1)
+  {
+    depctl_addr = &(pdev->regs.INEP_REGS[ep->num]->DIEPCTL);
+    depctl.d32 = USB_OTG_READ_REG32(depctl_addr);
+    
+    if (Status == USB_OTG_EP_TX_STALL)  
+    {
+      USB_OTG_EPSetStall(pdev, ep); return;
+    }
+    else if (Status == USB_OTG_EP_TX_NAK)
+      depctl.b.snak = 1;
+    else if (Status == USB_OTG_EP_TX_VALID)
+    {
+      if (depctl.b.stall == 1)
+      {  
+        ep->even_odd_frame = 0;
+        USB_OTG_EPClearStall(pdev, ep);
+        return;
+      }      
+      depctl.b.cnak = 1;
+      depctl.b.usbactep = 1; 
+      depctl.b.epena = 1;
+    }
+    else if (Status == USB_OTG_EP_TX_DIS)
+      depctl.b.usbactep = 0;
+  } 
+  else /* Process for OUT endpoint */
+  {
+    depctl_addr = &(pdev->regs.OUTEP_REGS[ep->num]->DOEPCTL);
+    depctl.d32 = USB_OTG_READ_REG32(depctl_addr);    
+    
+    if (Status == USB_OTG_EP_RX_STALL)  {
+      depctl.b.stall = 1;
+    }
+    else if (Status == USB_OTG_EP_RX_NAK)
+      depctl.b.snak = 1;
+    else if (Status == USB_OTG_EP_RX_VALID)
+    {
+      if (depctl.b.stall == 1)
+      {  
+        ep->even_odd_frame = 0;
+        USB_OTG_EPClearStall(pdev, ep);
+        return;
+      }  
+      depctl.b.cnak = 1;
+      depctl.b.usbactep = 1;    
+      depctl.b.epena = 1;
+    }
+    else if (Status == USB_OTG_EP_RX_DIS)
+    {
+      depctl.b.usbactep = 0;    
+    }
+  }
+  
+  USB_OTG_WRITE_REG32(depctl_addr, depctl.d32); 
+}
+
+#endif
+/**
+* @}
+*/ 
+
+/**
+* @}
+*/ 
+
+/**
+* @}
+*/
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/src/lib/usb_core.h
+++ b/src/lib/usb_core.h
@@ -1,0 +1,417 @@
+/**
+  ******************************************************************************
+  * @file    usb_core.h
+  * @author  MCD Application Team
+  * @version V2.1.0
+  * @date    19-March-2012
+  * @brief   Header of the Core Layer
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT 2012 STMicroelectronics</center></h2>
+  *
+  * Licensed under MCD-ST Liberty SW License Agreement V2, (the "License");
+  * You may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at:
+  *
+  *        http://www.st.com/software_license_agreement_liberty_v2
+  *
+  * Unless required by applicable law or agreed to in writing, software 
+  * distributed under the License is distributed on an "AS IS" BASIS, 
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __USB_CORE_H__
+#define __USB_CORE_H__
+
+/* Includes ------------------------------------------------------------------*/
+#include "usb_conf.h"
+#include "usb_regs.h"
+#include "usb_defines.h"
+
+
+/** @addtogroup USB_OTG_DRIVER
+  * @{
+  */
+  
+/** @defgroup USB_CORE
+  * @brief usb otg driver core layer
+  * @{
+  */ 
+
+
+/** @defgroup USB_CORE_Exported_Defines
+  * @{
+  */ 
+
+#define USB_OTG_EP0_IDLE                          0
+#define USB_OTG_EP0_SETUP                         1
+#define USB_OTG_EP0_DATA_IN                       2
+#define USB_OTG_EP0_DATA_OUT                      3
+#define USB_OTG_EP0_STATUS_IN                     4
+#define USB_OTG_EP0_STATUS_OUT                    5
+#define USB_OTG_EP0_STALL                         6
+
+#define USB_OTG_EP_TX_DIS       0x0000
+#define USB_OTG_EP_TX_STALL     0x0010
+#define USB_OTG_EP_TX_NAK       0x0020
+#define USB_OTG_EP_TX_VALID     0x0030
+ 
+#define USB_OTG_EP_RX_DIS       0x0000
+#define USB_OTG_EP_RX_STALL     0x1000
+#define USB_OTG_EP_RX_NAK       0x2000
+#define USB_OTG_EP_RX_VALID     0x3000
+/**
+  * @}
+  */ 
+#define   MAX_DATA_LENGTH                        0x200
+
+/** @defgroup USB_CORE_Exported_Types
+  * @{
+  */ 
+
+
+typedef enum {
+  USB_OTG_OK = 0,
+  USB_OTG_FAIL
+}USB_OTG_STS;
+
+typedef enum {
+  HC_IDLE = 0,
+  HC_XFRC,
+  HC_HALTED,
+  HC_NAK,
+  HC_NYET,
+  HC_STALL,
+  HC_XACTERR,  
+  HC_BBLERR,   
+  HC_DATATGLERR,  
+}HC_STATUS;
+
+typedef enum {
+  URB_IDLE = 0,
+  URB_DONE,
+  URB_NOTREADY,
+  URB_ERROR,
+  URB_STALL
+}URB_STATE;
+
+typedef enum {
+  CTRL_START = 0,
+  CTRL_XFRC,
+  CTRL_HALTED,
+  CTRL_NAK,
+  CTRL_STALL,
+  CTRL_XACTERR,  
+  CTRL_BBLERR,   
+  CTRL_DATATGLERR,  
+  CTRL_FAIL
+}CTRL_STATUS;
+
+
+typedef struct USB_OTG_hc
+{
+  uint8_t       dev_addr ;
+  uint8_t       ep_num;
+  uint8_t       ep_is_in;
+  uint8_t       speed;
+  uint8_t       do_ping;  
+  uint8_t       ep_type;
+  uint16_t      max_packet;
+  uint8_t       data_pid;
+  uint8_t       *xfer_buff;
+  uint32_t      xfer_len;
+  uint32_t      xfer_count;  
+  uint8_t       toggle_in;
+  uint8_t       toggle_out;
+  uint32_t       dma_addr;  
+}
+USB_OTG_HC , *PUSB_OTG_HC;
+
+typedef struct USB_OTG_ep
+{
+  uint8_t        num;
+  uint8_t        is_in;
+  uint8_t        is_stall;  
+  uint8_t        type;
+  uint8_t        data_pid_start;
+  uint8_t        even_odd_frame;
+  uint16_t       tx_fifo_num;
+  uint32_t       maxpacket;
+  /* transaction level variables*/
+  uint8_t        *xfer_buff;
+  uint32_t       dma_addr;  
+  uint32_t       xfer_len;
+  uint32_t       xfer_count;
+  /* Transfer level variables*/  
+  uint32_t       rem_data_len;
+  uint32_t       total_data_len;
+  uint32_t       ctl_data_len;  
+
+}
+
+USB_OTG_EP , *PUSB_OTG_EP;
+
+
+
+typedef struct USB_OTG_core_cfg
+{
+  uint8_t       host_channels;
+  uint8_t       dev_endpoints;
+  uint8_t       speed;
+  uint8_t       dma_enable;
+  uint16_t      mps;
+  uint16_t      TotalFifoSize;
+  uint8_t       phy_itface;
+  uint8_t       Sof_output;
+  uint8_t       low_power;
+  uint8_t       coreID;
+ 
+}
+USB_OTG_CORE_CFGS, *PUSB_OTG_CORE_CFGS;
+
+
+
+typedef  struct  usb_setup_req {
+    
+    uint8_t   bmRequest;                      
+    uint8_t   bRequest;                           
+    uint16_t  wValue;                             
+    uint16_t  wIndex;                             
+    uint16_t  wLength;                            
+} USB_SETUP_REQ;
+
+typedef struct _Device_TypeDef
+{
+  uint8_t  *(*GetDeviceDescriptor)( uint8_t speed , uint16_t *length);  
+  uint8_t  *(*GetLangIDStrDescriptor)( uint8_t speed , uint16_t *length); 
+  uint8_t  *(*GetManufacturerStrDescriptor)( uint8_t speed , uint16_t *length);  
+  uint8_t  *(*GetProductStrDescriptor)( uint8_t speed , uint16_t *length);  
+  uint8_t  *(*GetSerialStrDescriptor)( uint8_t speed , uint16_t *length);  
+  uint8_t  *(*GetConfigurationStrDescriptor)( uint8_t speed , uint16_t *length);  
+  uint8_t  *(*GetInterfaceStrDescriptor)( uint8_t speed , uint16_t *length);   
+} USBD_DEVICE, *pUSBD_DEVICE;
+
+//typedef struct USB_OTG_hPort
+//{
+//  void (*Disconnect) (void *phost);
+//  void (*Connect) (void *phost); 
+//  uint8_t ConnStatus;
+//  uint8_t DisconnStatus;
+//  uint8_t ConnHandled;
+//  uint8_t DisconnHandled;
+//} USB_OTG_hPort_TypeDef;
+
+typedef struct _Device_cb
+{
+  uint8_t  (*Init)         (void *pdev , uint8_t cfgidx);
+  uint8_t  (*DeInit)       (void *pdev , uint8_t cfgidx);
+ /* Control Endpoints*/
+  uint8_t  (*Setup)        (void *pdev , USB_SETUP_REQ  *req);  
+  uint8_t  (*EP0_TxSent)   (void *pdev );    
+  uint8_t  (*EP0_RxReady)  (void *pdev );  
+  /* Class Specific Endpoints*/
+  uint8_t  (*DataIn)       (void *pdev , uint8_t epnum);   
+  uint8_t  (*DataOut)      (void *pdev , uint8_t epnum); 
+  uint8_t  (*SOF)          (void *pdev); 
+  uint8_t  (*IsoINIncomplete)  (void *pdev); 
+  uint8_t  (*IsoOUTIncomplete)  (void *pdev);   
+
+  uint8_t  *(*GetConfigDescriptor)( uint8_t speed , uint16_t *length); 
+#ifdef USB_OTG_HS_CORE 
+  uint8_t  *(*GetOtherConfigDescriptor)( uint8_t speed , uint16_t *length);   
+#endif
+
+#ifdef USB_SUPPORT_USER_STRING_DESC 
+  uint8_t  *(*GetUsrStrDescriptor)( uint8_t speed ,uint8_t index,  uint16_t *length);   
+#endif  
+  
+} USBD_Class_cb_TypeDef;
+
+
+
+typedef struct _USBD_USR_PROP
+{
+  void (*Init)(void);   
+  void (*DeviceReset)(uint8_t speed); 
+  void (*DeviceConfigured)(void);
+  void (*DeviceSuspended)(void);
+  void (*DeviceResumed)(void);  
+  
+  void (*DeviceConnected)(void);  
+  void (*DeviceDisconnected)(void);    
+  
+}
+USBD_Usr_cb_TypeDef;
+
+typedef struct _DCD
+{
+  uint8_t        device_config;
+  uint8_t        device_state;
+  uint8_t        device_status;
+  uint8_t        device_old_status;
+  uint8_t        device_address;
+  uint8_t        connection_status;  
+  uint8_t        test_mode;
+  uint32_t       DevRemoteWakeup;
+  USB_OTG_EP     in_ep   [USB_OTG_MAX_TX_FIFOS];
+  USB_OTG_EP     out_ep  [USB_OTG_MAX_TX_FIFOS];
+  uint8_t        setup_packet [8*3];
+  USBD_Class_cb_TypeDef         *class_cb;
+  USBD_Usr_cb_TypeDef           *usr_cb;
+  USBD_DEVICE                   *usr_device;  
+  uint8_t        *pConfig_descriptor;
+ }
+DCD_DEV , *DCD_PDEV;
+
+
+typedef struct _HCD
+{
+  uint8_t                  Rx_Buffer [MAX_DATA_LENGTH];  
+  __IO uint32_t            ConnSts;
+  __IO uint32_t            ErrCnt[USB_OTG_MAX_TX_FIFOS];
+  __IO uint32_t            XferCnt[USB_OTG_MAX_TX_FIFOS];
+  __IO HC_STATUS           HC_Status[USB_OTG_MAX_TX_FIFOS];  
+  __IO URB_STATE           URB_State[USB_OTG_MAX_TX_FIFOS];
+  USB_OTG_HC               hc [USB_OTG_MAX_TX_FIFOS];
+  uint16_t                 channel [USB_OTG_MAX_TX_FIFOS];
+//  USB_OTG_hPort_TypeDef    *port_cb;  
+}
+HCD_DEV , *USB_OTG_USBH_PDEV;
+
+
+typedef struct _OTG
+{
+  uint8_t    OTG_State;
+  uint8_t    OTG_PrevState;  
+  uint8_t    OTG_Mode;    
+}
+OTG_DEV , *USB_OTG_USBO_PDEV;
+
+typedef struct USB_OTG_handle
+{
+  USB_OTG_CORE_CFGS    cfg;
+  USB_OTG_CORE_REGS    regs;
+#ifdef USE_DEVICE_MODE
+  DCD_DEV     dev;
+#endif
+#ifdef USE_HOST_MODE
+  HCD_DEV     host;
+#endif
+#ifdef USE_OTG_MODE
+  OTG_DEV     otg;
+#endif
+}
+USB_OTG_CORE_HANDLE , *PUSB_OTG_CORE_HANDLE;
+
+/**
+  * @}
+  */ 
+
+
+/** @defgroup USB_CORE_Exported_Macros
+  * @{
+  */ 
+
+/**
+  * @}
+  */ 
+
+/** @defgroup USB_CORE_Exported_Variables
+  * @{
+  */ 
+/**
+  * @}
+  */ 
+
+/** @defgroup USB_CORE_Exported_FunctionsPrototype
+  * @{
+  */ 
+
+
+USB_OTG_STS  USB_OTG_CoreInit        (USB_OTG_CORE_HANDLE *pdev);
+USB_OTG_STS  USB_OTG_SelectCore      (USB_OTG_CORE_HANDLE *pdev, 
+                                      USB_OTG_CORE_ID_TypeDef coreID);
+USB_OTG_STS  USB_OTG_EnableGlobalInt (USB_OTG_CORE_HANDLE *pdev);
+USB_OTG_STS  USB_OTG_DisableGlobalInt(USB_OTG_CORE_HANDLE *pdev);
+void*           USB_OTG_ReadPacket   (USB_OTG_CORE_HANDLE *pdev ,
+    uint8_t *dest,
+    uint16_t len);
+USB_OTG_STS  USB_OTG_WritePacket     (USB_OTG_CORE_HANDLE *pdev ,
+    uint8_t *src,
+    uint8_t ch_ep_num,
+    uint16_t len);
+USB_OTG_STS  USB_OTG_FlushTxFifo     (USB_OTG_CORE_HANDLE *pdev , uint32_t num);
+USB_OTG_STS  USB_OTG_FlushRxFifo     (USB_OTG_CORE_HANDLE *pdev);
+
+uint32_t     USB_OTG_ReadCoreItr     (USB_OTG_CORE_HANDLE *pdev);
+uint32_t     USB_OTG_ReadOtgItr      (USB_OTG_CORE_HANDLE *pdev);
+uint8_t      USB_OTG_IsHostMode      (USB_OTG_CORE_HANDLE *pdev);
+uint8_t      USB_OTG_IsDeviceMode    (USB_OTG_CORE_HANDLE *pdev);
+uint32_t     USB_OTG_GetMode         (USB_OTG_CORE_HANDLE *pdev);
+USB_OTG_STS  USB_OTG_PhyInit         (USB_OTG_CORE_HANDLE *pdev);
+USB_OTG_STS  USB_OTG_SetCurrentMode  (USB_OTG_CORE_HANDLE *pdev,
+    uint8_t mode);
+
+/*********************** HOST APIs ********************************************/
+#ifdef USE_HOST_MODE
+USB_OTG_STS  USB_OTG_CoreInitHost    (USB_OTG_CORE_HANDLE *pdev);
+USB_OTG_STS  USB_OTG_EnableHostInt   (USB_OTG_CORE_HANDLE *pdev);
+USB_OTG_STS  USB_OTG_HC_Init         (USB_OTG_CORE_HANDLE *pdev, uint8_t hc_num);
+USB_OTG_STS  USB_OTG_HC_Halt         (USB_OTG_CORE_HANDLE *pdev, uint8_t hc_num);
+USB_OTG_STS  USB_OTG_HC_StartXfer    (USB_OTG_CORE_HANDLE *pdev, uint8_t hc_num);
+USB_OTG_STS  USB_OTG_HC_DoPing       (USB_OTG_CORE_HANDLE *pdev , uint8_t hc_num);
+uint32_t     USB_OTG_ReadHostAllChannels_intr    (USB_OTG_CORE_HANDLE *pdev);
+uint32_t     USB_OTG_ResetPort       (USB_OTG_CORE_HANDLE *pdev);
+uint32_t     USB_OTG_ReadHPRT0       (USB_OTG_CORE_HANDLE *pdev);
+void         USB_OTG_DriveVbus       (USB_OTG_CORE_HANDLE *pdev, uint8_t state);
+void         USB_OTG_InitFSLSPClkSel (USB_OTG_CORE_HANDLE *pdev ,uint8_t freq);
+uint8_t      USB_OTG_IsEvenFrame     (USB_OTG_CORE_HANDLE *pdev) ;
+void         USB_OTG_StopHost        (USB_OTG_CORE_HANDLE *pdev);
+#endif
+/********************* DEVICE APIs ********************************************/
+#ifdef USE_DEVICE_MODE
+USB_OTG_STS  USB_OTG_CoreInitDev         (USB_OTG_CORE_HANDLE *pdev);
+USB_OTG_STS  USB_OTG_EnableDevInt        (USB_OTG_CORE_HANDLE *pdev);
+uint32_t     USB_OTG_ReadDevAllInEPItr           (USB_OTG_CORE_HANDLE *pdev);
+enum USB_OTG_SPEED USB_OTG_GetDeviceSpeed (USB_OTG_CORE_HANDLE *pdev);
+USB_OTG_STS  USB_OTG_EP0Activate (USB_OTG_CORE_HANDLE *pdev);
+USB_OTG_STS  USB_OTG_EPActivate  (USB_OTG_CORE_HANDLE *pdev , USB_OTG_EP *ep);
+USB_OTG_STS  USB_OTG_EPDeactivate(USB_OTG_CORE_HANDLE *pdev , USB_OTG_EP *ep);
+USB_OTG_STS  USB_OTG_EPStartXfer (USB_OTG_CORE_HANDLE *pdev , USB_OTG_EP *ep);
+USB_OTG_STS  USB_OTG_EP0StartXfer(USB_OTG_CORE_HANDLE *pdev , USB_OTG_EP *ep);
+USB_OTG_STS  USB_OTG_EPSetStall          (USB_OTG_CORE_HANDLE *pdev , USB_OTG_EP *ep);
+USB_OTG_STS  USB_OTG_EPClearStall        (USB_OTG_CORE_HANDLE *pdev , USB_OTG_EP *ep);
+uint32_t     USB_OTG_ReadDevAllOutEp_itr (USB_OTG_CORE_HANDLE *pdev);
+uint32_t     USB_OTG_ReadDevOutEP_itr    (USB_OTG_CORE_HANDLE *pdev , uint8_t epnum);
+uint32_t     USB_OTG_ReadDevAllInEPItr   (USB_OTG_CORE_HANDLE *pdev);
+void         USB_OTG_InitDevSpeed        (USB_OTG_CORE_HANDLE *pdev , uint8_t speed);
+uint8_t      USBH_IsEvenFrame (USB_OTG_CORE_HANDLE *pdev);
+void         USB_OTG_EP0_OutStart(USB_OTG_CORE_HANDLE *pdev);
+void         USB_OTG_ActiveRemoteWakeup(USB_OTG_CORE_HANDLE *pdev);
+void         USB_OTG_UngateClock(USB_OTG_CORE_HANDLE *pdev);
+void         USB_OTG_StopDevice(USB_OTG_CORE_HANDLE *pdev);
+void         USB_OTG_SetEPStatus (USB_OTG_CORE_HANDLE *pdev , USB_OTG_EP *ep , uint32_t Status);
+uint32_t     USB_OTG_GetEPStatus(USB_OTG_CORE_HANDLE *pdev ,USB_OTG_EP *ep);
+#endif
+/**
+  * @}
+  */ 
+
+#endif  /* __USB_CORE_H__ */
+
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
+

--- a/src/lib/usb_dcd.h
+++ b/src/lib/usb_dcd.h
@@ -1,0 +1,164 @@
+/**
+  ******************************************************************************
+  * @file    usb_dcd.h
+  * @author  MCD Application Team
+  * @version V2.1.0
+  * @date    19-March-2012
+  * @brief   Peripheral Driver Header file
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT 2012 STMicroelectronics</center></h2>
+  *
+  * Licensed under MCD-ST Liberty SW License Agreement V2, (the "License");
+  * You may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at:
+  *
+  *        http://www.st.com/software_license_agreement_liberty_v2
+  *
+  * Unless required by applicable law or agreed to in writing, software 
+  * distributed under the License is distributed on an "AS IS" BASIS, 
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __DCD_H__
+#define __DCD_H__
+
+/* Includes ------------------------------------------------------------------*/
+#include "usb_core.h"
+
+
+/** @addtogroup USB_OTG_DRIVER
+* @{
+*/
+
+/** @defgroup USB_DCD
+* @brief This file is the 
+* @{
+*/ 
+
+
+/** @defgroup USB_DCD_Exported_Defines
+* @{
+*/ 
+#define USB_OTG_EP_CONTROL                       0
+#define USB_OTG_EP_ISOC                          1
+#define USB_OTG_EP_BULK                          2
+#define USB_OTG_EP_INT                           3
+#define USB_OTG_EP_MASK                          3
+
+/*  Device Status */
+#define USB_OTG_DEFAULT                          1
+#define USB_OTG_ADDRESSED                        2
+#define USB_OTG_CONFIGURED                       3
+#define USB_OTG_SUSPENDED                        4
+
+/**
+* @}
+*/ 
+
+
+/** @defgroup USB_DCD_Exported_Types
+* @{
+*/ 
+/********************************************************************************
+Data structure type
+********************************************************************************/
+typedef struct
+{
+  uint8_t  bLength;
+  uint8_t  bDescriptorType;
+  uint8_t  bEndpointAddress;
+  uint8_t  bmAttributes;
+  uint16_t wMaxPacketSize;
+  uint8_t  bInterval;
+}
+EP_DESCRIPTOR , *PEP_DESCRIPTOR;
+
+/**
+* @}
+*/ 
+
+
+/** @defgroup USB_DCD_Exported_Macros
+* @{
+*/ 
+/**
+* @}
+*/ 
+
+/** @defgroup USB_DCD_Exported_Variables
+* @{
+*/ 
+/**
+* @}
+*/ 
+
+/** @defgroup USB_DCD_Exported_FunctionsPrototype
+* @{
+*/ 
+/********************************************************************************
+EXPORTED FUNCTION FROM THE USB-OTG LAYER
+********************************************************************************/
+void       DCD_Init(USB_OTG_CORE_HANDLE *pdev ,
+                    USB_OTG_CORE_ID_TypeDef coreID);
+
+void        DCD_DevConnect (USB_OTG_CORE_HANDLE *pdev);
+void        DCD_DevDisconnect (USB_OTG_CORE_HANDLE *pdev);
+void        DCD_EP_SetAddress (USB_OTG_CORE_HANDLE *pdev,
+                               uint8_t address);
+uint32_t    DCD_EP_Open(USB_OTG_CORE_HANDLE *pdev , 
+                     uint8_t ep_addr,
+                     uint16_t ep_mps,
+                     uint8_t ep_type);
+
+uint32_t    DCD_EP_Close  (USB_OTG_CORE_HANDLE *pdev,
+                                uint8_t  ep_addr);
+
+
+uint32_t   DCD_EP_PrepareRx ( USB_OTG_CORE_HANDLE *pdev,
+                        uint8_t   ep_addr,                                  
+                        uint8_t *pbuf,                                  
+                        uint16_t  buf_len);
+  
+uint32_t    DCD_EP_Tx (USB_OTG_CORE_HANDLE *pdev,
+                               uint8_t  ep_addr,
+                               uint8_t  *pbuf,
+                               uint32_t   buf_len);
+uint32_t    DCD_EP_Stall (USB_OTG_CORE_HANDLE *pdev,
+                              uint8_t   epnum);
+uint32_t    DCD_EP_ClrStall (USB_OTG_CORE_HANDLE *pdev,
+                                  uint8_t epnum);
+uint32_t    DCD_EP_Flush (USB_OTG_CORE_HANDLE *pdev,
+                               uint8_t epnum);
+uint32_t    DCD_Handle_ISR(USB_OTG_CORE_HANDLE *pdev);
+
+uint32_t DCD_GetEPStatus(USB_OTG_CORE_HANDLE *pdev ,
+                         uint8_t epnum);
+
+void DCD_SetEPStatus (USB_OTG_CORE_HANDLE *pdev , 
+                      uint8_t epnum , 
+                      uint32_t Status);
+
+/**
+* @}
+*/ 
+
+
+#endif //__DCD_H__
+
+
+/**
+* @}
+*/ 
+
+/**
+* @}
+*/ 
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
+

--- a/src/lib/usb_dcd_int.h
+++ b/src/lib/usb_dcd_int.h
@@ -1,0 +1,127 @@
+/**
+  ******************************************************************************
+  * @file    usb_dcd_int.h
+  * @author  MCD Application Team
+  * @version V2.1.0
+  * @date    19-March-2012
+  * @brief   Peripheral Device Interface Layer
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT 2012 STMicroelectronics</center></h2>
+  *
+  * Licensed under MCD-ST Liberty SW License Agreement V2, (the "License");
+  * You may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at:
+  *
+  *        http://www.st.com/software_license_agreement_liberty_v2
+  *
+  * Unless required by applicable law or agreed to in writing, software 
+  * distributed under the License is distributed on an "AS IS" BASIS, 
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef USB_DCD_INT_H__
+#define USB_DCD_INT_H__
+
+/* Includes ------------------------------------------------------------------*/
+#include "usb_dcd.h"
+
+
+
+/** @addtogroup USB_OTG_DRIVER
+  * @{
+  */
+  
+/** @defgroup USB_DCD_INT
+  * @brief This file is the 
+  * @{
+  */ 
+
+
+/** @defgroup USB_DCD_INT_Exported_Defines
+  * @{
+  */ 
+
+typedef struct _USBD_DCD_INT
+{
+  uint8_t (* DataOutStage) (USB_OTG_CORE_HANDLE *pdev , uint8_t epnum);
+  uint8_t (* DataInStage)  (USB_OTG_CORE_HANDLE *pdev , uint8_t epnum);
+  uint8_t (* SetupStage) (USB_OTG_CORE_HANDLE *pdev);
+  uint8_t (* SOF) (USB_OTG_CORE_HANDLE *pdev);
+  uint8_t (* Reset) (USB_OTG_CORE_HANDLE *pdev);
+  uint8_t (* Suspend) (USB_OTG_CORE_HANDLE *pdev);
+  uint8_t (* Resume) (USB_OTG_CORE_HANDLE *pdev);
+  uint8_t (* IsoINIncomplete) (USB_OTG_CORE_HANDLE *pdev);
+  uint8_t (* IsoOUTIncomplete) (USB_OTG_CORE_HANDLE *pdev);  
+  
+  uint8_t (* DevConnected) (USB_OTG_CORE_HANDLE *pdev);
+  uint8_t (* DevDisconnected) (USB_OTG_CORE_HANDLE *pdev);   
+  
+}USBD_DCD_INT_cb_TypeDef;
+
+extern USBD_DCD_INT_cb_TypeDef *USBD_DCD_INT_fops;
+/**
+  * @}
+  */ 
+
+
+/** @defgroup USB_DCD_INT_Exported_Types
+  * @{
+  */ 
+/**
+  * @}
+  */ 
+
+/** @defgroup USB_DCD_INT_Exported_Macros
+  * @{
+  */ 
+
+#define CLEAR_IN_EP_INTR(epnum,intr) \
+  diepint.d32=0; \
+  diepint.b.intr = 1; \
+  USB_OTG_WRITE_REG32(&pdev->regs.INEP_REGS[epnum]->DIEPINT,diepint.d32);
+
+#define CLEAR_OUT_EP_INTR(epnum,intr) \
+  doepint.d32=0; \
+  doepint.b.intr = 1; \
+  USB_OTG_WRITE_REG32(&pdev->regs.OUTEP_REGS[epnum]->DOEPINT,doepint.d32);
+
+/**
+  * @}
+  */ 
+
+/** @defgroup USB_DCD_INT_Exported_Variables
+  * @{
+  */ 
+/**
+  * @}
+  */ 
+
+/** @defgroup USB_DCD_INT_Exported_FunctionsPrototype
+  * @{
+  */ 
+
+uint32_t USBD_OTG_ISR_Handler (USB_OTG_CORE_HANDLE *pdev);
+
+/**
+  * @}
+  */ 
+
+
+#endif // USB_DCD_INT_H__
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
+

--- a/src/lib/usb_defines.h
+++ b/src/lib/usb_defines.h
@@ -1,0 +1,249 @@
+/**
+  ******************************************************************************
+  * @file    usb_defines.h
+  * @author  MCD Application Team
+  * @version V2.1.0
+  * @date    19-March-2012
+  * @brief   Header of the Core Layer
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT 2012 STMicroelectronics</center></h2>
+  *
+  * Licensed under MCD-ST Liberty SW License Agreement V2, (the "License");
+  * You may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at:
+  *
+  *        http://www.st.com/software_license_agreement_liberty_v2
+  *
+  * Unless required by applicable law or agreed to in writing, software 
+  * distributed under the License is distributed on an "AS IS" BASIS, 
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __USB_DEF_H__
+#define __USB_DEF_H__
+
+/* Includes ------------------------------------------------------------------*/
+#include  "usb_conf.h"
+
+/** @addtogroup USB_OTG_DRIVER
+  * @{
+  */
+  
+/** @defgroup USB_DEFINES
+  * @brief This file is the 
+  * @{
+  */ 
+
+
+/** @defgroup USB_DEFINES_Exported_Defines
+  * @{
+  */ 
+/**
+  * @}
+  */ 
+
+
+/** @defgroup _CORE_DEFINES_
+  * @{
+  */
+
+#define USB_OTG_SPEED_PARAM_HIGH 0
+#define USB_OTG_SPEED_PARAM_HIGH_IN_FULL 1
+#define USB_OTG_SPEED_PARAM_FULL 3
+
+#define USB_OTG_SPEED_HIGH      0
+#define USB_OTG_SPEED_FULL      1
+
+#define USB_OTG_ULPI_PHY      1
+#define USB_OTG_EMBEDDED_PHY  2
+
+/**
+  * @}
+  */
+
+
+/** @defgroup _GLOBAL_DEFINES_
+  * @{
+  */
+#define GAHBCFG_TXFEMPTYLVL_EMPTY              1
+#define GAHBCFG_TXFEMPTYLVL_HALFEMPTY          0
+#define GAHBCFG_GLBINT_ENABLE                  1
+#define GAHBCFG_INT_DMA_BURST_SINGLE           0
+#define GAHBCFG_INT_DMA_BURST_INCR             1
+#define GAHBCFG_INT_DMA_BURST_INCR4            3
+#define GAHBCFG_INT_DMA_BURST_INCR8            5
+#define GAHBCFG_INT_DMA_BURST_INCR16           7
+#define GAHBCFG_DMAENABLE                      1
+#define GAHBCFG_TXFEMPTYLVL_EMPTY              1
+#define GAHBCFG_TXFEMPTYLVL_HALFEMPTY          0
+#define GRXSTS_PKTSTS_IN                       2
+#define GRXSTS_PKTSTS_IN_XFER_COMP             3
+#define GRXSTS_PKTSTS_DATA_TOGGLE_ERR          5
+#define GRXSTS_PKTSTS_CH_HALTED                7
+/**
+  * @}
+  */
+
+
+/** @defgroup _OnTheGo_DEFINES_
+  * @{
+  */
+#define MODE_HNP_SRP_CAPABLE                   0
+#define MODE_SRP_ONLY_CAPABLE                  1
+#define MODE_NO_HNP_SRP_CAPABLE                2
+#define MODE_SRP_CAPABLE_DEVICE                3
+#define MODE_NO_SRP_CAPABLE_DEVICE             4
+#define MODE_SRP_CAPABLE_HOST                  5
+#define MODE_NO_SRP_CAPABLE_HOST               6
+#define A_HOST                                 1
+#define A_SUSPEND                              2
+#define A_PERIPHERAL                           3
+#define B_PERIPHERAL                           4
+#define B_HOST                                 5
+#define DEVICE_MODE                            0
+#define HOST_MODE                              1
+#define OTG_MODE                               2
+/**
+  * @}
+  */
+
+
+/** @defgroup __DEVICE_DEFINES_
+  * @{
+  */
+#define DSTS_ENUMSPD_HS_PHY_30MHZ_OR_60MHZ     0
+#define DSTS_ENUMSPD_FS_PHY_30MHZ_OR_60MHZ     1
+#define DSTS_ENUMSPD_LS_PHY_6MHZ               2
+#define DSTS_ENUMSPD_FS_PHY_48MHZ              3
+
+#define DCFG_FRAME_INTERVAL_80                 0
+#define DCFG_FRAME_INTERVAL_85                 1
+#define DCFG_FRAME_INTERVAL_90                 2
+#define DCFG_FRAME_INTERVAL_95                 3
+
+#define DEP0CTL_MPS_64                         0
+#define DEP0CTL_MPS_32                         1
+#define DEP0CTL_MPS_16                         2
+#define DEP0CTL_MPS_8                          3
+
+#define EP_SPEED_LOW                           0
+#define EP_SPEED_FULL                          1
+#define EP_SPEED_HIGH                          2
+
+#define EP_TYPE_CTRL                           0
+#define EP_TYPE_ISOC                           1
+#define EP_TYPE_BULK                           2
+#define EP_TYPE_INTR                           3
+#define EP_TYPE_MSK                            3
+
+#define STS_GOUT_NAK                           1
+#define STS_DATA_UPDT                          2
+#define STS_XFER_COMP                          3
+#define STS_SETUP_COMP                         4
+#define STS_SETUP_UPDT                         6
+/**
+  * @}
+  */
+
+
+/** @defgroup __HOST_DEFINES_
+  * @{
+  */
+#define HC_PID_DATA0                           0
+#define HC_PID_DATA2                           1
+#define HC_PID_DATA1                           2
+#define HC_PID_SETUP                           3
+
+#define HPRT0_PRTSPD_HIGH_SPEED                0
+#define HPRT0_PRTSPD_FULL_SPEED                1
+#define HPRT0_PRTSPD_LOW_SPEED                 2
+
+#define HCFG_30_60_MHZ                         0
+#define HCFG_48_MHZ                            1
+#define HCFG_6_MHZ                             2
+
+#define HCCHAR_CTRL                            0
+#define HCCHAR_ISOC                            1
+#define HCCHAR_BULK                            2
+#define HCCHAR_INTR                            3
+
+#define  MIN(a, b)      (((a) < (b)) ? (a) : (b))
+
+/**
+  * @}
+  */
+
+
+/** @defgroup USB_DEFINES_Exported_Types
+  * @{
+  */ 
+
+typedef enum
+{
+  USB_OTG_HS_CORE_ID = 0,
+  USB_OTG_FS_CORE_ID = 1
+}USB_OTG_CORE_ID_TypeDef;
+/**
+  * @}
+  */ 
+
+
+/** @defgroup USB_DEFINES_Exported_Macros
+  * @{
+  */ 
+/**
+  * @}
+  */ 
+
+/** @defgroup USB_DEFINES_Exported_Variables
+  * @{
+  */ 
+/**
+  * @}
+  */ 
+
+/** @defgroup USB_DEFINES_Exported_FunctionsPrototype
+  * @{
+  */ 
+/**
+  * @}
+  */ 
+
+
+/** @defgroup Internal_Macro's
+  * @{
+  */
+#define USB_OTG_READ_REG32(reg)  (*(__IO uint32_t *)reg)
+#define USB_OTG_WRITE_REG32(reg,value) (*(__IO uint32_t *)reg = value)
+#define USB_OTG_MODIFY_REG32(reg,clear_mask,set_mask) \
+  USB_OTG_WRITE_REG32(reg, (((USB_OTG_READ_REG32(reg)) & ~clear_mask) | set_mask ) )
+
+/********************************************************************************
+                              ENUMERATION TYPE
+********************************************************************************/
+enum USB_OTG_SPEED {
+  USB_SPEED_UNKNOWN = 0,
+  USB_SPEED_LOW,
+  USB_SPEED_FULL,
+  USB_SPEED_HIGH
+};
+
+#endif //__USB_DEFINES__H__
+
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
+

--- a/src/lib/usb_hcd.c
+++ b/src/lib/usb_hcd.c
@@ -1,0 +1,262 @@
+/**
+  ******************************************************************************
+  * @file    usb_hcd.c
+  * @author  MCD Application Team
+  * @version V2.1.0
+  * @date    19-March-2012
+  * @brief   Host Interface Layer
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT 2012 STMicroelectronics</center></h2>
+  *
+  * Licensed under MCD-ST Liberty SW License Agreement V2, (the "License");
+  * You may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at:
+  *
+  *        http://www.st.com/software_license_agreement_liberty_v2
+  *
+  * Unless required by applicable law or agreed to in writing, software 
+  * distributed under the License is distributed on an "AS IS" BASIS, 
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "usb_core.h"
+#include "usb_hcd.h"
+#include "usb_conf.h"
+#include "usb_bsp.h"
+
+
+/** @addtogroup USB_OTG_DRIVER
+  * @{
+  */
+  
+/** @defgroup USB_HCD 
+  * @brief This file is the interface between EFSL ans Host mass-storage class
+  * @{
+  */
+
+
+/** @defgroup USB_HCD_Private_Defines
+  * @{
+  */ 
+/**
+  * @}
+  */ 
+ 
+
+/** @defgroup USB_HCD_Private_TypesDefinitions
+  * @{
+  */ 
+/**
+  * @}
+  */ 
+
+
+
+/** @defgroup USB_HCD_Private_Macros
+  * @{
+  */ 
+/**
+  * @}
+  */ 
+
+
+/** @defgroup USB_HCD_Private_Variables
+  * @{
+  */ 
+/**
+  * @}
+  */ 
+
+
+/** @defgroup USB_HCD_Private_FunctionPrototypes
+  * @{
+  */ 
+/**
+  * @}
+  */ 
+
+
+/** @defgroup USB_HCD_Private_Functions
+  * @{
+  */ 
+
+/**
+  * @brief  HCD_Init 
+  *         Initialize the HOST portion of the driver.
+  * @param  pdev: Selected device
+  * @param  base_address: OTG base address
+  * @retval Status
+  */
+uint32_t HCD_Init(USB_OTG_CORE_HANDLE *pdev , 
+                  USB_OTG_CORE_ID_TypeDef coreID)
+{
+  uint8_t i = 0;
+  pdev->host.ConnSts = 0;
+  
+  for (i= 0; i< USB_OTG_MAX_TX_FIFOS; i++)
+  {
+  pdev->host.ErrCnt[i]  = 0;
+  pdev->host.XferCnt[i]   = 0;
+  pdev->host.HC_Status[i]   = HC_IDLE;
+  }
+  pdev->host.hc[0].max_packet  = 8; 
+
+  USB_OTG_SelectCore(pdev, coreID);
+#ifndef DUAL_ROLE_MODE_ENABLED
+  USB_OTG_DisableGlobalInt(pdev);
+  USB_OTG_CoreInit(pdev);
+
+  /* Force Host Mode*/
+  USB_OTG_SetCurrentMode(pdev , HOST_MODE);
+  USB_OTG_CoreInitHost(pdev);
+  USB_OTG_EnableGlobalInt(pdev);
+#endif
+   
+  return 0;
+}
+
+
+/**
+  * @brief  HCD_GetCurrentSpeed
+  *         Get Current device Speed.
+  * @param  pdev : Selected device
+  * @retval Status
+  */
+
+uint32_t HCD_GetCurrentSpeed (USB_OTG_CORE_HANDLE *pdev)
+{    
+    USB_OTG_HPRT0_TypeDef  HPRT0;
+    HPRT0.d32 = USB_OTG_READ_REG32(pdev->regs.HPRT0);
+    
+    return HPRT0.b.prtspd;
+}
+
+/**
+  * @brief  HCD_ResetPort
+  *         Issues the reset command to device
+  * @param  pdev : Selected device
+  * @retval Status
+  */
+uint32_t HCD_ResetPort(USB_OTG_CORE_HANDLE *pdev)
+{
+  /*
+  Before starting to drive a USB reset, the application waits for the OTG 
+  interrupt triggered by the debounce done bit (DBCDNE bit in OTG_FS_GOTGINT), 
+  which indicates that the bus is stable again after the electrical debounce 
+  caused by the attachment of a pull-up resistor on DP (FS) or DM (LS).
+  */
+  
+  USB_OTG_ResetPort(pdev); 
+  return 0;
+}
+
+/**
+  * @brief  HCD_IsDeviceConnected
+  *         Check if the device is connected.
+  * @param  pdev : Selected device
+  * @retval Device connection status. 1 -> connected and 0 -> disconnected
+  * 
+  */
+uint32_t HCD_IsDeviceConnected(USB_OTG_CORE_HANDLE *pdev)
+{
+  return (pdev->host.ConnSts);
+}
+
+/**
+  * @brief  HCD_GetCurrentFrame 
+  *         This function returns the frame number for sof packet
+  * @param  pdev : Selected device
+  * @retval Frame number
+  * 
+  */
+uint32_t HCD_GetCurrentFrame (USB_OTG_CORE_HANDLE *pdev) 
+{
+ return (USB_OTG_READ_REG32(&pdev->regs.HREGS->HFNUM) & 0xFFFF) ;
+}
+
+/**
+  * @brief  HCD_GetURB_State 
+  *         This function returns the last URBstate
+  * @param  pdev: Selected device
+  * @retval URB_STATE
+  * 
+  */
+URB_STATE HCD_GetURB_State (USB_OTG_CORE_HANDLE *pdev , uint8_t ch_num) 
+{
+  return pdev->host.URB_State[ch_num] ;
+}
+
+/**
+  * @brief  HCD_GetXferCnt 
+  *         This function returns the last URBstate
+  * @param  pdev: Selected device
+  * @retval No. of data bytes transferred
+  * 
+  */
+uint32_t HCD_GetXferCnt (USB_OTG_CORE_HANDLE *pdev, uint8_t ch_num) 
+{
+  return pdev->host.XferCnt[ch_num] ;
+}
+
+
+
+/**
+  * @brief  HCD_GetHCState 
+  *         This function returns the HC Status 
+  * @param  pdev: Selected device
+  * @retval HC_STATUS
+  * 
+  */
+HC_STATUS HCD_GetHCState (USB_OTG_CORE_HANDLE *pdev ,  uint8_t ch_num) 
+{
+  return pdev->host.HC_Status[ch_num] ;
+}
+
+/**
+  * @brief  HCD_HC_Init 
+  *         This function prepare a HC and start a transfer
+  * @param  pdev: Selected device
+  * @param  hc_num: Channel number 
+  * @retval status 
+  */
+uint32_t HCD_HC_Init (USB_OTG_CORE_HANDLE *pdev , uint8_t hc_num) 
+{
+  return USB_OTG_HC_Init(pdev, hc_num);  
+}
+
+/**
+  * @brief  HCD_SubmitRequest 
+  *         This function prepare a HC and start a transfer
+  * @param  pdev: Selected device
+  * @param  hc_num: Channel number 
+  * @retval status
+  */
+uint32_t HCD_SubmitRequest (USB_OTG_CORE_HANDLE *pdev , uint8_t hc_num) 
+{
+  
+  pdev->host.URB_State[hc_num] =   URB_IDLE;  
+  pdev->host.hc[hc_num].xfer_count = 0 ;
+  return USB_OTG_HC_StartXfer(pdev, hc_num);
+}
+
+
+/**
+* @}
+*/ 
+
+/**
+* @}
+*/ 
+
+/**
+* @}
+*/
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/src/lib/usb_hcd.h
+++ b/src/lib/usb_hcd.h
@@ -1,0 +1,108 @@
+/**
+  ******************************************************************************
+  * @file    usb_hcd.h
+  * @author  MCD Application Team
+  * @version V2.1.0
+  * @date    19-March-2012
+  * @brief   Host layer Header file
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT 2012 STMicroelectronics</center></h2>
+  *
+  * Licensed under MCD-ST Liberty SW License Agreement V2, (the "License");
+  * You may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at:
+  *
+  *        http://www.st.com/software_license_agreement_liberty_v2
+  *
+  * Unless required by applicable law or agreed to in writing, software 
+  * distributed under the License is distributed on an "AS IS" BASIS, 
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __USB_HCD_H__
+#define __USB_HCD_H__
+
+/* Includes ------------------------------------------------------------------*/
+#include "usb_regs.h"
+#include "usb_core.h"
+
+
+/** @addtogroup USB_OTG_DRIVER
+  * @{
+  */
+  
+/** @defgroup USB_HCD
+  * @brief This file is the 
+  * @{
+  */ 
+
+
+/** @defgroup USB_HCD_Exported_Defines
+  * @{
+  */ 
+/**
+  * @}
+  */ 
+
+
+/** @defgroup USB_HCD_Exported_Types
+  * @{
+  */ 
+/**
+  * @}
+  */ 
+
+
+/** @defgroup USB_HCD_Exported_Macros
+  * @{
+  */ 
+/**
+  * @}
+  */ 
+
+/** @defgroup USB_HCD_Exported_Variables
+  * @{
+  */ 
+/**
+  * @}
+  */ 
+
+/** @defgroup USB_HCD_Exported_FunctionsPrototype
+  * @{
+  */ 
+uint32_t  HCD_Init                 (USB_OTG_CORE_HANDLE *pdev ,
+                                    USB_OTG_CORE_ID_TypeDef coreID);
+uint32_t  HCD_HC_Init              (USB_OTG_CORE_HANDLE *pdev , 
+                                    uint8_t hc_num); 
+uint32_t  HCD_SubmitRequest        (USB_OTG_CORE_HANDLE *pdev , 
+                                    uint8_t hc_num) ;
+uint32_t  HCD_GetCurrentSpeed      (USB_OTG_CORE_HANDLE *pdev);
+uint32_t  HCD_ResetPort            (USB_OTG_CORE_HANDLE *pdev);
+uint32_t  HCD_IsDeviceConnected    (USB_OTG_CORE_HANDLE *pdev);
+uint32_t  HCD_GetCurrentFrame      (USB_OTG_CORE_HANDLE *pdev) ;
+URB_STATE HCD_GetURB_State         (USB_OTG_CORE_HANDLE *pdev,  uint8_t ch_num); 
+uint32_t  HCD_GetXferCnt           (USB_OTG_CORE_HANDLE *pdev,  uint8_t ch_num); 
+HC_STATUS HCD_GetHCState           (USB_OTG_CORE_HANDLE *pdev,  uint8_t ch_num) ;
+/**
+  * @}
+  */ 
+
+#endif //__USB_HCD_H__
+
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
+

--- a/src/lib/usb_hcd_int.c
+++ b/src/lib/usb_hcd_int.c
@@ -1,0 +1,858 @@
+/**
+  ******************************************************************************
+  * @file    usb_hcd_int.c
+  * @author  MCD Application Team
+  * @version V2.1.0
+  * @date    19-March-2012
+  * @brief   Host driver interrupt subroutines
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT 2012 STMicroelectronics</center></h2>
+  *
+  * Licensed under MCD-ST Liberty SW License Agreement V2, (the "License");
+  * You may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at:
+  *
+  *        http://www.st.com/software_license_agreement_liberty_v2
+  *
+  * Unless required by applicable law or agreed to in writing, software 
+  * distributed under the License is distributed on an "AS IS" BASIS, 
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "usb_core.h"
+#include "usb_defines.h"
+#include "usb_hcd_int.h"
+
+#if defined   (__CC_ARM) /*!< ARM Compiler */
+#pragma O0
+#elif defined (__GNUC__) /*!< GNU Compiler */
+#pragma GCC optimize ("O0")
+#elif defined  (__TASKING__) /*!< TASKING Compiler */ 
+#pragma optimize=0                          
+
+#endif /* __CC_ARM */
+
+/** @addtogroup USB_OTG_DRIVER
+* @{
+*/
+
+/** @defgroup USB_HCD_INT 
+* @brief This file contains the interrupt subroutines for the Host mode.
+* @{
+*/
+
+
+/** @defgroup USB_HCD_INT_Private_Defines
+* @{
+*/ 
+/**
+* @}
+*/ 
+
+
+/** @defgroup USB_HCD_INT_Private_TypesDefinitions
+* @{
+*/ 
+/**
+* @}
+*/ 
+
+
+
+/** @defgroup USB_HCD_INT_Private_Macros
+* @{
+*/ 
+/**
+* @}
+*/ 
+
+
+/** @defgroup USB_HCD_INT_Private_Variables
+* @{
+*/ 
+/**
+* @}
+*/ 
+
+
+/** @defgroup USB_HCD_INT_Private_FunctionPrototypes
+* @{
+*/ 
+
+static uint32_t USB_OTG_USBH_handle_sof_ISR(USB_OTG_CORE_HANDLE *pdev);
+static uint32_t USB_OTG_USBH_handle_port_ISR(USB_OTG_CORE_HANDLE *pdev);
+static uint32_t USB_OTG_USBH_handle_hc_ISR (USB_OTG_CORE_HANDLE *pdev);
+static uint32_t USB_OTG_USBH_handle_hc_n_In_ISR (USB_OTG_CORE_HANDLE *pdev ,
+                                                 uint32_t num);
+static uint32_t USB_OTG_USBH_handle_hc_n_Out_ISR (USB_OTG_CORE_HANDLE *pdev , 
+                                                  uint32_t num);
+static uint32_t USB_OTG_USBH_handle_rx_qlvl_ISR (USB_OTG_CORE_HANDLE *pdev);
+static uint32_t USB_OTG_USBH_handle_nptxfempty_ISR (USB_OTG_CORE_HANDLE *pdev);
+static uint32_t USB_OTG_USBH_handle_ptxfempty_ISR (USB_OTG_CORE_HANDLE *pdev);
+static uint32_t USB_OTG_USBH_handle_Disconnect_ISR (USB_OTG_CORE_HANDLE *pdev);
+static uint32_t USB_OTG_USBH_handle_IncompletePeriodicXfer_ISR (USB_OTG_CORE_HANDLE *pdev);
+
+/**
+* @}
+*/ 
+
+
+/** @defgroup USB_HCD_INT_Private_Functions
+* @{
+*/ 
+
+/**
+* @brief  HOST_Handle_ISR 
+*         This function handles all USB Host Interrupts
+* @param  pdev: Selected device
+* @retval status 
+*/
+
+uint32_t USBH_OTG_ISR_Handler (USB_OTG_CORE_HANDLE *pdev)
+{
+  USB_OTG_GINTSTS_TypeDef  gintsts;
+  uint32_t retval = 0;
+  
+  gintsts.d32 = 0;
+  
+  /* Check if HOST Mode */
+  if (USB_OTG_IsHostMode(pdev))
+  {
+    gintsts.d32 = USB_OTG_ReadCoreItr(pdev);
+    if (!gintsts.d32)
+    {
+      return 0;
+    }
+    
+    if (gintsts.b.sofintr)
+    {
+      retval |= USB_OTG_USBH_handle_sof_ISR (pdev);
+    }
+    
+    if (gintsts.b.rxstsqlvl)
+    {
+      retval |= USB_OTG_USBH_handle_rx_qlvl_ISR (pdev);
+    }
+    
+    if (gintsts.b.nptxfempty)
+    {
+      retval |= USB_OTG_USBH_handle_nptxfempty_ISR (pdev);
+    }
+    
+    if (gintsts.b.ptxfempty)
+    {
+      retval |= USB_OTG_USBH_handle_ptxfempty_ISR (pdev);
+    }    
+    
+    if (gintsts.b.hcintr)
+    {
+      retval |= USB_OTG_USBH_handle_hc_ISR (pdev);
+    }
+    
+    if (gintsts.b.portintr)
+    {
+      retval |= USB_OTG_USBH_handle_port_ISR (pdev);
+    }
+    
+    if (gintsts.b.disconnect)
+    {
+      retval |= USB_OTG_USBH_handle_Disconnect_ISR (pdev);  
+      
+    }
+    
+    if (gintsts.b.incomplisoout)
+    {
+      retval |= USB_OTG_USBH_handle_IncompletePeriodicXfer_ISR (pdev);
+    }
+    
+    
+  }
+  return retval;
+}
+
+/**
+* @brief  USB_OTG_USBH_handle_hc_ISR 
+*         This function indicates that one or more host channels has a pending
+* @param  pdev: Selected device
+* @retval status 
+*/
+static uint32_t USB_OTG_USBH_handle_hc_ISR (USB_OTG_CORE_HANDLE *pdev)
+{
+  USB_OTG_HAINT_TypeDef        haint;
+  USB_OTG_HCCHAR_TypeDef       hcchar;
+  uint32_t i = 0;
+  uint32_t retval = 0;
+  
+  /* Clear appropriate bits in HCINTn to clear the interrupt bit in
+  * GINTSTS */
+  
+  haint.d32 = USB_OTG_ReadHostAllChannels_intr(pdev);
+  
+  for (i = 0; i < pdev->cfg.host_channels ; i++)
+  {
+    if (haint.b.chint & (1 << i))
+    {
+      hcchar.d32 = USB_OTG_READ_REG32(&pdev->regs.HC_REGS[i]->HCCHAR);
+      
+      if (hcchar.b.epdir)
+      {
+        retval |= USB_OTG_USBH_handle_hc_n_In_ISR (pdev, i);
+      }
+      else
+      {
+        retval |=  USB_OTG_USBH_handle_hc_n_Out_ISR (pdev, i);
+      }
+    }
+  }
+  
+  return retval;
+}
+
+/**
+* @brief  USB_OTG_otg_hcd_handle_sof_intr 
+*         Handles the start-of-frame interrupt in host mode.
+* @param  pdev: Selected device
+* @retval status 
+*/
+static uint32_t USB_OTG_USBH_handle_sof_ISR (USB_OTG_CORE_HANDLE *pdev)
+{
+  USB_OTG_GINTSTS_TypeDef      gintsts;
+  gintsts.d32 = 0;
+  
+  USBH_HCD_INT_fops->SOF(pdev);
+  
+  /* Clear interrupt */
+  gintsts.b.sofintr = 1;
+  USB_OTG_WRITE_REG32(&pdev->regs.GREGS->GINTSTS, gintsts.d32);
+  
+  return 1;
+}
+
+/**
+* @brief  USB_OTG_USBH_handle_Disconnect_ISR 
+*         Handles disconnect event.
+* @param  pdev: Selected device
+* @retval status 
+*/
+static uint32_t USB_OTG_USBH_handle_Disconnect_ISR (USB_OTG_CORE_HANDLE *pdev)
+{
+  USB_OTG_GINTSTS_TypeDef      gintsts;
+  
+  gintsts.d32 = 0;
+  
+  USBH_HCD_INT_fops->DevDisconnected(pdev);
+  
+  /* Clear interrupt */
+  gintsts.b.disconnect = 1;
+  USB_OTG_WRITE_REG32(&pdev->regs.GREGS->GINTSTS, gintsts.d32);
+  
+  return 1;
+}
+#if defined ( __ICCARM__ ) /*!< IAR Compiler */
+#pragma optimize = none
+#endif /* __CC_ARM */
+/**
+* @brief  USB_OTG_USBH_handle_nptxfempty_ISR 
+*         Handles non periodic tx fifo empty.
+* @param  pdev: Selected device
+* @retval status 
+*/
+static uint32_t USB_OTG_USBH_handle_nptxfempty_ISR (USB_OTG_CORE_HANDLE *pdev)
+{
+  USB_OTG_GINTMSK_TypeDef      intmsk;
+  USB_OTG_HNPTXSTS_TypeDef     hnptxsts; 
+  uint16_t                     len_words , len; 
+  
+  hnptxsts.d32 = USB_OTG_READ_REG32(&pdev->regs.GREGS->HNPTXSTS);
+  
+  len_words = (pdev->host.hc[hnptxsts.b.nptxqtop.chnum].xfer_len + 3) / 4;
+  
+  while ((hnptxsts.b.nptxfspcavail > len_words)&&
+         (pdev->host.hc[hnptxsts.b.nptxqtop.chnum].xfer_len != 0))
+  {
+    
+    len = hnptxsts.b.nptxfspcavail * 4;
+    
+    if (len > pdev->host.hc[hnptxsts.b.nptxqtop.chnum].xfer_len)
+    {
+      /* Last packet */
+      len = pdev->host.hc[hnptxsts.b.nptxqtop.chnum].xfer_len;
+      
+      intmsk.d32 = 0;
+      intmsk.b.nptxfempty = 1;
+      USB_OTG_MODIFY_REG32( &pdev->regs.GREGS->GINTMSK, intmsk.d32, 0);       
+    }
+    
+    len_words = (pdev->host.hc[hnptxsts.b.nptxqtop.chnum].xfer_len + 3) / 4;
+    
+    USB_OTG_WritePacket (pdev , pdev->host.hc[hnptxsts.b.nptxqtop.chnum].xfer_buff, hnptxsts.b.nptxqtop.chnum, len);
+    
+    pdev->host.hc[hnptxsts.b.nptxqtop.chnum].xfer_buff  += len;
+    pdev->host.hc[hnptxsts.b.nptxqtop.chnum].xfer_len   -= len;
+    pdev->host.hc[hnptxsts.b.nptxqtop.chnum].xfer_count  += len; 
+    
+    hnptxsts.d32 = USB_OTG_READ_REG32(&pdev->regs.GREGS->HNPTXSTS);
+  }  
+  
+  return 1;
+}
+#if defined ( __ICCARM__ ) /*!< IAR Compiler */
+#pragma optimize = none
+#endif /* __CC_ARM */
+/**
+* @brief  USB_OTG_USBH_handle_ptxfempty_ISR 
+*         Handles periodic tx fifo empty
+* @param  pdev: Selected device
+* @retval status 
+*/
+static uint32_t USB_OTG_USBH_handle_ptxfempty_ISR (USB_OTG_CORE_HANDLE *pdev)
+{
+  USB_OTG_GINTMSK_TypeDef      intmsk;
+  USB_OTG_HPTXSTS_TypeDef      hptxsts; 
+  uint16_t                     len_words , len; 
+  
+  hptxsts.d32 = USB_OTG_READ_REG32(&pdev->regs.HREGS->HPTXSTS);
+  
+  len_words = (pdev->host.hc[hptxsts.b.ptxqtop.chnum].xfer_len + 3) / 4;
+  
+  while ((hptxsts.b.ptxfspcavail > len_words)&&
+         (pdev->host.hc[hptxsts.b.ptxqtop.chnum].xfer_len != 0))    
+  {
+    
+    len = hptxsts.b.ptxfspcavail * 4;
+    
+    if (len > pdev->host.hc[hptxsts.b.ptxqtop.chnum].xfer_len)
+    {
+      len = pdev->host.hc[hptxsts.b.ptxqtop.chnum].xfer_len;
+      /* Last packet */
+      intmsk.d32 = 0;
+      intmsk.b.ptxfempty = 1;
+      USB_OTG_MODIFY_REG32( &pdev->regs.GREGS->GINTMSK, intmsk.d32, 0); 
+    }
+    
+    len_words = (pdev->host.hc[hptxsts.b.ptxqtop.chnum].xfer_len + 3) / 4;
+    
+    USB_OTG_WritePacket (pdev , pdev->host.hc[hptxsts.b.ptxqtop.chnum].xfer_buff, hptxsts.b.ptxqtop.chnum, len);
+    
+    pdev->host.hc[hptxsts.b.ptxqtop.chnum].xfer_buff  += len;
+    pdev->host.hc[hptxsts.b.ptxqtop.chnum].xfer_len   -= len;
+    pdev->host.hc[hptxsts.b.ptxqtop.chnum].xfer_count  += len; 
+    
+    hptxsts.d32 = USB_OTG_READ_REG32(&pdev->regs.HREGS->HPTXSTS);
+  }  
+  
+  return 1;
+}
+
+/**
+* @brief  USB_OTG_USBH_handle_port_ISR 
+*         This function determines which interrupt conditions have occurred
+* @param  pdev: Selected device
+* @retval status 
+*/
+#if defined ( __ICCARM__ ) /*!< IAR Compiler */
+#pragma optimize = none
+#endif /* __CC_ARM */
+static uint32_t USB_OTG_USBH_handle_port_ISR (USB_OTG_CORE_HANDLE *pdev)
+{
+  USB_OTG_HPRT0_TypeDef  hprt0;
+  USB_OTG_HPRT0_TypeDef  hprt0_dup;
+  USB_OTG_HCFG_TypeDef   hcfg;    
+  uint32_t do_reset = 0;
+  uint32_t retval = 0;
+  
+  hcfg.d32 = 0;
+  hprt0.d32 = 0;
+  hprt0_dup.d32 = 0;
+  
+  hprt0.d32 = USB_OTG_READ_REG32(pdev->regs.HPRT0);
+  hprt0_dup.d32 = USB_OTG_READ_REG32(pdev->regs.HPRT0);
+  
+  /* Clear the interrupt bits in GINTSTS */
+  
+  hprt0_dup.b.prtena = 0;
+  hprt0_dup.b.prtconndet = 0;
+  hprt0_dup.b.prtenchng = 0;
+  hprt0_dup.b.prtovrcurrchng = 0;
+  
+  /* Port Connect Detected */
+  if (hprt0.b.prtconndet)
+  {
+
+    hprt0_dup.b.prtconndet = 1;
+    USBH_HCD_INT_fops->DevConnected(pdev);
+    retval |= 1;
+  }
+  
+  /* Port Enable Changed */
+  if (hprt0.b.prtenchng)
+  {
+    hprt0_dup.b.prtenchng = 1;
+    
+    if (hprt0.b.prtena == 1)
+    {
+      
+      USBH_HCD_INT_fops->DevConnected(pdev);
+      
+      if ((hprt0.b.prtspd == HPRT0_PRTSPD_LOW_SPEED) ||
+          (hprt0.b.prtspd == HPRT0_PRTSPD_FULL_SPEED))
+      {
+        
+        hcfg.d32 = USB_OTG_READ_REG32(&pdev->regs.HREGS->HCFG);
+        
+        if (hprt0.b.prtspd == HPRT0_PRTSPD_LOW_SPEED)
+        {
+          USB_OTG_WRITE_REG32(&pdev->regs.HREGS->HFIR, 6000 );
+          if (hcfg.b.fslspclksel != HCFG_6_MHZ)
+          {
+            if(pdev->cfg.phy_itface  == USB_OTG_EMBEDDED_PHY)
+            {
+              USB_OTG_InitFSLSPClkSel(pdev ,HCFG_6_MHZ );
+            }
+            do_reset = 1;
+          }
+        }
+        else
+        {
+          
+          USB_OTG_WRITE_REG32(&pdev->regs.HREGS->HFIR, 48000 );            
+          if (hcfg.b.fslspclksel != HCFG_48_MHZ)
+          {
+            USB_OTG_InitFSLSPClkSel(pdev ,HCFG_48_MHZ );
+            do_reset = 1;
+          }
+        }
+      }
+      else
+      {
+        do_reset = 1;
+      }
+    }
+  }
+  /* Overcurrent Change Interrupt */
+  if (hprt0.b.prtovrcurrchng)
+  {
+    hprt0_dup.b.prtovrcurrchng = 1;
+    retval |= 1;
+  }
+  if (do_reset)
+  {
+    USB_OTG_ResetPort(pdev);
+  }
+  /* Clear Port Interrupts */
+  USB_OTG_WRITE_REG32(pdev->regs.HPRT0, hprt0_dup.d32);
+  
+  return retval;
+}
+#if defined ( __ICCARM__ ) /*!< IAR Compiler */
+#pragma optimize = none
+#endif /* __CC_ARM */
+/**
+* @brief  USB_OTG_USBH_handle_hc_n_Out_ISR 
+*         Handles interrupt for a specific Host Channel
+* @param  pdev: Selected device
+* @param  hc_num: Channel number
+* @retval status 
+*/
+uint32_t USB_OTG_USBH_handle_hc_n_Out_ISR (USB_OTG_CORE_HANDLE *pdev , uint32_t num)
+{
+  
+  USB_OTG_HCINTn_TypeDef     hcint;
+  USB_OTG_HCINTMSK_TypeDef  hcintmsk;
+  USB_OTG_HC_REGS *hcreg;
+  USB_OTG_HCCHAR_TypeDef     hcchar; 
+  
+  hcreg = pdev->regs.HC_REGS[num];
+  hcint.d32 = USB_OTG_READ_REG32(&hcreg->HCINT);
+  hcintmsk.d32 = USB_OTG_READ_REG32(&hcreg->HCINTMSK);
+  hcint.d32 = hcint.d32 & hcintmsk.d32;
+  
+  hcchar.d32 = USB_OTG_READ_REG32(&pdev->regs.HC_REGS[num]->HCCHAR);
+  
+  if (hcint.b.ahberr)
+  {
+    CLEAR_HC_INT(hcreg ,ahberr);
+    UNMASK_HOST_INT_CHH (num);
+  } 
+  else if (hcint.b.ack)
+  {
+    CLEAR_HC_INT(hcreg , ack);
+  }
+  else if (hcint.b.frmovrun)
+  {
+    UNMASK_HOST_INT_CHH (num);
+    USB_OTG_HC_Halt(pdev, num);
+    CLEAR_HC_INT(hcreg ,frmovrun);
+  }
+  else if (hcint.b.xfercompl)
+  {
+    pdev->host.ErrCnt[num] = 0;
+    UNMASK_HOST_INT_CHH (num);
+    USB_OTG_HC_Halt(pdev, num);
+    CLEAR_HC_INT(hcreg , xfercompl);
+    pdev->host.HC_Status[num] = HC_XFRC;            
+  }
+  
+  else if (hcint.b.stall)
+  {
+    CLEAR_HC_INT(hcreg , stall);
+    UNMASK_HOST_INT_CHH (num);
+    USB_OTG_HC_Halt(pdev, num);
+    pdev->host.HC_Status[num] = HC_STALL;      
+  }
+  
+  else if (hcint.b.nak)
+  {
+    pdev->host.ErrCnt[num] = 0;
+    UNMASK_HOST_INT_CHH (num);
+    USB_OTG_HC_Halt(pdev, num);
+    CLEAR_HC_INT(hcreg , nak);
+    pdev->host.HC_Status[num] = HC_NAK;      
+  }
+  
+  else if (hcint.b.xacterr)
+  {
+    UNMASK_HOST_INT_CHH (num);
+    USB_OTG_HC_Halt(pdev, num);
+    pdev->host.ErrCnt[num] ++;
+    pdev->host.HC_Status[num] = HC_XACTERR;
+    CLEAR_HC_INT(hcreg , xacterr);
+  }
+  else if (hcint.b.nyet)
+  {
+    pdev->host.ErrCnt[num] = 0;
+    UNMASK_HOST_INT_CHH (num);
+    USB_OTG_HC_Halt(pdev, num);
+    CLEAR_HC_INT(hcreg , nyet);
+    pdev->host.HC_Status[num] = HC_NYET;    
+  }
+  else if (hcint.b.datatglerr)
+  {
+    
+    UNMASK_HOST_INT_CHH (num);
+    USB_OTG_HC_Halt(pdev, num);
+    CLEAR_HC_INT(hcreg , nak);   
+    pdev->host.HC_Status[num] = HC_DATATGLERR;
+    
+    CLEAR_HC_INT(hcreg , datatglerr);
+  }  
+  else if (hcint.b.chhltd)
+  {
+    MASK_HOST_INT_CHH (num);
+    
+    if(pdev->host.HC_Status[num] == HC_XFRC)
+    {
+      pdev->host.URB_State[num] = URB_DONE;  
+      
+      if (hcchar.b.eptype == EP_TYPE_BULK)
+      {
+        pdev->host.hc[num].toggle_out ^= 1; 
+      }
+    }
+    else if(pdev->host.HC_Status[num] == HC_NAK)
+    {
+      pdev->host.URB_State[num] = URB_NOTREADY;      
+    }    
+    else if(pdev->host.HC_Status[num] == HC_NYET)
+    {
+      if(pdev->host.hc[num].do_ping == 1)
+      {
+        USB_OTG_HC_DoPing(pdev, num);
+      }
+      pdev->host.URB_State[num] = URB_NOTREADY;      
+    }      
+    else if(pdev->host.HC_Status[num] == HC_STALL)
+    {
+      pdev->host.URB_State[num] = URB_STALL;      
+    }  
+    else if(pdev->host.HC_Status[num] == HC_XACTERR)
+    {
+      if (pdev->host.ErrCnt[num] == 3)
+      {
+        pdev->host.URB_State[num] = URB_ERROR;  
+        pdev->host.ErrCnt[num] = 0;
+      }
+    }
+    CLEAR_HC_INT(hcreg , chhltd);    
+  }
+  
+  
+  return 1;
+}
+#if defined ( __ICCARM__ ) /*!< IAR Compiler */
+#pragma optimize = none
+#endif /* __CC_ARM */
+/**
+* @brief  USB_OTG_USBH_handle_hc_n_In_ISR 
+*         Handles interrupt for a specific Host Channel
+* @param  pdev: Selected device
+* @param  hc_num: Channel number
+* @retval status 
+*/
+uint32_t USB_OTG_USBH_handle_hc_n_In_ISR (USB_OTG_CORE_HANDLE *pdev , uint32_t num)
+{
+  USB_OTG_HCINTn_TypeDef     hcint;
+  USB_OTG_HCINTMSK_TypeDef  hcintmsk;
+  USB_OTG_HCCHAR_TypeDef     hcchar; 
+  USB_OTG_HCTSIZn_TypeDef  hctsiz;
+  USB_OTG_HC_REGS *hcreg;
+  
+  
+  hcreg = pdev->regs.HC_REGS[num];
+  hcint.d32 = USB_OTG_READ_REG32(&hcreg->HCINT);
+  hcintmsk.d32 = USB_OTG_READ_REG32(&hcreg->HCINTMSK);
+  hcint.d32 = hcint.d32 & hcintmsk.d32;
+  hcchar.d32 = USB_OTG_READ_REG32(&pdev->regs.HC_REGS[num]->HCCHAR);
+  hcintmsk.d32 = 0;
+  
+  
+  if (hcint.b.ahberr)
+  {
+    CLEAR_HC_INT(hcreg ,ahberr);
+    UNMASK_HOST_INT_CHH (num);
+  }  
+  else if (hcint.b.ack)
+  {
+    CLEAR_HC_INT(hcreg ,ack);
+  }
+  
+  else if (hcint.b.stall)  
+  {
+    UNMASK_HOST_INT_CHH (num);
+    pdev->host.HC_Status[num] = HC_STALL; 
+    CLEAR_HC_INT(hcreg , nak);   /* Clear the NAK Condition */
+    CLEAR_HC_INT(hcreg , stall); /* Clear the STALL Condition */
+    hcint.b.nak = 0;           /* NOTE: When there is a 'stall', reset also nak, 
+                                  else, the pdev->host.HC_Status = HC_STALL
+    will be overwritten by 'nak' in code below */
+    USB_OTG_HC_Halt(pdev, num);    
+  }
+  else if (hcint.b.datatglerr)
+  {
+    
+    UNMASK_HOST_INT_CHH (num);
+    USB_OTG_HC_Halt(pdev, num);
+    CLEAR_HC_INT(hcreg , nak);   
+    pdev->host.HC_Status[num] = HC_DATATGLERR; 
+    CLEAR_HC_INT(hcreg , datatglerr);
+  }    
+  
+  if (hcint.b.frmovrun)
+  {
+    UNMASK_HOST_INT_CHH (num);
+    USB_OTG_HC_Halt(pdev, num);
+    CLEAR_HC_INT(hcreg ,frmovrun);
+  }
+  
+  else if (hcint.b.xfercompl)
+  {
+    
+    if (pdev->cfg.dma_enable == 1)
+    {
+      hctsiz.d32 = USB_OTG_READ_REG32(&pdev->regs.HC_REGS[num]->HCTSIZ);
+      pdev->host.XferCnt[num] =  pdev->host.hc[num].xfer_len - hctsiz.b.xfersize;
+    }
+    
+    pdev->host.HC_Status[num] = HC_XFRC;     
+    pdev->host.ErrCnt [num]= 0;
+    CLEAR_HC_INT(hcreg , xfercompl);
+    
+    if ((hcchar.b.eptype == EP_TYPE_CTRL)||
+        (hcchar.b.eptype == EP_TYPE_BULK))
+    {
+      UNMASK_HOST_INT_CHH (num);
+      USB_OTG_HC_Halt(pdev, num);
+      CLEAR_HC_INT(hcreg , nak); 
+      pdev->host.hc[num].toggle_in ^= 1;
+      
+    }
+    else if(hcchar.b.eptype == EP_TYPE_INTR)
+    {
+      hcchar.b.oddfrm  = 1;
+      USB_OTG_WRITE_REG32(&pdev->regs.HC_REGS[num]->HCCHAR, hcchar.d32); 
+      pdev->host.URB_State[num] = URB_DONE;  
+    }
+    
+  }
+  else if (hcint.b.chhltd)
+  {
+    MASK_HOST_INT_CHH (num);
+    
+    if(pdev->host.HC_Status[num] == HC_XFRC)
+    {
+      pdev->host.URB_State[num] = URB_DONE;      
+    }
+    
+    else if (pdev->host.HC_Status[num] == HC_STALL) 
+    {
+      pdev->host.URB_State[num] = URB_STALL;
+    }   
+    
+    else if((pdev->host.HC_Status[num] == HC_XACTERR) ||
+            (pdev->host.HC_Status[num] == HC_DATATGLERR))
+    {
+      pdev->host.ErrCnt[num] = 0;
+      pdev->host.URB_State[num] = URB_ERROR;  
+      
+    }
+    else if(hcchar.b.eptype == EP_TYPE_INTR)
+    {
+      pdev->host.hc[num].toggle_in ^= 1;
+    }
+    
+    CLEAR_HC_INT(hcreg , chhltd);    
+    
+  }    
+  else if (hcint.b.xacterr)
+  {
+    UNMASK_HOST_INT_CHH (num);
+    pdev->host.ErrCnt[num] ++;
+    pdev->host.HC_Status[num] = HC_XACTERR;
+    USB_OTG_HC_Halt(pdev, num);
+    CLEAR_HC_INT(hcreg , xacterr);    
+    
+  }
+  else if (hcint.b.nak)  
+  {  
+    if(hcchar.b.eptype == EP_TYPE_INTR)
+    {
+      UNMASK_HOST_INT_CHH (num);
+      USB_OTG_HC_Halt(pdev, num);
+    }
+    else if  ((hcchar.b.eptype == EP_TYPE_CTRL)||
+              (hcchar.b.eptype == EP_TYPE_BULK))
+    {
+      /* re-activate the channel  */
+      hcchar.b.chen = 1;
+      hcchar.b.chdis = 0;
+      USB_OTG_WRITE_REG32(&pdev->regs.HC_REGS[num]->HCCHAR, hcchar.d32); 
+    }
+    pdev->host.HC_Status[num] = HC_NAK;
+    CLEAR_HC_INT(hcreg , nak);   
+  }
+  
+  
+  return 1;
+  
+}
+
+/**
+* @brief  USB_OTG_USBH_handle_rx_qlvl_ISR 
+*         Handles the Rx Status Queue Level Interrupt
+* @param  pdev: Selected device
+* @retval status 
+*/
+#if defined ( __ICCARM__ ) /*!< IAR Compiler */
+#pragma optimize = none
+#endif /* __CC_ARM */
+static uint32_t USB_OTG_USBH_handle_rx_qlvl_ISR (USB_OTG_CORE_HANDLE *pdev)
+{
+  USB_OTG_GRXFSTS_TypeDef       grxsts;
+  USB_OTG_GINTMSK_TypeDef       intmsk;
+  USB_OTG_HCTSIZn_TypeDef       hctsiz; 
+  USB_OTG_HCCHAR_TypeDef        hcchar;
+  __IO uint8_t                  channelnum =0;  
+  uint32_t                      count;    
+  
+  /* Disable the Rx Status Queue Level interrupt */
+  intmsk.d32 = 0;
+  intmsk.b.rxstsqlvl = 1;
+  USB_OTG_MODIFY_REG32( &pdev->regs.GREGS->GINTMSK, intmsk.d32, 0);
+  
+  grxsts.d32 = USB_OTG_READ_REG32(&pdev->regs.GREGS->GRXSTSP);
+  channelnum = grxsts.b.chnum;  
+  hcchar.d32 = USB_OTG_READ_REG32(&pdev->regs.HC_REGS[channelnum]->HCCHAR);
+  
+  switch (grxsts.b.pktsts)
+  {
+  case GRXSTS_PKTSTS_IN:
+    /* Read the data into the host buffer. */
+    if ((grxsts.b.bcnt > 0) && (pdev->host.hc[channelnum].xfer_buff != (void  *)0))
+    {  
+      
+      USB_OTG_ReadPacket(pdev, pdev->host.hc[channelnum].xfer_buff, grxsts.b.bcnt);
+      /*manage multiple Xfer */
+      pdev->host.hc[grxsts.b.chnum].xfer_buff += grxsts.b.bcnt;           
+      pdev->host.hc[grxsts.b.chnum].xfer_count  += grxsts.b.bcnt;
+      
+      
+      count = pdev->host.hc[channelnum].xfer_count;
+      pdev->host.XferCnt[channelnum]  = count;
+      
+      hctsiz.d32 = USB_OTG_READ_REG32(&pdev->regs.HC_REGS[channelnum]->HCTSIZ);
+      if(hctsiz.b.pktcnt > 0)
+      {
+        /* re-activate the channel when more packets are expected */
+        hcchar.b.chen = 1;
+        hcchar.b.chdis = 0;
+        USB_OTG_WRITE_REG32(&pdev->regs.HC_REGS[channelnum]->HCCHAR, hcchar.d32);
+      }
+    }
+    break;
+    
+  case GRXSTS_PKTSTS_IN_XFER_COMP:
+    
+  case GRXSTS_PKTSTS_DATA_TOGGLE_ERR:
+  case GRXSTS_PKTSTS_CH_HALTED:
+  default:
+    break;
+  }
+  
+  /* Enable the Rx Status Queue Level interrupt */
+  intmsk.b.rxstsqlvl = 1;
+  USB_OTG_MODIFY_REG32(&pdev->regs.GREGS->GINTMSK, 0, intmsk.d32);
+  return 1;
+}
+
+/**
+* @brief  USB_OTG_USBH_handle_IncompletePeriodicXfer_ISR 
+*         Handles the incomplete Periodic transfer Interrupt
+* @param  pdev: Selected device
+* @retval status 
+*/
+#if defined ( __ICCARM__ ) /*!< IAR Compiler */
+#pragma optimize = none
+#endif /* __CC_ARM */
+static uint32_t USB_OTG_USBH_handle_IncompletePeriodicXfer_ISR (USB_OTG_CORE_HANDLE *pdev)
+{
+  
+  USB_OTG_GINTSTS_TypeDef       gintsts;
+  USB_OTG_HCCHAR_TypeDef        hcchar; 
+  
+  
+  
+  
+  hcchar.d32 = USB_OTG_READ_REG32(&pdev->regs.HC_REGS[0]->HCCHAR);
+  hcchar.b.chen = 1;
+  hcchar.b.chdis = 1;
+  USB_OTG_WRITE_REG32(&pdev->regs.HC_REGS[0]->HCCHAR, hcchar.d32);  
+  
+  gintsts.d32 = 0;
+  /* Clear interrupt */
+  gintsts.b.incomplisoout = 1;
+  USB_OTG_WRITE_REG32(&pdev->regs.GREGS->GINTSTS, gintsts.d32);
+  
+  return 1;
+}
+
+/**
+* @}
+*/ 
+
+/**
+* @}
+*/ 
+
+/**
+* @}
+*/
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
+

--- a/src/lib/usb_hcd_int.h
+++ b/src/lib/usb_hcd_int.h
@@ -1,0 +1,141 @@
+/**
+  ******************************************************************************
+  * @file    usb_hcd_int.h
+  * @author  MCD Application Team
+  * @version V2.1.0
+  * @date    19-March-2012
+  * @brief   Peripheral Device Interface Layer
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT 2012 STMicroelectronics</center></h2>
+  *
+  * Licensed under MCD-ST Liberty SW License Agreement V2, (the "License");
+  * You may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at:
+  *
+  *        http://www.st.com/software_license_agreement_liberty_v2
+  *
+  * Unless required by applicable law or agreed to in writing, software 
+  * distributed under the License is distributed on an "AS IS" BASIS, 
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __HCD_INT_H__
+#define __HCD_INT_H__
+
+/* Includes ------------------------------------------------------------------*/
+#include "usb_hcd.h"
+
+
+/** @addtogroup USB_OTG_DRIVER
+  * @{
+  */
+  
+/** @defgroup USB_HCD_INT
+  * @brief This file is the 
+  * @{
+  */ 
+
+
+/** @defgroup USB_HCD_INT_Exported_Defines
+  * @{
+  */ 
+/**
+  * @}
+  */ 
+
+
+/** @defgroup USB_HCD_INT_Exported_Types
+  * @{
+  */ 
+
+typedef struct _USBH_HCD_INT
+{
+  uint8_t (* SOF) (USB_OTG_CORE_HANDLE *pdev);
+  uint8_t (* DevConnected) (USB_OTG_CORE_HANDLE *pdev);
+  uint8_t (* DevDisconnected) (USB_OTG_CORE_HANDLE *pdev);   
+  
+}USBH_HCD_INT_cb_TypeDef;
+
+extern USBH_HCD_INT_cb_TypeDef *USBH_HCD_INT_fops;
+/**
+  * @}
+  */ 
+
+
+/** @defgroup USB_HCD_INT_Exported_Macros
+  * @{
+  */ 
+
+#define CLEAR_HC_INT(HC_REGS, intr) \
+  {\
+  USB_OTG_HCINTn_TypeDef  hcint_clear; \
+  hcint_clear.d32 = 0; \
+  hcint_clear.b.intr = 1; \
+  USB_OTG_WRITE_REG32(&((HC_REGS)->HCINT), hcint_clear.d32);\
+  }\
+
+#define MASK_HOST_INT_CHH(hc_num) { USB_OTG_HCINTMSK_TypeDef  INTMSK; \
+    INTMSK.d32 = USB_OTG_READ_REG32(&pdev->regs.HC_REGS[hc_num]->HCINTMSK); \
+    INTMSK.b.chhltd = 0; \
+    USB_OTG_WRITE_REG32(&pdev->regs.HC_REGS[hc_num]->HCINTMSK, INTMSK.d32);}
+
+#define UNMASK_HOST_INT_CHH(hc_num) { USB_OTG_HCINTMSK_TypeDef  INTMSK; \
+    INTMSK.d32 = USB_OTG_READ_REG32(&pdev->regs.HC_REGS[hc_num]->HCINTMSK); \
+    INTMSK.b.chhltd = 1; \
+    USB_OTG_WRITE_REG32(&pdev->regs.HC_REGS[hc_num]->HCINTMSK, INTMSK.d32);}
+
+#define MASK_HOST_INT_ACK(hc_num) { USB_OTG_HCINTMSK_TypeDef  INTMSK; \
+    INTMSK.d32 = USB_OTG_READ_REG32(&pdev->regs.HC_REGS[hc_num]->HCINTMSK); \
+    INTMSK.b.ack = 0; \
+    USB_OTG_WRITE_REG32(&pdev->regs.HC_REGS[hc_num]->HCINTMSK, GINTMSK.d32);}
+
+#define UNMASK_HOST_INT_ACK(hc_num) { USB_OTG_HCGINTMSK_TypeDef  INTMSK; \
+    INTMSK.d32 = USB_OTG_READ_REG32(&pdev->regs.HC_REGS[hc_num]->HCINTMSK); \
+    INTMSK.b.ack = 1; \
+    USB_OTG_WRITE_REG32(&pdev->regs.HC_REGS[hc_num]->HCINTMSK, INTMSK.d32);}
+
+/**
+  * @}
+  */ 
+
+/** @defgroup USB_HCD_INT_Exported_Variables
+  * @{
+  */ 
+/**
+  * @}
+  */ 
+
+/** @defgroup USB_HCD_INT_Exported_FunctionsPrototype
+  * @{
+  */ 
+/* Callbacks handler */
+void ConnectCallback_Handler(USB_OTG_CORE_HANDLE *pdev);
+void Disconnect_Callback_Handler(USB_OTG_CORE_HANDLE *pdev);
+void Overcurrent_Callback_Handler(USB_OTG_CORE_HANDLE *pdev);
+uint32_t USBH_OTG_ISR_Handler (USB_OTG_CORE_HANDLE *pdev);
+
+/**
+  * @}
+  */ 
+
+
+
+#endif //__HCD_INT_H__
+
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
+

--- a/src/lib/usb_otg.h
+++ b/src/lib/usb_otg.h
@@ -1,0 +1,99 @@
+/**
+  ******************************************************************************
+  * @file    usb_otg.h
+  * @author  MCD Application Team
+  * @version V2.1.0
+  * @date    19-March-2012
+  * @brief   OTG Core Header
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT 2012 STMicroelectronics</center></h2>
+  *
+  * Licensed under MCD-ST Liberty SW License Agreement V2, (the "License");
+  * You may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at:
+  *
+  *        http://www.st.com/software_license_agreement_liberty_v2
+  *
+  * Unless required by applicable law or agreed to in writing, software 
+  * distributed under the License is distributed on an "AS IS" BASIS, 
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __USB_OTG__
+#define __USB_OTG__
+
+
+/** @addtogroup USB_OTG_DRIVER
+  * @{
+  */
+  
+/** @defgroup USB_OTG
+  * @brief This file is the 
+  * @{
+  */ 
+
+
+/** @defgroup USB_OTG_Exported_Defines
+  * @{
+  */ 
+
+
+void USB_OTG_InitiateSRP(void);
+void USB_OTG_InitiateHNP(uint8_t state , uint8_t mode);
+void USB_OTG_Switchback (USB_OTG_CORE_DEVICE *pdev);
+uint32_t  USB_OTG_GetCurrentState (USB_OTG_CORE_DEVICE *pdev);
+
+/**
+  * @}
+  */ 
+
+
+/** @defgroup USB_OTG_Exported_Types
+  * @{
+  */ 
+/**
+  * @}
+  */ 
+
+
+/** @defgroup USB_OTG_Exported_Macros
+  * @{
+  */ 
+/**
+  * @}
+  */ 
+
+/** @defgroup USB_OTG_Exported_Variables
+  * @{
+  */ 
+/**
+  * @}
+  */ 
+
+/** @defgroup USB_OTG_Exported_FunctionsPrototype
+  * @{
+  */ 
+/**
+  * @}
+  */ 
+
+
+#endif //__USB_OTG__
+
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
+

--- a/src/lib/usb_regs.h
+++ b/src/lib/usb_regs.h
@@ -1,0 +1,1188 @@
+/**
+  ******************************************************************************
+  * @file    usb_regs.h
+  * @author  MCD Application Team
+  * @version V2.1.0
+  * @date    19-March-2012
+  * @brief   hardware registers
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT 2012 STMicroelectronics</center></h2>
+  *
+  * Licensed under MCD-ST Liberty SW License Agreement V2, (the "License");
+  * You may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at:
+  *
+  *        http://www.st.com/software_license_agreement_liberty_v2
+  *
+  * Unless required by applicable law or agreed to in writing, software 
+  * distributed under the License is distributed on an "AS IS" BASIS, 
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __USB_OTG_REGS_H__
+#define __USB_OTG_REGS_H__
+
+/* Includes ------------------------------------------------------------------*/
+#include "usb_conf.h"
+
+
+/** @addtogroup USB_OTG_DRIVER
+  * @{
+  */
+  
+/** @defgroup USB_REGS
+  * @brief This file is the 
+  * @{
+  */ 
+
+
+/** @defgroup USB_REGS_Exported_Defines
+  * @{
+  */ 
+
+#define USB_OTG_HS_BASE_ADDR                 0x40040000
+#define USB_OTG_FS_BASE_ADDR                 0x50000000
+
+#define USB_OTG_CORE_GLOBAL_REGS_OFFSET      0x000
+#define USB_OTG_DEV_GLOBAL_REG_OFFSET        0x800
+#define USB_OTG_DEV_IN_EP_REG_OFFSET         0x900
+#define USB_OTG_EP_REG_OFFSET                0x20
+#define USB_OTG_DEV_OUT_EP_REG_OFFSET        0xB00
+#define USB_OTG_HOST_GLOBAL_REG_OFFSET       0x400
+#define USB_OTG_HOST_PORT_REGS_OFFSET        0x440
+#define USB_OTG_HOST_CHAN_REGS_OFFSET        0x500
+#define USB_OTG_CHAN_REGS_OFFSET             0x20
+#define USB_OTG_PCGCCTL_OFFSET               0xE00
+#define USB_OTG_DATA_FIFO_OFFSET             0x1000
+#define USB_OTG_DATA_FIFO_SIZE               0x1000
+
+
+#define USB_OTG_MAX_TX_FIFOS                 15
+
+#define USB_OTG_HS_MAX_PACKET_SIZE           512
+#define USB_OTG_FS_MAX_PACKET_SIZE           64
+#define USB_OTG_MAX_EP0_SIZE                 64
+/**
+  * @}
+  */ 
+
+/** @defgroup USB_REGS_Exported_Types
+  * @{
+  */ 
+
+/** @defgroup __USB_OTG_Core_register
+  * @{
+  */
+typedef struct _USB_OTG_GREGS  //000h
+{
+  __IO uint32_t GOTGCTL;      /* USB_OTG Control and Status Register    000h*/
+  __IO uint32_t GOTGINT;      /* USB_OTG Interrupt Register             004h*/
+  __IO uint32_t GAHBCFG;      /* Core AHB Configuration Register    008h*/
+  __IO uint32_t GUSBCFG;      /* Core USB Configuration Register    00Ch*/
+  __IO uint32_t GRSTCTL;      /* Core Reset Register                010h*/
+  __IO uint32_t GINTSTS;      /* Core Interrupt Register            014h*/
+  __IO uint32_t GINTMSK;      /* Core Interrupt Mask Register       018h*/
+  __IO uint32_t GRXSTSR;      /* Receive Sts Q Read Register        01Ch*/
+  __IO uint32_t GRXSTSP;      /* Receive Sts Q Read & POP Register  020h*/
+  __IO uint32_t GRXFSIZ;      /* Receive FIFO Size Register         024h*/
+  __IO uint32_t DIEPTXF0_HNPTXFSIZ;   /* EP0 / Non Periodic Tx FIFO Size Register 028h*/
+  __IO uint32_t HNPTXSTS;     /* Non Periodic Tx FIFO/Queue Sts reg 02Ch*/
+  uint32_t Reserved30[2];     /* Reserved                           030h*/
+  __IO uint32_t GCCFG;        /* General Purpose IO Register        038h*/
+  __IO uint32_t CID;          /* User ID Register                   03Ch*/
+  uint32_t  Reserved40[48];   /* Reserved                      040h-0FFh*/
+  __IO uint32_t HPTXFSIZ; /* Host Periodic Tx FIFO Size Reg     100h*/
+  __IO uint32_t DIEPTXF[USB_OTG_MAX_TX_FIFOS];/* dev Periodic Transmit FIFO */
+}
+USB_OTG_GREGS;
+/**
+  * @}
+  */
+
+
+/** @defgroup __device_Registers
+  * @{
+  */
+typedef struct _USB_OTG_DREGS // 800h
+{
+  __IO uint32_t DCFG;         /* dev Configuration Register   800h*/
+  __IO uint32_t DCTL;         /* dev Control Register         804h*/
+  __IO uint32_t DSTS;         /* dev Status Register (RO)     808h*/
+  uint32_t Reserved0C;           /* Reserved                     80Ch*/
+  __IO uint32_t DIEPMSK;   /* dev IN Endpoint Mask         810h*/
+  __IO uint32_t DOEPMSK;  /* dev OUT Endpoint Mask        814h*/
+  __IO uint32_t DAINT;     /* dev All Endpoints Itr Reg    818h*/
+  __IO uint32_t DAINTMSK; /* dev All Endpoints Itr Mask   81Ch*/
+  uint32_t  Reserved20;          /* Reserved                     820h*/
+  uint32_t Reserved9;       /* Reserved                     824h*/
+  __IO uint32_t DVBUSDIS;    /* dev VBUS discharge Register  828h*/
+  __IO uint32_t DVBUSPULSE;  /* dev VBUS Pulse Register      82Ch*/
+  __IO uint32_t DTHRCTL;     /* dev thr                      830h*/
+  __IO uint32_t DIEPEMPMSK; /* dev empty msk             834h*/
+  __IO uint32_t DEACHINT;    /* dedicated EP interrupt       838h*/
+  __IO uint32_t DEACHMSK;    /* dedicated EP msk             83Ch*/  
+  uint32_t Reserved40;      /* dedicated EP mask           840h*/
+  __IO uint32_t DINEP1MSK;  /* dedicated EP mask           844h*/
+  uint32_t  Reserved44[15];      /* Reserved                 844-87Ch*/
+  __IO uint32_t DOUTEP1MSK; /* dedicated EP msk            884h*/   
+}
+USB_OTG_DREGS;
+/**
+  * @}
+  */
+
+
+/** @defgroup __IN_Endpoint-Specific_Register
+  * @{
+  */
+typedef struct _USB_OTG_INEPREGS
+{
+  __IO uint32_t DIEPCTL; /* dev IN Endpoint Control Reg 900h + (ep_num * 20h) + 00h*/
+  uint32_t Reserved04;             /* Reserved                       900h + (ep_num * 20h) + 04h*/
+  __IO uint32_t DIEPINT; /* dev IN Endpoint Itr Reg     900h + (ep_num * 20h) + 08h*/
+  uint32_t Reserved0C;             /* Reserved                       900h + (ep_num * 20h) + 0Ch*/
+  __IO uint32_t DIEPTSIZ; /* IN Endpoint Txfer Size   900h + (ep_num * 20h) + 10h*/
+  __IO uint32_t DIEPDMA; /* IN Endpoint DMA Address Reg    900h + (ep_num * 20h) + 14h*/
+  __IO uint32_t DTXFSTS;/*IN Endpoint Tx FIFO Status Reg 900h + (ep_num * 20h) + 18h*/
+  uint32_t Reserved18;             /* Reserved  900h+(ep_num*20h)+1Ch-900h+ (ep_num * 20h) + 1Ch*/
+}
+USB_OTG_INEPREGS;
+/**
+  * @}
+  */
+
+
+/** @defgroup __OUT_Endpoint-Specific_Registers
+  * @{
+  */
+typedef struct _USB_OTG_OUTEPREGS
+{
+  __IO uint32_t DOEPCTL;       /* dev OUT Endpoint Control Reg  B00h + (ep_num * 20h) + 00h*/
+  uint32_t Reserved04;         /* Reserved                      B00h + (ep_num * 20h) + 04h*/
+  __IO uint32_t DOEPINT;       /* dev OUT Endpoint Itr Reg      B00h + (ep_num * 20h) + 08h*/
+  uint32_t Reserved0C;         /* Reserved                      B00h + (ep_num * 20h) + 0Ch*/
+  __IO uint32_t DOEPTSIZ;      /* dev OUT Endpoint Txfer Size   B00h + (ep_num * 20h) + 10h*/
+  __IO uint32_t DOEPDMA;       /* dev OUT Endpoint DMA Address  B00h + (ep_num * 20h) + 14h*/
+  uint32_t Reserved18[2];      /* Reserved B00h + (ep_num * 20h) + 18h - B00h + (ep_num * 20h) + 1Ch*/
+}
+USB_OTG_OUTEPREGS;
+/**
+  * @}
+  */
+
+
+/** @defgroup __Host_Mode_Register_Structures
+  * @{
+  */
+typedef struct _USB_OTG_HREGS
+{
+  __IO uint32_t HCFG;             /* Host Configuration Register    400h*/
+  __IO uint32_t HFIR;      /* Host Frame Interval Register   404h*/
+  __IO uint32_t HFNUM;         /* Host Frame Nbr/Frame Remaining 408h*/
+  uint32_t Reserved40C;                   /* Reserved                       40Ch*/
+  __IO uint32_t HPTXSTS;   /* Host Periodic Tx FIFO/ Queue Status 410h*/
+  __IO uint32_t HAINT;   /* Host All Channels Interrupt Register 414h*/
+  __IO uint32_t HAINTMSK;   /* Host All Channels Interrupt Mask 418h*/
+}
+USB_OTG_HREGS;
+/**
+  * @}
+  */
+
+
+/** @defgroup __Host_Channel_Specific_Registers
+  * @{
+  */
+typedef struct _USB_OTG_HC_REGS
+{
+  __IO uint32_t HCCHAR;
+  __IO uint32_t HCSPLT;
+  __IO uint32_t HCINT;
+  __IO uint32_t HCINTMSK;
+  __IO uint32_t HCTSIZ;
+  __IO uint32_t HCDMA;
+  uint32_t Reserved[2];
+}
+USB_OTG_HC_REGS;
+/**
+  * @}
+  */
+
+
+/** @defgroup __otg_Core_registers
+  * @{
+  */
+typedef struct USB_OTG_core_regs //000h
+{
+  USB_OTG_GREGS         *GREGS;
+  USB_OTG_DREGS         *DREGS;
+  USB_OTG_HREGS         *HREGS;
+  USB_OTG_INEPREGS      *INEP_REGS[USB_OTG_MAX_TX_FIFOS];
+  USB_OTG_OUTEPREGS     *OUTEP_REGS[USB_OTG_MAX_TX_FIFOS];
+  USB_OTG_HC_REGS       *HC_REGS[USB_OTG_MAX_TX_FIFOS];
+  __IO uint32_t         *HPRT0;
+  __IO uint32_t         *DFIFO[USB_OTG_MAX_TX_FIFOS];
+  __IO uint32_t         *PCGCCTL;
+}
+USB_OTG_CORE_REGS , *PUSB_OTG_CORE_REGS;
+typedef union _USB_OTG_GOTGCTL_TypeDef 
+{
+  uint32_t d32;
+  struct
+  {
+uint32_t sesreqscs :
+    1;
+uint32_t sesreq :
+    1;
+uint32_t Reserved2_7 :
+    6;
+uint32_t hstnegscs :
+    1;
+uint32_t hnpreq :
+    1;
+uint32_t hstsethnpen :
+    1;
+uint32_t devhnpen :
+    1;
+uint32_t Reserved12_15 :
+    4;
+uint32_t conidsts :
+    1;
+uint32_t dbct :
+    1;
+uint32_t asesvld :
+    1;
+uint32_t bsesvld :
+    1;
+uint32_t Reserved20_31 :
+    12;
+  }
+  b;
+} USB_OTG_GOTGCTL_TypeDef ;
+
+typedef union _USB_OTG_GOTGINT_TypeDef 
+{
+  uint32_t d32;
+  struct
+  {
+uint32_t Reserved0_1 :
+    2;
+uint32_t sesenddet :
+    1;
+uint32_t Reserved3_7 :
+    5;
+uint32_t sesreqsucstschng :
+    1;
+uint32_t hstnegsucstschng :
+    1;
+uint32_t reserver10_16 :
+    7;
+uint32_t hstnegdet :
+    1;
+uint32_t adevtoutchng :
+    1;
+uint32_t debdone :
+    1;
+uint32_t Reserved31_20 :
+    12;
+  }
+  b;
+} USB_OTG_GOTGINT_TypeDef ;
+typedef union _USB_OTG_GAHBCFG_TypeDef 
+{
+  uint32_t d32;
+  struct
+  {
+uint32_t glblintrmsk :
+    1;
+uint32_t hburstlen :
+    4;
+uint32_t dmaenable :
+    1;
+uint32_t Reserved :
+    1;
+uint32_t nptxfemplvl_txfemplvl :
+    1;
+uint32_t ptxfemplvl :
+    1;
+uint32_t Reserved9_31 :
+    23;
+  }
+  b;
+} USB_OTG_GAHBCFG_TypeDef ;
+typedef union _USB_OTG_GUSBCFG_TypeDef 
+{
+  uint32_t d32;
+  struct
+  {
+uint32_t toutcal :
+    3;
+uint32_t Reserved3_5 :
+    3;
+uint32_t physel :
+    1;
+uint32_t Reserved7 :
+    1;
+uint32_t srpcap :
+    1;
+uint32_t hnpcap :
+    1;
+uint32_t usbtrdtim :
+    4;
+uint32_t Reserved14 :
+    1;
+uint32_t phylpwrclksel :
+    1;
+uint32_t Reserved16 :
+    1;
+uint32_t ulpi_fsls :
+    1;
+uint32_t ulpi_auto_res :
+    1;
+uint32_t ulpi_clk_sus_m :
+    1;
+uint32_t ulpi_ext_vbus_drv :
+    1;
+uint32_t ulpi_int_vbus_ind :
+    1;
+uint32_t term_sel_dl_pulse :
+    1;
+uint32_t ulpi_ind_cpl :
+    1;
+uint32_t ulpi_passthrough :
+    1;       
+uint32_t ulpi_protect_disable :
+    1; 
+uint32_t Reserved26_28 :
+    3;     
+uint32_t force_host :
+    1;
+uint32_t force_dev :
+    1;
+uint32_t corrupt_tx :
+    1;
+  }
+  b;
+} USB_OTG_GUSBCFG_TypeDef ;
+typedef union _USB_OTG_GRSTCTL_TypeDef 
+{
+  uint32_t d32;
+  struct
+  {
+uint32_t csftrst :
+    1;
+uint32_t hsftrst :
+    1;
+uint32_t hstfrm :
+    1;
+uint32_t Reserved3 :
+    1;
+uint32_t rxfflsh :
+    1;
+uint32_t txfflsh :
+    1;
+uint32_t txfnum :
+    5;
+uint32_t Reserved11_29 :
+    19;
+uint32_t dmareq :
+    1;
+uint32_t ahbidle :
+    1;
+  }
+  b;
+} USB_OTG_GRSTCTL_TypeDef ;
+typedef union _USB_OTG_GINTMSK_TypeDef 
+{
+  uint32_t d32;
+  struct
+  {
+uint32_t Reserved0 :
+    1;
+uint32_t modemismatch :
+    1;
+uint32_t otgintr :
+    1;
+uint32_t sofintr :
+    1;
+uint32_t rxstsqlvl :
+    1;
+uint32_t nptxfempty :
+    1;
+uint32_t ginnakeff :
+    1;
+uint32_t goutnakeff :
+    1;
+uint32_t Reserved8_9 :
+    2;
+uint32_t erlysuspend :
+    1;
+uint32_t usbsuspend :
+    1;
+uint32_t usbreset :
+    1;
+uint32_t enumdone :
+    1;
+uint32_t isooutdrop :
+    1;
+uint32_t eopframe :
+    1;
+uint32_t Reserved16 :
+    1;
+uint32_t epmismatch :
+    1;
+uint32_t inepintr :
+    1;
+uint32_t outepintr :
+    1;
+uint32_t incomplisoin :
+    1;
+uint32_t incomplisoout :
+    1;
+uint32_t Reserved22_23 :
+    2;
+uint32_t portintr :
+    1;
+uint32_t hcintr :
+    1;
+uint32_t ptxfempty :
+    1;
+uint32_t Reserved27 :
+    1;
+uint32_t conidstschng :
+    1;
+uint32_t disconnect :
+    1;
+uint32_t sessreqintr :
+    1;
+uint32_t wkupintr :
+    1;
+  }
+  b;
+} USB_OTG_GINTMSK_TypeDef ;
+typedef union _USB_OTG_GINTSTS_TypeDef 
+{
+  uint32_t d32;
+  struct
+  {
+uint32_t curmode :
+    1;
+uint32_t modemismatch :
+    1;
+uint32_t otgintr :
+    1;
+uint32_t sofintr :
+    1;
+uint32_t rxstsqlvl :
+    1;
+uint32_t nptxfempty :
+    1;
+uint32_t ginnakeff :
+    1;
+uint32_t goutnakeff :
+    1;
+uint32_t Reserved8_9 :
+    2;
+uint32_t erlysuspend :
+    1;
+uint32_t usbsuspend :
+    1;
+uint32_t usbreset :
+    1;
+uint32_t enumdone :
+    1;
+uint32_t isooutdrop :
+    1;
+uint32_t eopframe :
+    1;
+uint32_t Reserved16_17 :
+    2;
+uint32_t inepint:
+    1;
+uint32_t outepintr :
+    1;
+uint32_t incomplisoin :
+    1;
+uint32_t incomplisoout :
+    1;
+uint32_t Reserved22_23 :
+    2;
+uint32_t portintr :
+    1;
+uint32_t hcintr :
+    1;
+uint32_t ptxfempty :
+    1;
+uint32_t Reserved27 :
+    1;
+uint32_t conidstschng :
+    1;
+uint32_t disconnect :
+    1;
+uint32_t sessreqintr :
+    1;
+uint32_t wkupintr :
+    1;
+  }
+  b;
+} USB_OTG_GINTSTS_TypeDef ;
+typedef union _USB_OTG_DRXSTS_TypeDef 
+{
+  uint32_t d32;
+  struct
+  {
+uint32_t epnum :
+    4;
+uint32_t bcnt :
+    11;
+uint32_t dpid :
+    2;
+uint32_t pktsts :
+    4;
+uint32_t fn :
+    4;
+uint32_t Reserved :
+    7;
+  }
+  b;
+} USB_OTG_DRXSTS_TypeDef ;
+typedef union _USB_OTG_GRXSTS_TypeDef 
+{
+  uint32_t d32;
+  struct
+  {
+uint32_t chnum :
+    4;
+uint32_t bcnt :
+    11;
+uint32_t dpid :
+    2;
+uint32_t pktsts :
+    4;
+uint32_t Reserved :
+    11;
+  }
+  b;
+} USB_OTG_GRXFSTS_TypeDef ;
+typedef union _USB_OTG_FSIZ_TypeDef 
+{
+  uint32_t d32;
+  struct
+  {
+uint32_t startaddr :
+    16;
+uint32_t depth :
+    16;
+  }
+  b;
+} USB_OTG_FSIZ_TypeDef ;
+typedef union _USB_OTG_HNPTXSTS_TypeDef 
+{
+  uint32_t d32;
+  struct
+  {
+    uint32_t nptxfspcavail :
+      16;
+    uint32_t nptxqspcavail :
+      8;
+      struct
+        {
+          uint32_t terminate :
+            1;
+          uint32_t token :
+            2;
+          uint32_t chnum :
+            4; 
+         } nptxqtop;
+     uint32_t Reserved :
+        1;
+  }
+  b;
+} USB_OTG_HNPTXSTS_TypeDef ;
+typedef union _USB_OTG_DTXFSTSn_TypeDef 
+{
+  uint32_t d32;
+  struct
+  {
+uint32_t txfspcavail :
+    16;
+uint32_t Reserved :
+    16;
+  }
+  b;
+} USB_OTG_DTXFSTSn_TypeDef ;
+
+typedef union _USB_OTG_GCCFG_TypeDef 
+{
+  uint32_t d32;
+  struct
+  {
+uint32_t Reserved_in :
+    16;
+uint32_t pwdn :
+    1;
+uint32_t Reserved_17 :
+    1;
+uint32_t vbussensingA :
+    1;
+uint32_t vbussensingB :
+    1;
+uint32_t sofouten :
+    1;
+uint32_t disablevbussensing :
+    1;
+uint32_t Reserved_out :
+    10;
+  }
+  b;
+} USB_OTG_GCCFG_TypeDef ;
+
+typedef union _USB_OTG_DCFG_TypeDef 
+{
+  uint32_t d32;
+  struct
+  {
+uint32_t devspd :
+    2;
+uint32_t nzstsouthshk :
+    1;
+uint32_t Reserved3 :
+    1;
+uint32_t devaddr :
+    7;
+uint32_t perfrint :
+    2;
+uint32_t Reserved12_31 :
+    19;
+  }
+  b;
+} USB_OTG_DCFG_TypeDef ;
+typedef union _USB_OTG_DCTL_TypeDef 
+{
+  uint32_t d32;
+  struct
+  {
+uint32_t rmtwkupsig :
+    1;
+uint32_t sftdiscon :
+    1;
+uint32_t gnpinnaksts :
+    1;
+uint32_t goutnaksts :
+    1;
+uint32_t tstctl :
+    3;
+uint32_t sgnpinnak :
+    1;
+uint32_t cgnpinnak :
+    1;
+uint32_t sgoutnak :
+    1;
+uint32_t cgoutnak :
+    1;
+uint32_t poprg_done :
+    1;    
+uint32_t Reserved :
+    20;
+  }
+  b;
+} USB_OTG_DCTL_TypeDef ;
+typedef union _USB_OTG_DSTS_TypeDef 
+{
+  uint32_t d32;
+  struct
+  {
+uint32_t suspsts :
+    1;
+uint32_t enumspd :
+    2;
+uint32_t errticerr :
+    1;
+uint32_t Reserved4_7:
+    4;
+uint32_t soffn :
+    14;
+uint32_t Reserved22_31 :
+    10;
+  }
+  b;
+} USB_OTG_DSTS_TypeDef ;
+typedef union _USB_OTG_DIEPINTn_TypeDef 
+{
+  uint32_t d32;
+  struct
+  {
+uint32_t xfercompl :
+    1;
+uint32_t epdisabled :
+    1;
+uint32_t Reserved2 :
+    1;
+uint32_t timeout :
+    1;
+uint32_t intktxfemp :
+    1;
+uint32_t Reserved5 :
+    1;
+uint32_t inepnakeff :
+    1;
+uint32_t emptyintr :
+    1;
+uint32_t txfifoundrn :
+    1;
+uint32_t Reserved14_31 :
+    23;
+  }
+  b;
+} USB_OTG_DIEPINTn_TypeDef ;
+typedef union _USB_OTG_DIEPINTn_TypeDef   USB_OTG_DIEPMSK_TypeDef ;
+typedef union _USB_OTG_DOEPINTn_TypeDef 
+{
+  uint32_t d32;
+  struct
+  {
+uint32_t xfercompl :
+    1;
+uint32_t epdisabled :
+    1;
+uint32_t Reserved2 :
+    1;
+uint32_t setup :
+    1;
+uint32_t Reserved04_31 :
+    28;
+  }
+  b;
+} USB_OTG_DOEPINTn_TypeDef ;
+typedef union _USB_OTG_DOEPINTn_TypeDef   USB_OTG_DOEPMSK_TypeDef ;
+
+typedef union _USB_OTG_DAINT_TypeDef 
+{
+  uint32_t d32;
+  struct
+  {
+uint32_t in :
+    16;
+uint32_t out :
+    16;
+  }
+  ep;
+} USB_OTG_DAINT_TypeDef ;
+
+typedef union _USB_OTG_DTHRCTL_TypeDef 
+{
+  uint32_t d32;
+  struct
+  {
+uint32_t non_iso_thr_en :
+    1;
+uint32_t iso_thr_en :
+    1;
+uint32_t tx_thr_len :
+    9;
+uint32_t Reserved11_15 :
+    5;
+uint32_t rx_thr_en :
+    1;
+uint32_t rx_thr_len :
+    9;
+uint32_t Reserved26 : 
+    1;
+uint32_t arp_en :  
+    1;
+uint32_t Reserved28_31 :
+    4;   
+  }
+  b;
+} USB_OTG_DTHRCTL_TypeDef ;
+typedef union _USB_OTG_DEPCTL_TypeDef 
+{
+  uint32_t d32;
+  struct
+  {
+uint32_t mps :
+    11;
+uint32_t reserved :
+    4;
+uint32_t usbactep :
+    1;
+uint32_t dpid :
+    1;
+uint32_t naksts :
+    1;
+uint32_t eptype :
+    2;
+uint32_t snp :
+    1;
+uint32_t stall :
+    1;
+uint32_t txfnum :
+    4;
+uint32_t cnak :
+    1;
+uint32_t snak :
+    1;
+uint32_t setd0pid :
+    1;
+uint32_t setd1pid :
+    1;
+uint32_t epdis :
+    1;
+uint32_t epena :
+    1;
+  }
+  b;
+} USB_OTG_DEPCTL_TypeDef ;
+typedef union _USB_OTG_DEPXFRSIZ_TypeDef 
+{
+  uint32_t d32;
+  struct
+  {
+uint32_t xfersize :
+    19;
+uint32_t pktcnt :
+    10;
+uint32_t mc :
+    2;
+uint32_t Reserved :
+    1;
+  }
+  b;
+} USB_OTG_DEPXFRSIZ_TypeDef ;
+typedef union _USB_OTG_DEP0XFRSIZ_TypeDef 
+{
+  uint32_t d32;
+  struct
+  {
+uint32_t xfersize :
+    7;
+uint32_t Reserved7_18 :
+    12;
+uint32_t pktcnt :
+    2;
+uint32_t Reserved20_28 :
+    9;
+uint32_t supcnt :
+    2;
+    uint32_t Reserved31;
+  }
+  b;
+} USB_OTG_DEP0XFRSIZ_TypeDef ;
+typedef union _USB_OTG_HCFG_TypeDef 
+{
+  uint32_t d32;
+  struct
+  {
+uint32_t fslspclksel :
+    2;
+uint32_t fslssupp :
+    1;
+  }
+  b;
+} USB_OTG_HCFG_TypeDef ;
+typedef union _USB_OTG_HFRMINTRVL_TypeDef 
+{
+  uint32_t d32;
+  struct
+  {
+uint32_t frint :
+    16;
+uint32_t Reserved :
+    16;
+  }
+  b;
+} USB_OTG_HFRMINTRVL_TypeDef ;
+
+typedef union _USB_OTG_HFNUM_TypeDef 
+{
+  uint32_t d32;
+  struct
+  {
+uint32_t frnum :
+    16;
+uint32_t frrem :
+    16;
+  }
+  b;
+} USB_OTG_HFNUM_TypeDef ;
+typedef union _USB_OTG_HPTXSTS_TypeDef 
+{
+  uint32_t d32;
+  struct
+  {
+uint32_t ptxfspcavail :
+    16;
+uint32_t ptxqspcavail :
+    8;
+      struct
+        {
+          uint32_t terminate :
+            1;
+          uint32_t token :
+            2;
+          uint32_t chnum :
+            4; 
+          uint32_t odd_even :
+            1;            
+         } ptxqtop;    
+  }
+  b;
+} USB_OTG_HPTXSTS_TypeDef ;
+typedef union _USB_OTG_HPRT0_TypeDef 
+{
+  uint32_t d32;
+  struct
+  {
+uint32_t prtconnsts :
+    1;
+uint32_t prtconndet :
+    1;
+uint32_t prtena :
+    1;
+uint32_t prtenchng :
+    1;
+uint32_t prtovrcurract :
+    1;
+uint32_t prtovrcurrchng :
+    1;
+uint32_t prtres :
+    1;
+uint32_t prtsusp :
+    1;
+uint32_t prtrst :
+    1;
+uint32_t Reserved9 :
+    1;
+uint32_t prtlnsts :
+    2;
+uint32_t prtpwr :
+    1;
+uint32_t prttstctl :
+    4;
+uint32_t prtspd :
+    2;
+uint32_t Reserved19_31 :
+    13;
+  }
+  b;
+} USB_OTG_HPRT0_TypeDef ;
+typedef union _USB_OTG_HAINT_TypeDef 
+{
+  uint32_t d32;
+  struct
+  {
+uint32_t chint :
+    16;
+uint32_t Reserved :
+    16;
+  }
+  b;
+} USB_OTG_HAINT_TypeDef ;
+typedef union _USB_OTG_HAINTMSK_TypeDef 
+{
+  uint32_t d32;
+  struct
+  {
+uint32_t chint :
+    16;
+uint32_t Reserved :
+    16;
+  }
+  b;
+} USB_OTG_HAINTMSK_TypeDef ;
+typedef union _USB_OTG_HCCHAR_TypeDef 
+{
+  uint32_t d32;
+  struct
+  {
+uint32_t mps :
+    11;
+uint32_t epnum :
+    4;
+uint32_t epdir :
+    1;
+uint32_t Reserved :
+    1;
+uint32_t lspddev :
+    1;
+uint32_t eptype :
+    2;
+uint32_t multicnt :
+    2;
+uint32_t devaddr :
+    7;
+uint32_t oddfrm :
+    1;
+uint32_t chdis :
+    1;
+uint32_t chen :
+    1;
+  }
+  b;
+} USB_OTG_HCCHAR_TypeDef ;
+typedef union _USB_OTG_HCSPLT_TypeDef 
+{
+  uint32_t d32;
+  struct
+  {
+uint32_t prtaddr :
+    7;
+uint32_t hubaddr :
+    7;
+uint32_t xactpos :
+    2;
+uint32_t compsplt :
+    1;
+uint32_t Reserved :
+    14;
+uint32_t spltena :
+    1;
+  }
+  b;
+} USB_OTG_HCSPLT_TypeDef ;
+typedef union _USB_OTG_HCINTn_TypeDef 
+{
+  uint32_t d32;
+  struct
+  {
+uint32_t xfercompl :
+    1;
+uint32_t chhltd :
+    1;
+uint32_t ahberr :
+    1;
+uint32_t stall :
+    1;
+uint32_t nak :
+    1;
+uint32_t ack :
+    1;
+uint32_t nyet :
+    1;
+uint32_t xacterr :
+    1;
+uint32_t bblerr :
+    1;
+uint32_t frmovrun :
+    1;
+uint32_t datatglerr :
+    1;
+uint32_t Reserved :
+    21;
+  }
+  b;
+} USB_OTG_HCINTn_TypeDef ;
+typedef union _USB_OTG_HCTSIZn_TypeDef 
+{
+  uint32_t d32;
+  struct
+  {
+uint32_t xfersize :
+    19;
+uint32_t pktcnt :
+    10;
+uint32_t pid :
+    2;
+uint32_t dopng :
+    1;
+  }
+  b;
+} USB_OTG_HCTSIZn_TypeDef ;
+typedef union _USB_OTG_HCINTMSK_TypeDef 
+{
+  uint32_t d32;
+  struct
+  {
+uint32_t xfercompl :
+    1;
+uint32_t chhltd :
+    1;
+uint32_t ahberr :
+    1;
+uint32_t stall :
+    1;
+uint32_t nak :
+    1;
+uint32_t ack :
+    1;
+uint32_t nyet :
+    1;
+uint32_t xacterr :
+    1;
+uint32_t bblerr :
+    1;
+uint32_t frmovrun :
+    1;
+uint32_t datatglerr :
+    1;
+uint32_t Reserved :
+    21;
+  }
+  b;
+} USB_OTG_HCINTMSK_TypeDef ;
+
+typedef union _USB_OTG_PCGCCTL_TypeDef 
+{
+  uint32_t d32;
+  struct
+  {
+uint32_t stoppclk :
+    1;
+uint32_t gatehclk :
+    1;
+uint32_t Reserved2_3 :
+    2;
+uint32_t phy_susp :
+    1;    
+uint32_t Reserved5_31 :
+    27;
+  }
+  b;
+} USB_OTG_PCGCCTL_TypeDef ;
+
+/**
+  * @}
+  */ 
+
+
+/** @defgroup USB_REGS_Exported_Macros
+  * @{
+  */ 
+/**
+  * @}
+  */ 
+
+/** @defgroup USB_REGS_Exported_Variables
+  * @{
+  */ 
+/**
+  * @}
+  */ 
+
+/** @defgroup USB_REGS_Exported_FunctionsPrototype
+  * @{
+  */ 
+/**
+  * @}
+  */ 
+
+
+#endif //__USB_OTG_REGS_H__
+
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
+

--- a/src/lib/usbh_conf.h
+++ b/src/lib/usbh_conf.h
@@ -1,0 +1,97 @@
+/**
+  ******************************************************************************
+  * @file    USBH_conf.h
+  * @author  MCD Application Team
+  * @version V2.1.0
+  * @date    19-March-2012
+  * @brief   General low level driver configuration
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT 2012 STMicroelectronics</center></h2>
+  *
+  * Licensed under MCD-ST Liberty SW License Agreement V2, (the "License");
+  * You may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at:
+  *
+  *        http://www.st.com/software_license_agreement_liberty_v2
+  *
+  * Unless required by applicable law or agreed to in writing, software 
+  * distributed under the License is distributed on an "AS IS" BASIS, 
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __USBH_CONF__H__
+#define __USBH_CONF__H__
+
+/* Includes ------------------------------------------------------------------*/
+
+/** @addtogroup USBH_OTG_DRIVER
+  * @{
+  */
+  
+/** @defgroup USBH_CONF
+  * @brief usb otg low level driver configuration file
+  * @{
+  */ 
+
+/** @defgroup USBH_CONF_Exported_Defines
+  * @{
+  */ 
+
+#define USBH_MAX_NUM_ENDPOINTS                2
+#define USBH_MAX_NUM_INTERFACES               2
+#define USBH_MSC_MPS_SIZE                 0x200
+
+/**
+  * @}
+  */ 
+
+
+/** @defgroup USBH_CONF_Exported_Types
+  * @{
+  */ 
+/**
+  * @}
+  */ 
+
+
+/** @defgroup USBH_CONF_Exported_Macros
+  * @{
+  */ 
+/**
+  * @}
+  */ 
+
+/** @defgroup USBH_CONF_Exported_Variables
+  * @{
+  */ 
+/**
+  * @}
+  */ 
+
+/** @defgroup USBH_CONF_Exported_FunctionsPrototype
+  * @{
+  */ 
+/**
+  * @}
+  */ 
+
+
+#endif //__USBH_CONF__H__
+
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
+

--- a/src/lib/usbh_core.c
+++ b/src/lib/usbh_core.c
@@ -1,0 +1,861 @@
+/**
+  ******************************************************************************
+  * @file    usbh_core.c 
+  * @author  MCD Application Team
+  * @version V2.1.0
+  * @date    19-March-2012
+  * @brief   This file implements the functions for the core state machine process
+  *          the enumeration and the control transfer process
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT 2012 STMicroelectronics</center></h2>
+  *
+  * Licensed under MCD-ST Liberty SW License Agreement V2, (the "License");
+  * You may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at:
+  *
+  *        http://www.st.com/software_license_agreement_liberty_v2
+  *
+  * Unless required by applicable law or agreed to in writing, software 
+  * distributed under the License is distributed on an "AS IS" BASIS, 
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  *
+  ******************************************************************************
+  */ 
+/* Includes ------------------------------------------------------------------*/
+
+#include "usbh_ioreq.h"
+#include "usb_bsp.h"
+#include "usbh_hcs.h"
+#include "usbh_stdreq.h"
+#include "usbh_core.h"
+#include "usb_hcd_int.h"
+
+
+/** @addtogroup USBH_LIB
+  * @{
+  */
+
+/** @addtogroup USBH_LIB_CORE
+* @{
+*/
+
+/** @defgroup USBH_CORE 
+  * @brief TThis file handles the basic enumaration when a device is connected 
+  *          to the host.
+  * @{
+  */ 
+
+/** @defgroup USBH_CORE_Private_TypesDefinitions
+  * @{
+  */ 
+uint8_t USBH_Disconnected (USB_OTG_CORE_HANDLE *pdev); 
+uint8_t USBH_Connected (USB_OTG_CORE_HANDLE *pdev); 
+uint8_t USBH_SOF (USB_OTG_CORE_HANDLE *pdev); 
+
+USBH_HCD_INT_cb_TypeDef USBH_HCD_INT_cb = 
+{
+  USBH_SOF,
+  USBH_Connected, 
+  USBH_Disconnected,    
+};
+
+USBH_HCD_INT_cb_TypeDef  *USBH_HCD_INT_fops = &USBH_HCD_INT_cb;
+
+
+HOST_State Tab_State_Machine[100];
+unsigned int Previous_status = 11;
+volatile unsigned int Tab_State_Machine_incr = 0;
+/**
+  * @}
+  */ 
+
+
+/** @defgroup USBH_CORE_Private_Defines
+  * @{
+  */ 
+/**
+  * @}
+  */ 
+
+
+/** @defgroup USBH_CORE_Private_Macros
+  * @{
+  */ 
+/**
+  * @}
+  */ 
+
+
+/** @defgroup USBH_CORE_Private_Variables
+  * @{
+  */ 
+/**
+  * @}
+  */ 
+
+
+/** @defgroup USBH_CORE_Private_FunctionPrototypes
+  * @{
+  */
+static USBH_Status USBH_HandleEnum(USB_OTG_CORE_HANDLE *pdev, USBH_HOST *phost);
+USBH_Status USBH_HandleControl (USB_OTG_CORE_HANDLE *pdev, USBH_HOST *phost);
+
+/**
+  * @}
+  */ 
+
+
+/** @defgroup USBH_CORE_Private_Functions
+  * @{
+  */ 
+
+
+/**
+  * @brief  USBH_Connected
+  *         USB Connect callback function from the Interrupt. 
+  * @param  selected device
+  * @retval Status
+*/
+uint8_t USBH_Connected (USB_OTG_CORE_HANDLE *pdev)
+{
+  pdev->host.ConnSts = 1;
+  return 0;
+}
+
+/**
+* @brief  USBH_Disconnected
+*         USB Disconnect callback function from the Interrupt. 
+* @param  selected device
+* @retval Status
+*/
+
+uint8_t USBH_Disconnected (USB_OTG_CORE_HANDLE *pdev)
+{
+  pdev->host.ConnSts = 0;
+  return 0;  
+}
+
+/**
+  * @brief  USBH_SOF
+  *         USB SOF callback function from the Interrupt. 
+  * @param  selected device
+  * @retval Status
+  */
+
+uint8_t USBH_SOF (USB_OTG_CORE_HANDLE *pdev)
+{
+  /* This callback could be used to implement a scheduler process */
+  return 0;  
+}
+/**
+  * @brief  USBH_Init
+  *         Host hardware and stack initializations 
+  * @param  class_cb: Class callback structure address
+  * @param  usr_cb: User callback structure address
+  * @retval None
+  */
+void USBH_Init(USB_OTG_CORE_HANDLE *pdev,
+               USB_OTG_CORE_ID_TypeDef coreID,
+               USBH_HOST *phost,               
+               USBH_Class_cb_TypeDef *class_cb, 
+               USBH_Usr_cb_TypeDef *usr_cb)
+{
+     
+  /* Hardware Init */
+  USB_OTG_BSP_Init(pdev);  
+  
+  /* configure GPIO pin used for switching VBUS power */
+  USB_OTG_BSP_ConfigVBUS(0);  
+  
+  
+  /* Host de-initializations */
+  USBH_DeInit(pdev, phost);
+  
+  /*Register class and user callbacks */
+  phost->class_cb = class_cb;
+  phost->usr_cb = usr_cb;  
+    
+  /* Start the USB OTG core */     
+   HCD_Init(pdev , coreID);
+   
+  /* Upon Init call usr call back */
+  phost->usr_cb->Init();
+  
+  /* Enable Interrupts */
+  USB_OTG_BSP_EnableInterrupt(pdev);
+}
+
+/**
+  * @brief  USBH_DeInit 
+  *         Re-Initialize Host
+  * @param  None 
+  * @retval status: USBH_Status
+  */
+USBH_Status USBH_DeInit(USB_OTG_CORE_HANDLE *pdev, USBH_HOST *phost)
+{
+  /* Software Init */
+  
+  phost->gState = HOST_IDLE;
+  phost->gStateBkp = HOST_IDLE; 
+  phost->EnumState = ENUM_IDLE;
+  phost->RequestState = CMD_SEND;  
+  
+  phost->Control.state = CTRL_SETUP;
+  phost->Control.ep0size = USB_OTG_MAX_EP0_SIZE;  
+  
+  phost->device_prop.address = USBH_DEVICE_ADDRESS_DEFAULT;
+  phost->device_prop.speed = HPRT0_PRTSPD_FULL_SPEED;
+  
+  USBH_Free_Channel  (pdev, phost->Control.hc_num_in);
+  USBH_Free_Channel  (pdev, phost->Control.hc_num_out);  
+  return USBH_OK;
+}
+
+/**
+* @brief  USBH_Process
+*         USB Host core main state machine process
+* @param  None 
+* @retval None
+*/
+void USBH_Process(USB_OTG_CORE_HANDLE *pdev , USBH_HOST *phost)
+{
+  volatile USBH_Status status = USBH_FAIL;
+  
+  
+  /* check for Host port events */
+  if ((HCD_IsDeviceConnected(pdev) == 0)&& (phost->gState != HOST_IDLE)) 
+  {
+    if(phost->gState != HOST_DEV_DISCONNECTED) 
+    {
+      phost->gState = HOST_DEV_DISCONNECTED;
+    }
+  }
+
+  switch (phost->gState)
+  {
+  
+  case HOST_IDLE :
+
+    if (HCD_IsDeviceConnected(pdev))  
+    {
+      phost->gState = HOST_DEV_ATTACHED;
+      USB_OTG_BSP_mDelay(100);
+    }
+    break;
+   
+  case HOST_DEV_ATTACHED :
+    
+    phost->usr_cb->DeviceAttached();
+    phost->Control.hc_num_out = USBH_Alloc_Channel(pdev, 0x00);
+    phost->Control.hc_num_in = USBH_Alloc_Channel(pdev, 0x80);  
+  
+    /* Reset USB Device */
+    if ( HCD_ResetPort(pdev) == 0)
+    {
+      phost->usr_cb->ResetDevice();
+      /*  Wait for USB USBH_ISR_PrtEnDisableChange()  
+      Host is Now ready to start the Enumeration 
+      */
+      
+      phost->device_prop.speed = HCD_GetCurrentSpeed(pdev);
+      
+      phost->gState = HOST_ENUMERATION;
+      phost->usr_cb->DeviceSpeedDetected(phost->device_prop.speed);
+        
+      /* Open Control pipes */
+      USBH_Open_Channel (pdev,
+                           phost->Control.hc_num_in,
+                           phost->device_prop.address,
+                           phost->device_prop.speed,
+                           EP_TYPE_CTRL,
+                           phost->Control.ep0size); 
+      
+      /* Open Control pipes */
+      USBH_Open_Channel (pdev,
+                           phost->Control.hc_num_out,
+                           phost->device_prop.address,
+                           phost->device_prop.speed,
+                           EP_TYPE_CTRL,
+                           phost->Control.ep0size);          
+   }
+    break;
+    
+  case HOST_ENUMERATION:     
+    /* Check for enumeration status */  
+    if ( USBH_HandleEnum(pdev , phost) == USBH_OK)
+    { 
+      /* The function shall return USBH_OK when full enumeration is complete */
+      
+      /* user callback for end of device basic enumeration */
+      phost->usr_cb->EnumerationDone();
+      
+      phost->gState  = HOST_USR_INPUT;    
+    }
+    break;
+    
+  case HOST_USR_INPUT:    
+    /*The function should return user response true to move to class state */
+    if ( phost->usr_cb->UserInput() == USBH_USR_RESP_OK)
+    {
+      if((phost->class_cb->Init(pdev, phost))\
+        == USBH_OK)
+      {
+        phost->gState  = HOST_CLASS_REQUEST;     
+      }     
+    }   
+    break;
+    
+  case HOST_CLASS_REQUEST:  
+    /* process class standard contol requests state machine */ 
+    status = phost->class_cb->Requests(pdev, phost);
+    
+     if(status == USBH_OK)
+     {
+       phost->gState  = HOST_CLASS;
+     }  
+     
+     else
+     {
+       USBH_ErrorHandle(phost, status);
+     }
+ 
+    
+    break;    
+  case HOST_CLASS:   
+    /* process class state machine */
+    status = phost->class_cb->Machine(pdev, phost);
+    USBH_ErrorHandle(phost, status);
+    break;       
+    
+  case HOST_CTRL_XFER:
+    /* process control transfer state machine */
+    USBH_HandleControl(pdev, phost);    
+    break;
+    
+  case HOST_SUSPENDED:
+    break;
+  
+  case HOST_ERROR_STATE:
+    /* Re-Initilaize Host for new Enumeration */
+    USBH_DeInit(pdev, phost);
+    phost->usr_cb->DeInit();
+    phost->class_cb->DeInit(pdev, &phost->device_prop);
+    break;
+    
+  case HOST_DEV_DISCONNECTED :
+    /* Manage User disconnect operations*/
+    phost->usr_cb->DeviceDisconnected();
+    
+    /* Re-Initilaize Host for new Enumeration */
+    USBH_DeInit(pdev, phost);
+    phost->usr_cb->DeInit();
+    phost->class_cb->DeInit(pdev, &phost->device_prop); 
+    USBH_DeAllocate_AllChannel(pdev);  
+    phost->gState = HOST_IDLE;
+    
+    break;
+    
+  default :
+    break;
+  }
+
+}
+
+
+/**
+  * @brief  USBH_ErrorHandle 
+  *         This function handles the Error on Host side.
+  * @param  errType : Type of Error or Busy/OK state
+  * @retval None
+  */
+void USBH_ErrorHandle(USBH_HOST *phost, USBH_Status errType)
+{
+  /* Error unrecovered or not supported device speed */
+  if ( (errType == USBH_ERROR_SPEED_UNKNOWN) ||
+       (errType == USBH_UNRECOVERED_ERROR) )
+  {
+    phost->usr_cb->UnrecoveredError(); 
+    phost->gState = HOST_ERROR_STATE;   
+  }  
+  /* USB host restart requested from application layer */
+  else if(errType == USBH_APPLY_DEINIT)
+  {
+    phost->gState = HOST_ERROR_STATE;  
+    /* user callback for initalization */
+    phost->usr_cb->Init();
+  } 
+}
+
+
+/**
+  * @brief  USBH_HandleEnum 
+  *         This function includes the complete enumeration process
+  * @param  pdev: Selected device
+  * @retval USBH_Status
+  */
+static USBH_Status USBH_HandleEnum(USB_OTG_CORE_HANDLE *pdev, USBH_HOST *phost)
+{
+  USBH_Status Status = USBH_BUSY;  
+  uint8_t Local_Buffer[64];
+  
+  switch (phost->EnumState)
+  {
+  case ENUM_IDLE:  
+    /* Get Device Desc for only 1st 8 bytes : To get EP0 MaxPacketSize */
+    if ( USBH_Get_DevDesc(pdev , phost, 8) == USBH_OK)
+    {
+      phost->Control.ep0size = phost->device_prop.Dev_Desc.bMaxPacketSize;
+      
+      /* Issue Reset  */
+      HCD_ResetPort(pdev);
+      phost->EnumState = ENUM_GET_FULL_DEV_DESC;
+      
+      /* modify control channels configuration for MaxPacket size */
+      USBH_Modify_Channel (pdev,
+                           phost->Control.hc_num_out,
+                           0,
+                           0,
+                           0,
+                           phost->Control.ep0size);
+      
+      USBH_Modify_Channel (pdev,
+                           phost->Control.hc_num_in,
+                           0,
+                           0,
+                           0,
+                           phost->Control.ep0size);      
+    }
+    break;
+    
+  case ENUM_GET_FULL_DEV_DESC:  
+    /* Get FULL Device Desc  */
+    if ( USBH_Get_DevDesc(pdev, phost, USB_DEVICE_DESC_SIZE)\
+      == USBH_OK)
+    {
+      /* user callback for device descriptor available */
+      phost->usr_cb->DeviceDescAvailable(&phost->device_prop.Dev_Desc);      
+      phost->EnumState = ENUM_SET_ADDR;
+    }
+    break;
+   
+  case ENUM_SET_ADDR: 
+    /* set address */
+    if ( USBH_SetAddress(pdev, phost, USBH_DEVICE_ADDRESS) == USBH_OK)
+    {
+      USB_OTG_BSP_mDelay(2);
+      phost->device_prop.address = USBH_DEVICE_ADDRESS;
+      
+      /* user callback for device address assigned */
+      phost->usr_cb->DeviceAddressAssigned();
+      phost->EnumState = ENUM_GET_CFG_DESC;
+      
+      /* modify control channels to update device address */
+      USBH_Modify_Channel (pdev,
+                           phost->Control.hc_num_in,
+                           phost->device_prop.address,
+                           0,
+                           0,
+                           0);
+      
+      USBH_Modify_Channel (pdev,
+                           phost->Control.hc_num_out,
+                           phost->device_prop.address,
+                           0,
+                           0,
+                           0);         
+    }
+    break;
+    
+  case ENUM_GET_CFG_DESC:  
+    /* get standard configuration descriptor */
+    if ( USBH_Get_CfgDesc(pdev, 
+                          phost,
+                          USB_CONFIGURATION_DESC_SIZE) == USBH_OK)
+    {
+      phost->EnumState = ENUM_GET_FULL_CFG_DESC;
+    }
+    break;
+    
+  case ENUM_GET_FULL_CFG_DESC:  
+    /* get FULL config descriptor (config, interface, endpoints) */
+    if (USBH_Get_CfgDesc(pdev, 
+                         phost,
+                         phost->device_prop.Cfg_Desc.wTotalLength) == USBH_OK)
+    {
+      /* User callback for configuration descriptors available */
+      phost->usr_cb->ConfigurationDescAvailable(&phost->device_prop.Cfg_Desc,
+                                                      phost->device_prop.Itf_Desc,
+                                                      phost->device_prop.Ep_Desc[0]);
+      
+      phost->EnumState = ENUM_GET_MFC_STRING_DESC;
+    }
+    break;
+    
+  case ENUM_GET_MFC_STRING_DESC:  
+    if (phost->device_prop.Dev_Desc.iManufacturer != 0)
+    { /* Check that Manufacturer String is available */
+      
+      if ( USBH_Get_StringDesc(pdev,
+                               phost,
+                               phost->device_prop.Dev_Desc.iManufacturer, 
+                               Local_Buffer , 
+                               0xff) == USBH_OK)
+      {
+        /* User callback for Manufacturing string */
+        phost->usr_cb->ManufacturerString(Local_Buffer);
+        phost->EnumState = ENUM_GET_PRODUCT_STRING_DESC;
+      }
+    }
+    else
+    {
+      phost->usr_cb->ManufacturerString("N/A");      
+      phost->EnumState = ENUM_GET_PRODUCT_STRING_DESC;
+    }
+    break;
+    
+  case ENUM_GET_PRODUCT_STRING_DESC:   
+    if (phost->device_prop.Dev_Desc.iProduct != 0)
+    { /* Check that Product string is available */
+      if ( USBH_Get_StringDesc(pdev,
+                               phost,
+                               phost->device_prop.Dev_Desc.iProduct, 
+                               Local_Buffer, 
+                               0xff) == USBH_OK)
+      {
+        /* User callback for Product string */
+        phost->usr_cb->ProductString(Local_Buffer);
+        phost->EnumState = ENUM_GET_SERIALNUM_STRING_DESC;
+      }
+    }
+    else
+    {
+      phost->usr_cb->ProductString("N/A");
+      phost->EnumState = ENUM_GET_SERIALNUM_STRING_DESC;
+    } 
+    break;
+    
+  case ENUM_GET_SERIALNUM_STRING_DESC:   
+    if (phost->device_prop.Dev_Desc.iSerialNumber != 0)
+    { /* Check that Serial number string is available */    
+      if ( USBH_Get_StringDesc(pdev, 
+                               phost,
+                               phost->device_prop.Dev_Desc.iSerialNumber, 
+                               Local_Buffer, 
+                               0xff) == USBH_OK)
+      {
+        /* User callback for Serial number string */
+        phost->usr_cb->SerialNumString(Local_Buffer);
+        phost->EnumState = ENUM_SET_CONFIGURATION;
+      }
+    }
+    else
+    {
+      phost->usr_cb->SerialNumString("N/A");      
+      phost->EnumState = ENUM_SET_CONFIGURATION;
+    }  
+    break;
+      
+  case ENUM_SET_CONFIGURATION:
+    /* set configuration  (default config) */
+    if (USBH_SetCfg(pdev, 
+                    phost,
+                    phost->device_prop.Cfg_Desc.bConfigurationValue) == USBH_OK)
+    {
+      phost->EnumState = ENUM_DEV_CONFIGURED;
+    }
+    break;
+
+    
+  case ENUM_DEV_CONFIGURED:
+    /* user callback for enumeration done */
+    Status = USBH_OK;
+    break;
+    
+  default:
+    break;
+  }  
+  return Status;
+}
+
+
+/**
+  * @brief  USBH_HandleControl
+  *         Handles the USB control transfer state machine
+  * @param  pdev: Selected device
+  * @retval Status
+  */
+USBH_Status USBH_HandleControl (USB_OTG_CORE_HANDLE *pdev, USBH_HOST *phost)
+{
+  uint8_t direction;  
+  static uint16_t timeout = 0;
+  USBH_Status status = USBH_OK;
+  URB_STATE URB_Status = URB_IDLE;
+  
+  phost->Control.status = CTRL_START;
+
+  
+  switch (phost->Control.state)
+  {
+  case CTRL_SETUP:
+    /* send a SETUP packet */
+    USBH_CtlSendSetup     (pdev, 
+	                   phost->Control.setup.d8 , 
+	                   phost->Control.hc_num_out);  
+    phost->Control.state = CTRL_SETUP_WAIT;  
+    break; 
+    
+  case CTRL_SETUP_WAIT:
+    
+    URB_Status = HCD_GetURB_State(pdev , phost->Control.hc_num_out); 
+    /* case SETUP packet sent successfully */
+    if(URB_Status == URB_DONE)
+    { 
+      direction = (phost->Control.setup.b.bmRequestType & USB_REQ_DIR_MASK);
+      
+      /* check if there is a data stage */
+      if (phost->Control.setup.b.wLength.w != 0 )
+      {        
+        timeout = DATA_STAGE_TIMEOUT;
+        if (direction == USB_D2H)
+        {
+          /* Data Direction is IN */
+          phost->Control.state = CTRL_DATA_IN;
+        }
+        else
+        {
+          /* Data Direction is OUT */
+          phost->Control.state = CTRL_DATA_OUT;
+        } 
+      }
+      /* No DATA stage */
+      else
+      {
+        timeout = NODATA_STAGE_TIMEOUT;
+        
+        /* If there is No Data Transfer Stage */
+        if (direction == USB_D2H)
+        {
+          /* Data Direction is IN */
+          phost->Control.state = CTRL_STATUS_OUT;
+        }
+        else
+        {
+          /* Data Direction is OUT */
+          phost->Control.state = CTRL_STATUS_IN;
+        } 
+      }          
+      /* Set the delay timer to enable timeout for data stage completion */
+      phost->Control.timer = HCD_GetCurrentFrame(pdev);
+    }
+    else if(URB_Status == URB_ERROR)
+    {
+      phost->Control.state = CTRL_ERROR;     
+      phost->Control.status = CTRL_XACTERR;
+    }    
+    break;
+    
+  case CTRL_DATA_IN:  
+    /* Issue an IN token */ 
+    USBH_CtlReceiveData(pdev,
+                        phost->Control.buff, 
+                        phost->Control.length,
+                        phost->Control.hc_num_in);
+ 
+    phost->Control.state = CTRL_DATA_IN_WAIT;
+    break;    
+    
+  case CTRL_DATA_IN_WAIT:
+    
+    URB_Status = HCD_GetURB_State(pdev , phost->Control.hc_num_in); 
+    
+    /* check is DATA packet transfered successfully */
+    if  (URB_Status == URB_DONE)
+    { 
+      phost->Control.state = CTRL_STATUS_OUT;
+    }
+   
+    /* manage error cases*/
+    if  (URB_Status == URB_STALL) 
+    { 
+      /* In stall case, return to previous machine state*/
+      phost->gState =   phost->gStateBkp;
+    }   
+    else if (URB_Status == URB_ERROR)
+    {
+      /* Device error */
+      phost->Control.state = CTRL_ERROR;    
+    }
+    else if ((HCD_GetCurrentFrame(pdev)- phost->Control.timer) > timeout)
+    {
+      /* timeout for IN transfer */
+      phost->Control.state = CTRL_ERROR; 
+    }   
+    break;
+    
+  case CTRL_DATA_OUT:
+    /* Start DATA out transfer (only one DATA packet)*/
+    pdev->host.hc[phost->Control.hc_num_out].toggle_out = 1; 
+        
+    USBH_CtlSendData (pdev,
+                      phost->Control.buff, 
+                      phost->Control.length , 
+                      phost->Control.hc_num_out);
+    
+
+
+
+    
+    phost->Control.state = CTRL_DATA_OUT_WAIT;
+    break;
+    
+  case CTRL_DATA_OUT_WAIT:
+    
+    URB_Status = HCD_GetURB_State(pdev , phost->Control.hc_num_out);     
+    if  (URB_Status == URB_DONE)
+    { /* If the Setup Pkt is sent successful, then change the state */
+      phost->Control.state = CTRL_STATUS_IN;
+    }
+    
+    /* handle error cases */
+    else if  (URB_Status == URB_STALL) 
+    { 
+      /* In stall case, return to previous machine state*/
+      phost->gState =   phost->gStateBkp;
+      phost->Control.state = CTRL_STALLED;  
+    } 
+    else if  (URB_Status == URB_NOTREADY)
+    { 
+      /* Nack received from device */
+      phost->Control.state = CTRL_DATA_OUT;
+    }    
+    else if (URB_Status == URB_ERROR)
+    {
+      /* device error */
+      phost->Control.state = CTRL_ERROR;      
+    } 
+    break;
+    
+    
+  case CTRL_STATUS_IN:
+    /* Send 0 bytes out packet */
+    USBH_CtlReceiveData (pdev,
+                         0,
+                         0,
+                         phost->Control.hc_num_in);
+    
+    phost->Control.state = CTRL_STATUS_IN_WAIT;
+    
+    break;
+    
+  case CTRL_STATUS_IN_WAIT:
+    
+    URB_Status = HCD_GetURB_State(pdev , phost->Control.hc_num_in); 
+    
+    if  ( URB_Status == URB_DONE)
+    { /* Control transfers completed, Exit the State Machine */
+      phost->gState =   phost->gStateBkp;
+      phost->Control.state = CTRL_COMPLETE;
+    }
+    
+    else if (URB_Status == URB_ERROR)
+    {
+      phost->Control.state = CTRL_ERROR;  
+    }
+    
+    else if((HCD_GetCurrentFrame(pdev)\
+      - phost->Control.timer) > timeout)
+    {
+      phost->Control.state = CTRL_ERROR; 
+    }
+     else if(URB_Status == URB_STALL)
+    {
+      /* Control transfers completed, Exit the State Machine */
+      phost->gState =   phost->gStateBkp;
+      phost->Control.status = CTRL_STALL;
+      status = USBH_NOT_SUPPORTED;
+    }
+    break;
+    
+  case CTRL_STATUS_OUT:
+    pdev->host.hc[phost->Control.hc_num_out].toggle_out ^= 1; 
+    USBH_CtlSendData (pdev,
+                      0,
+                      0,
+                      phost->Control.hc_num_out);
+    
+    phost->Control.state = CTRL_STATUS_OUT_WAIT;
+    break;
+    
+  case CTRL_STATUS_OUT_WAIT: 
+    
+    URB_Status = HCD_GetURB_State(pdev , phost->Control.hc_num_out);  
+    if  (URB_Status == URB_DONE)
+    { 
+      phost->gState =   phost->gStateBkp; 
+      phost->Control.state = CTRL_COMPLETE; 
+    }
+    else if  (URB_Status == URB_NOTREADY)
+    { 
+      phost->Control.state = CTRL_STATUS_OUT;
+    }      
+    else if (URB_Status == URB_ERROR)
+    {
+      phost->Control.state = CTRL_ERROR;      
+    }
+    break;
+    
+  case CTRL_ERROR:
+    /* 
+    After a halt condition is encountered or an error is detected by the 
+    host, a control endpoint is allowed to recover by accepting the next Setup 
+    PID; i.e., recovery actions via some other pipe are not required for control
+    endpoints. For the Default Control Pipe, a device reset will ultimately be 
+    required to clear the halt or error condition if the next Setup PID is not 
+    accepted.
+    */
+    if (++ phost->Control.errorcount <= USBH_MAX_ERROR_COUNT)
+    {
+      /* Do the transmission again, starting from SETUP Packet */
+      phost->Control.state = CTRL_SETUP; 
+    }
+    else
+    {
+      phost->Control.status = CTRL_FAIL;
+      phost->gState =   phost->gStateBkp;
+      
+      status = USBH_FAIL;
+    }
+    break;
+    
+  default:
+    break;
+  }
+  return status;
+}
+
+
+/**
+* @}
+*/ 
+
+/**
+* @}
+*/ 
+
+/**
+* @}
+*/
+
+/**
+* @}
+*/ 
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
+
+
+
+

--- a/src/lib/usbh_core.h
+++ b/src/lib/usbh_core.h
@@ -1,0 +1,295 @@
+/**
+  ******************************************************************************
+  * @file    usbh_core.h
+  * @author  MCD Application Team
+  * @version V2.1.0
+  * @date    19-March-2012
+  * @brief   Header file for usbh_core.c
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT 2012 STMicroelectronics</center></h2>
+  *
+  * Licensed under MCD-ST Liberty SW License Agreement V2, (the "License");
+  * You may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at:
+  *
+  *        http://www.st.com/software_license_agreement_liberty_v2
+  *
+  * Unless required by applicable law or agreed to in writing, software 
+  * distributed under the License is distributed on an "AS IS" BASIS, 
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  *
+  ******************************************************************************
+  */ 
+
+/* Define to prevent recursive  ----------------------------------------------*/
+#ifndef __USBH_CORE_H
+#define __USBH_CORE_H
+
+/* Includes ------------------------------------------------------------------*/
+#include "usb_hcd.h"
+#include "usbh_def.h"
+#include "usbh_conf.h"
+
+/** @addtogroup USBH_LIB
+  * @{
+  */
+
+/** @addtogroup USBH_LIB_CORE
+* @{
+*/
+  
+/** @defgroup USBH_CORE
+  * @brief This file is the Header file for usbh_core.c
+  * @{
+  */ 
+
+
+/** @defgroup USBH_CORE_Exported_Defines
+  * @{
+  */ 
+
+#define MSC_CLASS                         0x08
+#define HID_CLASS                         0x03
+#define MSC_PROTOCOL                      0x50
+#define CBI_PROTOCOL                      0x01
+
+
+#define USBH_MAX_ERROR_COUNT                            2
+#define USBH_DEVICE_ADDRESS_DEFAULT                     0
+#define USBH_DEVICE_ADDRESS                             1
+
+
+/**
+  * @}
+  */ 
+
+
+/** @defgroup USBH_CORE_Exported_Types
+  * @{
+  */
+
+typedef enum {
+  USBH_OK   = 0,
+  USBH_BUSY,
+  USBH_FAIL,
+  USBH_NOT_SUPPORTED,
+  USBH_UNRECOVERED_ERROR,
+  USBH_ERROR_SPEED_UNKNOWN,
+  USBH_APPLY_DEINIT
+}USBH_Status;
+
+/* Following states are used for gState */
+typedef enum {
+  HOST_IDLE =0,
+  HOST_DEV_ATTACHED,
+  HOST_DEV_DISCONNECTED,  
+  HOST_DETECT_DEVICE_SPEED,
+  HOST_ENUMERATION,
+  HOST_CLASS_REQUEST,  
+  HOST_CLASS,
+  HOST_CTRL_XFER,
+  HOST_USR_INPUT,
+  HOST_SUSPENDED,
+  HOST_ERROR_STATE  
+}HOST_State;  
+
+/* Following states are used for EnumerationState */
+typedef enum {
+  ENUM_IDLE = 0,
+  ENUM_GET_FULL_DEV_DESC,
+  ENUM_SET_ADDR,
+  ENUM_GET_CFG_DESC,
+  ENUM_GET_FULL_CFG_DESC,
+  ENUM_GET_MFC_STRING_DESC,
+  ENUM_GET_PRODUCT_STRING_DESC,
+  ENUM_GET_SERIALNUM_STRING_DESC,
+  ENUM_SET_CONFIGURATION,
+  ENUM_DEV_CONFIGURED
+} ENUM_State;  
+
+
+
+/* Following states are used for CtrlXferStateMachine */
+typedef enum {
+  CTRL_IDLE =0,
+  CTRL_SETUP,
+  CTRL_SETUP_WAIT,
+  CTRL_DATA_IN,
+  CTRL_DATA_IN_WAIT,
+  CTRL_DATA_OUT,
+  CTRL_DATA_OUT_WAIT,
+  CTRL_STATUS_IN,
+  CTRL_STATUS_IN_WAIT,
+  CTRL_STATUS_OUT,
+  CTRL_STATUS_OUT_WAIT,
+  CTRL_ERROR,
+  CTRL_STALLED,
+  CTRL_COMPLETE    
+}
+CTRL_State;  
+
+typedef enum {
+  USBH_USR_NO_RESP   = 0,
+  USBH_USR_RESP_OK = 1,
+}
+USBH_USR_Status;
+
+/* Following states are used for RequestState */
+typedef enum {
+  CMD_IDLE =0,
+  CMD_SEND,
+  CMD_WAIT
+} CMD_State;  
+
+
+
+typedef struct _Ctrl
+{
+  uint8_t               hc_num_in; 
+  uint8_t               hc_num_out; 
+  uint8_t               ep0size;  
+  uint8_t               *buff;
+  uint16_t              length;
+  uint8_t               errorcount;
+  uint16_t              timer;  
+  CTRL_STATUS           status;
+  USB_Setup_TypeDef     setup;
+  CTRL_State            state;  
+
+} USBH_Ctrl_TypeDef;
+
+
+
+typedef struct _DeviceProp
+{
+  
+  uint8_t                           address;
+  uint8_t                           speed;
+  USBH_DevDesc_TypeDef              Dev_Desc;
+  USBH_CfgDesc_TypeDef              Cfg_Desc;  
+  USBH_InterfaceDesc_TypeDef        Itf_Desc[USBH_MAX_NUM_INTERFACES];
+  USBH_EpDesc_TypeDef               Ep_Desc[USBH_MAX_NUM_INTERFACES][USBH_MAX_NUM_ENDPOINTS];
+  USBH_HIDDesc_TypeDef              HID_Desc;
+  
+}USBH_Device_TypeDef;
+
+typedef struct _USBH_Class_cb
+{
+  USBH_Status  (*Init)\
+    (USB_OTG_CORE_HANDLE *pdev , void *phost);
+  void         (*DeInit)\
+    (USB_OTG_CORE_HANDLE *pdev , void *phost);
+  USBH_Status  (*Requests)\
+    (USB_OTG_CORE_HANDLE *pdev , void *phost);  
+  USBH_Status  (*Machine)\
+    (USB_OTG_CORE_HANDLE *pdev , void *phost);     
+  
+} USBH_Class_cb_TypeDef;
+
+
+typedef struct _USBH_USR_PROP
+{
+  void (*Init)(void);       /* HostLibInitialized */
+  void (*DeInit)(void);       /* HostLibInitialized */  
+  void (*DeviceAttached)(void);           /* DeviceAttached */
+  void (*ResetDevice)(void);
+  void (*DeviceDisconnected)(void); 
+  void (*OverCurrentDetected)(void);  
+  void (*DeviceSpeedDetected)(uint8_t DeviceSpeed);          /* DeviceSpeed */
+  void (*DeviceDescAvailable)(void *);    /* DeviceDescriptor is available */
+  void (*DeviceAddressAssigned)(void);  /* Address is assigned to USB Device */
+  void (*ConfigurationDescAvailable)(USBH_CfgDesc_TypeDef *,
+                                     USBH_InterfaceDesc_TypeDef *,
+                                     USBH_EpDesc_TypeDef *); 
+  /* Configuration Descriptor available */
+  void (*ManufacturerString)(void *);     /* ManufacturerString*/
+  void (*ProductString)(void *);          /* ProductString*/
+  void (*SerialNumString)(void *);        /* SerialNubString*/
+  void (*EnumerationDone)(void);           /* Enumeration finished */
+  USBH_USR_Status (*UserInput)(void);
+  int  (*UserApplication) (void);
+  void (*DeviceNotSupported)(void); /* Device is not supported*/
+  void (*UnrecoveredError)(void);
+
+}
+USBH_Usr_cb_TypeDef;
+
+typedef struct _Host_TypeDef
+{
+  HOST_State            gState;       /*  Host State Machine Value */
+  HOST_State            gStateBkp;    /* backup of previous State machine value */
+  ENUM_State            EnumState;    /* Enumeration state Machine */
+  CMD_State             RequestState;       
+  USBH_Ctrl_TypeDef     Control;
+  
+  USBH_Device_TypeDef   device_prop; 
+  
+  USBH_Class_cb_TypeDef               *class_cb;  
+  USBH_Usr_cb_TypeDef  	              *usr_cb;
+
+  
+} USBH_HOST, *pUSBH_HOST;
+
+/**
+  * @}
+  */ 
+
+
+
+/** @defgroup USBH_CORE_Exported_Macros
+  * @{
+  */ 
+
+/**
+  * @}
+  */ 
+
+/** @defgroup USBH_CORE_Exported_Variables
+  * @{
+  */ 
+
+/**
+  * @}
+  */ 
+
+/** @defgroup USBH_CORE_Exported_FunctionsPrototype
+  * @{
+  */ 
+void USBH_Init(USB_OTG_CORE_HANDLE *pdev,
+               USB_OTG_CORE_ID_TypeDef coreID, 
+               USBH_HOST *phost,                    
+               USBH_Class_cb_TypeDef *class_cb, 
+               USBH_Usr_cb_TypeDef *usr_cb);
+               
+USBH_Status USBH_DeInit(USB_OTG_CORE_HANDLE *pdev, 
+                        USBH_HOST *phost);
+void USBH_Process(USB_OTG_CORE_HANDLE *pdev , 
+                  USBH_HOST *phost);
+void USBH_ErrorHandle(USBH_HOST *phost, 
+                      USBH_Status errType);
+
+/**
+  * @}
+  */ 
+
+#endif /* __USBH_CORE_H */
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+
+/**
+* @}
+*/ 
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
+
+
+

--- a/src/lib/usbh_def.h
+++ b/src/lib/usbh_def.h
@@ -1,0 +1,288 @@
+/**
+  ******************************************************************************
+  * @file    usbh_def.h
+  * @author  MCD Application Team
+  * @version V2.1.0
+  * @date    19-March-2012
+  * @brief   Definitions used in the USB host library
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT 2012 STMicroelectronics</center></h2>
+  *
+  * Licensed under MCD-ST Liberty SW License Agreement V2, (the "License");
+  * You may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at:
+  *
+  *        http://www.st.com/software_license_agreement_liberty_v2
+  *
+  * Unless required by applicable law or agreed to in writing, software 
+  * distributed under the License is distributed on an "AS IS" BASIS, 
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  *
+  ******************************************************************************
+  */ 
+
+/** @addtogroup USBH_LIB
+  * @{
+  */
+
+/** @addtogroup USBH_LIB_CORE
+* @{
+*/
+  
+/** @defgroup USBH_DEF
+  * @brief This file is includes USB descriptors
+  * @{
+  */ 
+
+#ifndef  USBH_DEF_H
+#define  USBH_DEF_H
+
+#ifndef USBH_NULL
+#define USBH_NULL ((void *)0)
+#endif
+
+#ifndef FALSE
+#define FALSE 0
+#endif
+
+#ifndef TRUE
+#define TRUE 1
+#endif
+
+
+#define ValBit(VAR,POS)                               (VAR & (1 << POS))
+#define SetBit(VAR,POS)                               (VAR |= (1 << POS))
+#define ClrBit(VAR,POS)                               (VAR &= ((1 << POS)^255))
+
+#define  LE16(addr)             (((u16)(*((u8 *)(addr))))\
+                                + (((u16)(*(((u8 *)(addr)) + 1))) << 8))
+
+#define  USB_LEN_DESC_HDR                               0x02
+#define  USB_LEN_DEV_DESC                               0x12
+#define  USB_LEN_CFG_DESC                               0x09
+#define  USB_LEN_IF_DESC                                0x09
+#define  USB_LEN_EP_DESC                                0x07
+#define  USB_LEN_OTG_DESC                               0x03
+#define  USB_LEN_SETUP_PKT                              0x08
+
+/* bmRequestType :D7 Data Phase Transfer Direction  */
+#define  USB_REQ_DIR_MASK                               0x80
+#define  USB_H2D                                        0x00
+#define  USB_D2H                                        0x80
+
+/* bmRequestType D6..5 Type */
+#define  USB_REQ_TYPE_STANDARD                          0x00
+#define  USB_REQ_TYPE_CLASS                             0x20
+#define  USB_REQ_TYPE_VENDOR                            0x40
+#define  USB_REQ_TYPE_RESERVED                          0x60
+
+/* bmRequestType D4..0 Recipient */
+#define  USB_REQ_RECIPIENT_DEVICE                       0x00
+#define  USB_REQ_RECIPIENT_INTERFACE                    0x01
+#define  USB_REQ_RECIPIENT_ENDPOINT                     0x02
+#define  USB_REQ_RECIPIENT_OTHER                        0x03
+
+/* Table 9-4. Standard Request Codes  */
+/* bRequest , Value */
+#define  USB_REQ_GET_STATUS                             0x00
+#define  USB_REQ_CLEAR_FEATURE                          0x01
+#define  USB_REQ_SET_FEATURE                            0x03
+#define  USB_REQ_SET_ADDRESS                            0x05
+#define  USB_REQ_GET_DESCRIPTOR                         0x06
+#define  USB_REQ_SET_DESCRIPTOR                         0x07
+#define  USB_REQ_GET_CONFIGURATION                      0x08
+#define  USB_REQ_SET_CONFIGURATION                      0x09
+#define  USB_REQ_GET_INTERFACE                          0x0A
+#define  USB_REQ_SET_INTERFACE                          0x0B
+#define  USB_REQ_SYNCH_FRAME                            0x0C
+
+/* Table 9-5. Descriptor Types of USB Specifications */
+#define  USB_DESC_TYPE_DEVICE                              1
+#define  USB_DESC_TYPE_CONFIGURATION                       2
+#define  USB_DESC_TYPE_STRING                              3
+#define  USB_DESC_TYPE_INTERFACE                           4
+#define  USB_DESC_TYPE_ENDPOINT                            5
+#define  USB_DESC_TYPE_DEVICE_QUALIFIER                    6
+#define  USB_DESC_TYPE_OTHER_SPEED_CONFIGURATION           7
+#define  USB_DESC_TYPE_INTERFACE_POWER                     8
+#define  USB_DESC_TYPE_HID                                 0x21
+#define  USB_DESC_TYPE_HID_REPORT                          0x22
+
+
+#define USB_DEVICE_DESC_SIZE                               18
+#define USB_CONFIGURATION_DESC_SIZE                        9
+#define USB_HID_DESC_SIZE                                  9
+#define USB_INTERFACE_DESC_SIZE                            9
+#define USB_ENDPOINT_DESC_SIZE                             7
+
+/* Descriptor Type and Descriptor Index  */
+/* Use the following values when calling the function USBH_GetDescriptor  */
+#define  USB_DESC_DEVICE                    ((USB_DESC_TYPE_DEVICE << 8) & 0xFF00)
+#define  USB_DESC_CONFIGURATION             ((USB_DESC_TYPE_CONFIGURATION << 8) & 0xFF00)
+#define  USB_DESC_STRING                    ((USB_DESC_TYPE_STRING << 8) & 0xFF00)
+#define  USB_DESC_INTERFACE                 ((USB_DESC_TYPE_INTERFACE << 8) & 0xFF00)
+#define  USB_DESC_ENDPOINT                  ((USB_DESC_TYPE_INTERFACE << 8) & 0xFF00)
+#define  USB_DESC_DEVICE_QUALIFIER          ((USB_DESC_TYPE_DEVICE_QUALIFIER << 8) & 0xFF00)
+#define  USB_DESC_OTHER_SPEED_CONFIGURATION ((USB_DESC_TYPE_OTHER_SPEED_CONFIGURATION << 8) & 0xFF00)
+#define  USB_DESC_INTERFACE_POWER           ((USB_DESC_TYPE_INTERFACE_POWER << 8) & 0xFF00)
+#define  USB_DESC_HID_REPORT                ((USB_DESC_TYPE_HID_REPORT << 8) & 0xFF00)
+#define  USB_DESC_HID                       ((USB_DESC_TYPE_HID << 8) & 0xFF00)
+
+
+#define  USB_EP_TYPE_CTRL                               0x00
+#define  USB_EP_TYPE_ISOC                               0x01
+#define  USB_EP_TYPE_BULK                               0x02
+#define  USB_EP_TYPE_INTR                               0x03
+
+#define  USB_EP_DIR_OUT                                 0x00
+#define  USB_EP_DIR_IN                                  0x80
+#define  USB_EP_DIR_MSK                                 0x80  
+
+/* supported classes */
+#define USB_MSC_CLASS                                   0x08
+#define USB_HID_CLASS                                   0x03
+
+/* Interface Descriptor field values for HID Boot Protocol */
+#define HID_BOOT_CODE                                  0x01    
+#define HID_KEYBRD_BOOT_CODE                           0x01
+#define HID_MOUSE_BOOT_CODE                            0x02
+
+/* As per USB specs 9.2.6.4 :Standard request with data request timeout: 5sec
+   Standard request with no data stage timeout : 50ms */
+#define DATA_STAGE_TIMEOUT                              5000 
+#define NODATA_STAGE_TIMEOUT                            50
+
+/**
+  * @}
+  */ 
+
+
+#define USBH_CONFIGURATION_DESCRIPTOR_SIZE (USB_CONFIGURATION_DESC_SIZE \
+                                           + USB_INTERFACE_DESC_SIZE\
+                                           + (USBH_MAX_NUM_ENDPOINTS * USB_ENDPOINT_DESC_SIZE))
+
+
+#define CONFIG_DESC_wTOTAL_LENGTH (ConfigurationDescriptorData.ConfigDescfield.\
+                                          ConfigurationDescriptor.wTotalLength)
+
+
+/*  This Union is copied from usb_core.h  */
+typedef union
+{
+  uint16_t w;
+  struct BW
+  {
+    uint8_t msb;
+    uint8_t lsb;
+  }
+  bw;
+}
+uint16_t_uint8_t;
+
+
+typedef union _USB_Setup
+{
+  uint8_t d8[8];
+  
+  struct _SetupPkt_Struc
+  {
+    uint8_t           bmRequestType;
+    uint8_t           bRequest;
+    uint16_t_uint8_t  wValue;
+    uint16_t_uint8_t  wIndex;
+    uint16_t_uint8_t  wLength;
+  } b;
+} 
+USB_Setup_TypeDef;  
+
+typedef  struct  _DescHeader 
+{
+    uint8_t  bLength;       
+    uint8_t  bDescriptorType;
+} 
+USBH_DescHeader_t;
+
+typedef struct _DeviceDescriptor
+{
+  uint8_t   bLength;
+  uint8_t   bDescriptorType;
+  uint16_t  bcdUSB;        /* USB Specification Number which device complies too */
+  uint8_t   bDeviceClass;
+  uint8_t   bDeviceSubClass; 
+  uint8_t   bDeviceProtocol;
+  /* If equal to Zero, each interface specifies its own class
+  code if equal to 0xFF, the class code is vendor specified.
+  Otherwise field is valid Class Code.*/
+  uint8_t   bMaxPacketSize;
+  uint16_t  idVendor;      /* Vendor ID (Assigned by USB Org) */
+  uint16_t  idProduct;     /* Product ID (Assigned by Manufacturer) */
+  uint16_t  bcdDevice;     /* Device Release Number */
+  uint8_t   iManufacturer;  /* Index of Manufacturer String Descriptor */
+  uint8_t   iProduct;       /* Index of Product String Descriptor */
+  uint8_t   iSerialNumber;  /* Index of Serial Number String Descriptor */
+  uint8_t   bNumConfigurations; /* Number of Possible Configurations */
+}
+USBH_DevDesc_TypeDef;
+
+
+typedef struct _ConfigurationDescriptor
+{
+  uint8_t   bLength;
+  uint8_t   bDescriptorType;
+  uint16_t  wTotalLength;        /* Total Length of Data Returned */
+  uint8_t   bNumInterfaces;       /* Number of Interfaces */
+  uint8_t   bConfigurationValue;  /* Value to use as an argument to select this configuration*/
+  uint8_t   iConfiguration;       /*Index of String Descriptor Describing this configuration */
+  uint8_t   bmAttributes;         /* D7 Bus Powered , D6 Self Powered, D5 Remote Wakeup , D4..0 Reserved (0)*/
+  uint8_t   bMaxPower;            /*Maximum Power Consumption */
+}
+USBH_CfgDesc_TypeDef;
+
+
+typedef struct _HIDDescriptor
+{
+  uint8_t   bLength;
+  uint8_t   bDescriptorType;
+  uint16_t  bcdHID;               /* indicates what endpoint this descriptor is describing */
+  uint8_t   bCountryCode;        /* specifies the transfer type. */
+  uint8_t   bNumDescriptors;     /* specifies the transfer type. */
+  uint8_t   bReportDescriptorType;    /* Maximum Packet Size this endpoint is capable of sending or receiving */  
+  uint16_t  wItemLength;          /* is used to specify the polling interval of certain transfers. */
+}
+USBH_HIDDesc_TypeDef;
+
+
+typedef struct _InterfaceDescriptor
+{
+  uint8_t bLength;
+  uint8_t bDescriptorType;
+  uint8_t bInterfaceNumber;
+  uint8_t bAlternateSetting;    /* Value used to select alternative setting */
+  uint8_t bNumEndpoints;        /* Number of Endpoints used for this interface */
+  uint8_t bInterfaceClass;      /* Class Code (Assigned by USB Org) */
+  uint8_t bInterfaceSubClass;   /* Subclass Code (Assigned by USB Org) */
+  uint8_t bInterfaceProtocol;   /* Protocol Code */
+  uint8_t iInterface;           /* Index of String Descriptor Describing this interface */
+  
+}
+USBH_InterfaceDesc_TypeDef;
+
+
+typedef struct _EndpointDescriptor
+{
+  uint8_t   bLength;
+  uint8_t   bDescriptorType;
+  uint8_t   bEndpointAddress;   /* indicates what endpoint this descriptor is describing */
+  uint8_t   bmAttributes;       /* specifies the transfer type. */
+  uint16_t  wMaxPacketSize;    /* Maximum Packet Size this endpoint is capable of sending or receiving */  
+  uint8_t   bInterval;          /* is used to specify the polling interval of certain transfers. */
+}
+USBH_EpDesc_TypeDef;
+#endif
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
+

--- a/src/lib/usbh_hcs.c
+++ b/src/lib/usbh_hcs.c
@@ -1,0 +1,259 @@
+/**
+  ******************************************************************************
+  * @file    usbh_hcs.c
+  * @author  MCD Application Team
+  * @version V2.1.0
+  * @date    19-March-2012
+  * @brief   This file implements functions for opening and closing host channels
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT 2012 STMicroelectronics</center></h2>
+  *
+  * Licensed under MCD-ST Liberty SW License Agreement V2, (the "License");
+  * You may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at:
+  *
+  *        http://www.st.com/software_license_agreement_liberty_v2
+  *
+  * Unless required by applicable law or agreed to in writing, software 
+  * distributed under the License is distributed on an "AS IS" BASIS, 
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  *
+  ******************************************************************************
+  */ 
+
+/* Includes ------------------------------------------------------------------*/
+#include "usbh_hcs.h"
+
+/** @addtogroup USBH_LIB
+  * @{
+  */
+
+/** @addtogroup USBH_LIB_CORE
+* @{
+*/
+  
+/** @defgroup USBH_HCS
+  * @brief This file includes opening and closing host channels
+  * @{
+  */ 
+
+/** @defgroup USBH_HCS_Private_Defines
+  * @{
+  */ 
+/**
+  * @}
+  */ 
+
+/** @defgroup USBH_HCS_Private_TypesDefinitions
+  * @{
+  */ 
+/**
+  * @}
+  */ 
+
+
+/** @defgroup USBH_HCS_Private_Macros
+  * @{
+  */ 
+/**
+  * @}
+  */ 
+
+
+/** @defgroup USBH_HCS_Private_Variables
+  * @{
+  */ 
+
+/**
+  * @}
+  */ 
+
+
+/** @defgroup USBH_HCS_Private_FunctionPrototypes
+  * @{
+  */ 
+static uint16_t USBH_GetFreeChannel (USB_OTG_CORE_HANDLE *pdev);
+/**
+  * @}
+  */ 
+
+
+/** @defgroup USBH_HCS_Private_Functions
+  * @{
+  */ 
+
+
+
+/**
+  * @brief  USBH_Open_Channel
+  *         Open a  pipe
+  * @param  pdev : Selected device
+  * @param  hc_num: Host channel Number
+  * @param  dev_address: USB Device address allocated to attached device
+  * @param  speed : USB device speed (Full/Low)
+  * @param  ep_type: end point type (Bulk/int/ctl)
+  * @param  mps: max pkt size
+  * @retval Status
+  */
+uint8_t USBH_Open_Channel  (USB_OTG_CORE_HANDLE *pdev,
+                            uint8_t hc_num,
+                            uint8_t dev_address,
+                            uint8_t speed,
+                            uint8_t ep_type,
+                            uint16_t mps)
+{
+
+  pdev->host.hc[hc_num].ep_num = pdev->host.channel[hc_num]& 0x7F;
+  pdev->host.hc[hc_num].ep_is_in = (pdev->host.channel[hc_num] & 0x80 ) == 0x80;  
+  pdev->host.hc[hc_num].dev_addr = dev_address;  
+  pdev->host.hc[hc_num].ep_type = ep_type;  
+  pdev->host.hc[hc_num].max_packet = mps; 
+  pdev->host.hc[hc_num].speed = speed; 
+  pdev->host.hc[hc_num].toggle_in = 0; 
+  pdev->host.hc[hc_num].toggle_out = 0;   
+  if(speed == HPRT0_PRTSPD_HIGH_SPEED)
+  {
+    pdev->host.hc[hc_num].do_ping = 1;
+  }
+  
+  USB_OTG_HC_Init(pdev, hc_num) ;
+  
+  return HC_OK; 
+
+}
+
+/**
+  * @brief  USBH_Modify_Channel
+  *         Modify a  pipe
+  * @param  pdev : Selected device
+  * @param  hc_num: Host channel Number
+  * @param  dev_address: USB Device address allocated to attached device
+  * @param  speed : USB device speed (Full/Low)
+  * @param  ep_type: end point type (Bulk/int/ctl)
+  * @param  mps: max pkt size
+  * @retval Status
+  */
+uint8_t USBH_Modify_Channel (USB_OTG_CORE_HANDLE *pdev,
+                            uint8_t hc_num,
+                            uint8_t dev_address,
+                            uint8_t speed,
+                            uint8_t ep_type,
+                            uint16_t mps)
+{
+  
+  if(dev_address != 0)
+  {
+    pdev->host.hc[hc_num].dev_addr = dev_address;  
+  }
+  
+  if((pdev->host.hc[hc_num].max_packet != mps) && (mps != 0))
+  {
+    pdev->host.hc[hc_num].max_packet = mps; 
+  }
+  
+  if((pdev->host.hc[hc_num].speed != speed ) && (speed != 0 )) 
+  {
+    pdev->host.hc[hc_num].speed = speed; 
+  }
+  
+  USB_OTG_HC_Init(pdev, hc_num);
+  return HC_OK; 
+
+}
+
+/**
+  * @brief  USBH_Alloc_Channel
+  *         Allocate a new channel for the pipe
+  * @param  ep_addr: End point for which the channel to be allocated
+  * @retval hc_num: Host channel number
+  */
+uint8_t USBH_Alloc_Channel  (USB_OTG_CORE_HANDLE *pdev, uint8_t ep_addr)
+{
+  uint16_t hc_num;
+  
+  hc_num =  USBH_GetFreeChannel(pdev);
+
+  if (hc_num != HC_ERROR)
+  {
+	pdev->host.channel[hc_num] = HC_USED | ep_addr;
+  }
+  return hc_num;
+}
+
+/**
+  * @brief  USBH_Free_Pipe
+  *         Free the USB host channel
+  * @param  idx: Channel number to be freed 
+  * @retval Status
+  */
+uint8_t USBH_Free_Channel  (USB_OTG_CORE_HANDLE *pdev, uint8_t idx)
+{
+   if(idx < HC_MAX)
+   {
+	 pdev->host.channel[idx] &= HC_USED_MASK;
+   }
+   return USBH_OK;
+}
+
+
+/**
+  * @brief  USBH_DeAllocate_AllChannel
+  *         Free all USB host channel
+* @param  pdev : core instance
+  * @retval Status
+  */
+uint8_t USBH_DeAllocate_AllChannel  (USB_OTG_CORE_HANDLE *pdev)
+{
+   uint8_t idx;
+   
+   for (idx = 2; idx < HC_MAX ; idx ++)
+   {
+	 pdev->host.channel[idx] = 0;
+   }
+   return USBH_OK;
+}
+
+/**
+  * @brief  USBH_GetFreeChannel
+  *         Get a free channel number for allocation to a device endpoint
+  * @param  None
+  * @retval idx: Free Channel number
+  */
+static uint16_t USBH_GetFreeChannel (USB_OTG_CORE_HANDLE *pdev)
+{
+  uint8_t idx = 0;
+  
+  for (idx = 0 ; idx < HC_MAX ; idx++)
+  {
+	if ((pdev->host.channel[idx] & HC_USED) == 0)
+	{
+	   return idx;
+	} 
+  }
+  return HC_ERROR;
+}
+
+
+/**
+* @}
+*/ 
+
+/**
+* @}
+*/ 
+
+/**
+* @}
+*/
+
+/**
+* @}
+*/ 
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
+
+

--- a/src/lib/usbh_hcs.h
+++ b/src/lib/usbh_hcs.h
@@ -1,0 +1,129 @@
+/**
+  ******************************************************************************
+  * @file    usbh_hcs.h
+  * @author  MCD Application Team
+  * @version V2.1.0
+  * @date    19-March-2012
+  * @brief   Header file for usbh_hcs.c
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT 2012 STMicroelectronics</center></h2>
+  *
+  * Licensed under MCD-ST Liberty SW License Agreement V2, (the "License");
+  * You may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at:
+  *
+  *        http://www.st.com/software_license_agreement_liberty_v2
+  *
+  * Unless required by applicable law or agreed to in writing, software 
+  * distributed under the License is distributed on an "AS IS" BASIS, 
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  *
+  ******************************************************************************
+  */ 
+
+/* Define to prevent recursive  ----------------------------------------------*/
+#ifndef __USBH_HCS_H
+#define __USBH_HCS_H
+
+/* Includes ------------------------------------------------------------------*/
+#include "usbh_core.h"
+
+/** @addtogroup USBH_LIB
+  * @{
+  */
+
+/** @addtogroup USBH_LIB_CORE
+* @{
+*/
+  
+/** @defgroup USBH_HCS
+  * @brief This file is the header file for usbh_hcs.c
+  * @{
+  */ 
+
+/** @defgroup USBH_HCS_Exported_Defines
+  * @{
+  */
+#define HC_MAX           8
+
+#define HC_OK            0x0000
+#define HC_USED          0x8000
+#define HC_ERROR         0xFFFF
+#define HC_USED_MASK     0x7FFF
+/**
+  * @}
+  */ 
+
+/** @defgroup USBH_HCS_Exported_Types
+  * @{
+  */ 
+/**
+  * @}
+  */ 
+
+
+/** @defgroup USBH_HCS_Exported_Macros
+  * @{
+  */ 
+/**
+  * @}
+  */ 
+
+/** @defgroup USBH_HCS_Exported_Variables
+  * @{
+  */ 
+/**
+  * @}
+  */ 
+
+/** @defgroup USBH_HCS_Exported_FunctionsPrototype
+  * @{
+  */
+
+uint8_t USBH_Alloc_Channel(USB_OTG_CORE_HANDLE *pdev, uint8_t ep_addr);
+
+uint8_t USBH_Free_Channel  (USB_OTG_CORE_HANDLE *pdev, uint8_t idx);
+
+uint8_t USBH_DeAllocate_AllChannel  (USB_OTG_CORE_HANDLE *pdev);
+
+uint8_t USBH_Open_Channel  (USB_OTG_CORE_HANDLE *pdev,
+                            uint8_t ch_num,
+                            uint8_t dev_address,
+                            uint8_t speed,
+                            uint8_t ep_type,
+                            uint16_t mps);
+
+uint8_t USBH_Modify_Channel (USB_OTG_CORE_HANDLE *pdev,
+                            uint8_t hc_num,
+                            uint8_t dev_address,
+                            uint8_t speed,
+                            uint8_t ep_type,
+                            uint16_t mps);
+/**
+  * @}
+  */ 
+
+
+
+#endif /* __USBH_HCS_H */
+
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+
+/**
+* @}
+*/ 
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
+
+

--- a/src/lib/usbh_hid_core.c
+++ b/src/lib/usbh_hid_core.c
@@ -1,0 +1,665 @@
+/**
+  ******************************************************************************
+  * @file    usbh_hid_core.c
+  * @author  MCD Application Team
+  * @version V2.1.0
+  * @date    19-March-2012
+  * @brief   This file is the HID Layer Handlers for USB Host HID class.
+  *
+  * @verbatim
+  *      
+  *          ===================================================================      
+  *                                HID Class  Description
+  *          =================================================================== 
+  *           This module manages the MSC class V1.11 following the "Device Class Definition
+  *           for Human Interface Devices (HID) Version 1.11 Jun 27, 2001".
+  *           This driver implements the following aspects of the specification:
+  *             - The Boot Interface Subclass
+  *             - The Mouse and Keyboard protocols
+  *      
+  *  @endverbatim
+  *
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT 2012 STMicroelectronics</center></h2>
+  *
+  * Licensed under MCD-ST Liberty SW License Agreement V2, (the "License");
+  * You may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at:
+  *
+  *        http://www.st.com/software_license_agreement_liberty_v2
+  *
+  * Unless required by applicable law or agreed to in writing, software 
+  * distributed under the License is distributed on an "AS IS" BASIS, 
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "usbh_hid_core.h"
+#include "usbh_hid_gamepad.h"
+#include "usbh_hid_mouse.h"
+#include "usbh_hid_keybd.h"
+
+/** @addtogroup USBH_LIB
+* @{
+*/
+
+/** @addtogroup USBH_CLASS
+* @{
+*/
+
+/** @addtogroup USBH_HID_CLASS
+* @{
+*/
+
+/** @defgroup USBH_HID_CORE 
+* @brief    This file includes HID Layer Handlers for USB Host HID class.
+* @{
+*/ 
+
+/** @defgroup USBH_HID_CORE_Private_TypesDefinitions
+* @{
+*/ 
+/**
+* @}
+*/ 
+
+
+/** @defgroup USBH_HID_CORE_Private_Defines
+* @{
+*/ 
+/**
+* @}
+*/ 
+
+
+/** @defgroup USBH_HID_CORE_Private_Macros
+* @{
+*/ 
+/**
+* @}
+*/ 
+
+
+/** @defgroup USBH_HID_CORE_Private_Variables
+* @{
+*/
+#ifdef USB_OTG_HS_INTERNAL_DMA_ENABLED
+  #if defined ( __ICCARM__ ) /*!< IAR Compiler */
+    #pragma data_alignment=4   
+  #endif
+#endif /* USB_OTG_HS_INTERNAL_DMA_ENABLED */
+__ALIGN_BEGIN HID_Machine_TypeDef        HID_Machines[2] __ALIGN_END ;
+
+#ifdef USB_OTG_HS_INTERNAL_DMA_ENABLED
+  #if defined ( __ICCARM__ ) /*!< IAR Compiler */
+    #pragma data_alignment=4   
+  #endif
+#endif /* USB_OTG_HS_INTERNAL_DMA_ENABLED */
+__ALIGN_BEGIN HID_Report_TypeDef         HID_Reports[2] __ALIGN_END ;
+
+#ifdef USB_OTG_HS_INTERNAL_DMA_ENABLED
+  #if defined ( __ICCARM__ ) /*!< IAR Compiler */
+    #pragma data_alignment=4   
+  #endif
+#endif /* USB_OTG_HS_INTERNAL_DMA_ENABLED */
+__ALIGN_BEGIN USB_Setup_TypeDef          HID_Setups[2] __ALIGN_END ;
+
+#ifdef USB_OTG_HS_INTERNAL_DMA_ENABLED
+  #if defined ( __ICCARM__ ) /*!< IAR Compiler */
+    #pragma data_alignment=4   
+  #endif
+#endif /* USB_OTG_HS_INTERNAL_DMA_ENABLED */
+__ALIGN_BEGIN USBH_HIDDesc_TypeDef       HID_Descs[2] __ALIGN_END ; 
+
+__IO uint8_t start_toggles[2] = {0,0};
+/**
+* @}
+*/ 
+
+
+/** @defgroup USBH_HID_CORE_Private_FunctionPrototypes
+* @{
+*/ 
+
+static USBH_Status USBH_HID_InterfaceInit  (USB_OTG_CORE_HANDLE *pdev , 
+                                            void *phost);
+
+static void  USBH_ParseHIDDesc (USBH_HIDDesc_TypeDef *desc, uint8_t *buf);
+
+static void USBH_HID_InterfaceDeInit  (USB_OTG_CORE_HANDLE *pdev , 
+                                       void *phost);
+
+static USBH_Status USBH_HID_Handle(USB_OTG_CORE_HANDLE *pdev , 
+                                   void *phost);
+
+static USBH_Status USBH_HID_ClassRequest(USB_OTG_CORE_HANDLE *pdev , 
+                                         void *phost);
+
+static USBH_Status USBH_Get_HID_ReportDescriptor (USB_OTG_CORE_HANDLE *pdev, 
+                                                  USBH_HOST *phost,
+                                                  uint16_t length);
+
+static USBH_Status USBH_Get_HID_Descriptor (USB_OTG_CORE_HANDLE *pdev,\
+                                            USBH_HOST *phost,  
+                                            uint16_t length);
+
+static USBH_Status USBH_Set_Idle (USB_OTG_CORE_HANDLE *pdev, 
+                                  USBH_HOST *phost,
+                                  uint8_t duration,
+                                  uint8_t reportId);
+
+static USBH_Status USBH_Set_Protocol (USB_OTG_CORE_HANDLE *pdev, 
+                                      USBH_HOST *phost,
+                                      uint8_t protocol);
+
+
+USBH_Class_cb_TypeDef  HID_cb = 
+{
+  USBH_HID_InterfaceInit,
+  USBH_HID_InterfaceDeInit,
+  USBH_HID_ClassRequest,
+  USBH_HID_Handle
+};
+/**
+* @}
+*/ 
+
+
+/** @defgroup USBH_HID_CORE_Private_Functions
+* @{
+*/ 
+
+/**
+* @brief  USBH_HID_InterfaceInit 
+*         The function init the HID class.
+* @param  pdev: Selected device
+* @param  hdev: Selected device property
+* @retval  USBH_Status :Response for USB HID driver intialization
+*/
+static USBH_Status USBH_HID_InterfaceInit ( USB_OTG_CORE_HANDLE *pdev, 
+                                           void *phost)
+{	
+  uint8_t maxEP;
+  USBH_HOST *pphost = phost;
+  HID_Machine_TypeDef *HID_Machine = &HID_Machines[pdev->cfg.coreID];
+  uint8_t num =0;
+  USBH_Status status = USBH_BUSY ;
+  HID_Machine->state = HID_ERROR;
+  
+
+  if (HID_GAMEPAD_cb.Detect(pphost->device_prop.Dev_Desc.idVendor, pphost->device_prop.Dev_Desc.idProduct) || (pphost->device_prop.Itf_Desc[0].bInterfaceSubClass  == HID_BOOT_CODE)) 
+  { 
+    /*Decode Bootclass Protocl: Mouse or Keyboard*/
+    if(pphost->device_prop.Itf_Desc[0].bInterfaceProtocol == HID_KEYBRD_BOOT_CODE)
+    {
+      HID_Machine->cb = &HID_KEYBRD_cb;
+    }
+    else if(pphost->device_prop.Itf_Desc[0].bInterfaceProtocol  == HID_MOUSE_BOOT_CODE)
+    {
+      HID_Machine->cb = &HID_MOUSE_cb;
+    } 
+    else
+    {
+      HID_Machine->cb = &HID_GAMEPAD_cb;
+    }
+    
+    HID_Machine->state     = HID_IDLE;
+    HID_Machine->ctl_state = HID_REQ_IDLE; 
+    HID_Machine->ep_addr   = pphost->device_prop.Ep_Desc[0][0].bEndpointAddress;
+    HID_Machine->length    = pphost->device_prop.Ep_Desc[0][0].wMaxPacketSize;
+    HID_Machine->poll      = pphost->device_prop.Ep_Desc[0][0].bInterval ;
+    
+    if (HID_Machine->poll  < HID_MIN_POLL) 
+    {
+       HID_Machine->poll = HID_MIN_POLL;
+    }
+
+    
+    /* Check fo available number of endpoints */
+    /* Find the number of EPs in the Interface Descriptor */      
+    /* Choose the lower number in order not to overrun the buffer allocated */
+    maxEP = ( (pphost->device_prop.Itf_Desc[0].bNumEndpoints <= USBH_MAX_NUM_ENDPOINTS) ? 
+             pphost->device_prop.Itf_Desc[0].bNumEndpoints :
+                 USBH_MAX_NUM_ENDPOINTS); 
+    
+    
+    /* Decode endpoint IN and OUT address from interface descriptor */
+    for (num=0; num < maxEP; num++)
+    {
+      if(pphost->device_prop.Ep_Desc[0][num].bEndpointAddress & 0x80)
+      {
+        HID_Machine->HIDIntInEp = (pphost->device_prop.Ep_Desc[0][num].bEndpointAddress);
+        HID_Machine->hc_num_in  =\
+               USBH_Alloc_Channel(pdev, 
+                                  pphost->device_prop.Ep_Desc[0][num].bEndpointAddress);
+        
+        /* Open channel for IN endpoint */
+        USBH_Open_Channel  (pdev,
+                            HID_Machine->hc_num_in,
+                            pphost->device_prop.address,
+                            pphost->device_prop.speed,
+                            EP_TYPE_INTR,
+                            HID_Machine->length); 
+      }
+      else
+      {
+        HID_Machine->HIDIntOutEp = (pphost->device_prop.Ep_Desc[0][num].bEndpointAddress);
+        HID_Machine->hc_num_out  =\
+                USBH_Alloc_Channel(pdev, 
+                                   pphost->device_prop.Ep_Desc[0][num].bEndpointAddress);
+        
+        /* Open channel for OUT endpoint */
+        USBH_Open_Channel  (pdev,
+                            HID_Machine->hc_num_out,
+                            pphost->device_prop.address,
+                            pphost->device_prop.speed,
+                            EP_TYPE_INTR,
+                            HID_Machine->length); 
+      }
+      
+    }   
+    
+     start_toggles[pdev->cfg.coreID] =0;
+     status = USBH_OK; 
+  }
+  else
+  {
+    pphost->usr_cb->DeviceNotSupported();   
+  }
+
+  return status;
+  
+}
+
+
+
+/**
+* @brief  USBH_HID_InterfaceDeInit 
+*         The function DeInit the Host Channels used for the HID class.
+* @param  pdev: Selected device
+* @param  hdev: Selected device property
+* @retval None
+*/
+void USBH_HID_InterfaceDeInit ( USB_OTG_CORE_HANDLE *pdev,
+                               void *phost)
+{
+  HID_Machine_TypeDef *HID_Machine = &HID_Machines[pdev->cfg.coreID];	
+   //USBH_HOST *pphost = phost;
+    
+  if(HID_Machine->hc_num_in != 0x00)
+  {   
+    USB_OTG_HC_Halt(pdev, HID_Machine->hc_num_in);
+    USBH_Free_Channel  (pdev, HID_Machine->hc_num_in);
+    HID_Machine->hc_num_in = 0;     /* Reset the Channel as Free */  
+  }
+  
+  if(HID_Machine->hc_num_out != 0x00)
+  {   
+    USB_OTG_HC_Halt(pdev, HID_Machine->hc_num_out);
+    USBH_Free_Channel  (pdev, HID_Machine->hc_num_out);
+    HID_Machine->hc_num_out = 0;     /* Reset the Channel as Free */  
+  }
+ 
+  start_toggles[pdev->cfg.coreID] = 0;
+}
+
+/**
+* @brief  USBH_HID_ClassRequest 
+*         The function is responsible for handling HID Class requests
+*         for HID class.
+* @param  pdev: Selected device
+* @param  hdev: Selected device property
+* @retval  USBH_Status :Response for USB Set Protocol request
+*/
+static USBH_Status USBH_HID_ClassRequest(USB_OTG_CORE_HANDLE *pdev , 
+                                         void *phost)
+{   
+  USBH_HOST *pphost = phost;
+  HID_Machine_TypeDef *HID_Machine = &HID_Machines[pdev->cfg.coreID];   
+ 
+  USBH_Status status         = USBH_BUSY;
+  USBH_Status classReqStatus = USBH_BUSY;
+  
+  
+  /* Switch HID state machine */
+  switch (HID_Machine->ctl_state)
+  {
+  case HID_IDLE:  
+  case HID_REQ_GET_HID_DESC:
+    
+    /* Get HID Desc */ 
+    if (USBH_Get_HID_Descriptor (pdev, pphost, USB_HID_DESC_SIZE)== USBH_OK)
+    {
+      
+      USBH_ParseHIDDesc(&HID_Descs[pdev->cfg.coreID], pdev->host.Rx_Buffer);
+      HID_Machine->ctl_state = HID_REQ_GET_REPORT_DESC;
+    }
+    
+    break;     
+  case HID_REQ_GET_REPORT_DESC:
+    
+    
+    /* Get Report Desc */ 
+    if (USBH_Get_HID_ReportDescriptor(pdev , pphost, HID_Descs[pdev->cfg.coreID].wItemLength) == USBH_OK)
+    {
+      HID_Machine->ctl_state = HID_REQ_SET_IDLE;
+    }
+    
+    break;
+    
+  case HID_REQ_SET_IDLE:
+    
+    classReqStatus = USBH_Set_Idle (pdev, pphost, 0, 0);
+    
+    /* set Idle */
+    if (classReqStatus == USBH_OK)
+    {
+      HID_Machine->ctl_state = HID_REQ_SET_PROTOCOL;  
+    }
+    else if(classReqStatus == USBH_NOT_SUPPORTED) 
+    {
+      HID_Machine->ctl_state = HID_REQ_SET_PROTOCOL;        
+    } 
+    break; 
+    
+  case HID_REQ_SET_PROTOCOL:
+    /* set protocol */
+    if (USBH_Set_Protocol (pdev ,pphost, 0) == USBH_OK)
+    {
+      HID_Machine->ctl_state = HID_REQ_IDLE;
+      
+      /* all requests performed*/
+      status = USBH_OK; 
+    } 
+    break;
+    
+  default:
+    break;
+  }
+  
+  return status; 
+}
+
+
+/**
+* @brief  USBH_HID_Handle 
+*         The function is for managing state machine for HID data transfers 
+* @param  pdev: Selected device
+* @param  hdev: Selected device property
+* @retval USBH_Status
+*/
+static USBH_Status USBH_HID_Handle(USB_OTG_CORE_HANDLE *pdev , 
+                                   void   *phost)
+{
+  USBH_HOST *pphost = phost;
+  HID_Machine_TypeDef *HID_Machine = &HID_Machines[pdev->cfg.coreID];
+  USBH_Status status = USBH_OK;
+  
+  switch (HID_Machine->state)
+  {
+    
+  case HID_IDLE:
+    HID_Machine->cb->Init(pdev->cfg.coreID,pphost->device_prop.Dev_Desc.idVendor,pphost->device_prop.Dev_Desc.idProduct);
+    HID_Machine->state = HID_SYNC;
+    
+  case HID_SYNC:
+
+    /* Sync with start of Even Frame */
+    if(USB_OTG_IsEvenFrame(pdev) == TRUE)
+    {
+      HID_Machine->state = HID_GET_DATA;  
+    }
+    break;
+    
+  case HID_GET_DATA:
+
+    USBH_InterruptReceiveData(pdev, 
+                              HID_Machine->buff,
+                              HID_Machine->length,
+                              HID_Machine->hc_num_in);
+    start_toggles[pdev->cfg.coreID] = 1;
+    
+    HID_Machine->state = HID_POLL;
+    HID_Machine->timer = HCD_GetCurrentFrame(pdev);
+    break;
+    
+  case HID_POLL:
+    if(( HCD_GetCurrentFrame(pdev) - HID_Machine->timer) >= HID_Machine->poll)
+    {
+      HID_Machine->state = HID_GET_DATA;
+    }
+    else if(HCD_GetURB_State(pdev , HID_Machine->hc_num_in) == URB_DONE)
+    {
+      if(start_toggles[pdev->cfg.coreID] == 1) /* handle data once */
+      {
+        start_toggles[pdev->cfg.coreID] = 0;
+        HID_Machine->cb->Decode(pdev->cfg.coreID,HID_Machine->buff);
+      }
+    }
+    else if(HCD_GetURB_State(pdev, HID_Machine->hc_num_in) == URB_STALL) /* IN Endpoint Stalled */
+    {
+      
+      /* Issue Clear Feature on interrupt IN endpoint */ 
+      if( (USBH_ClrFeature(pdev, 
+                           pphost,
+                           HID_Machine->ep_addr,
+                           HID_Machine->hc_num_in)) == USBH_OK)
+      {
+        /* Change state to issue next IN token */
+        HID_Machine->state = HID_GET_DATA;
+        
+      }
+      
+    }      
+    break;
+    
+  default:
+    break;
+  }
+  return status;
+}
+
+
+/**
+* @brief  USBH_Get_HID_ReportDescriptor
+*         Issue report Descriptor command to the device. Once the response 
+*         received, parse the report descriptor and update the status.
+* @param  pdev   : Selected device
+* @param  Length : HID Report Descriptor Length
+* @retval USBH_Status : Response for USB HID Get Report Descriptor Request
+*/
+static USBH_Status USBH_Get_HID_ReportDescriptor (USB_OTG_CORE_HANDLE *pdev,
+                                                  USBH_HOST *phost,
+                                                  uint16_t length)
+{
+  
+  USBH_Status status;
+  
+  status = USBH_GetDescriptor(pdev,
+                              phost,
+                              USB_REQ_RECIPIENT_INTERFACE
+                                | USB_REQ_TYPE_STANDARD,                                  
+                                USB_DESC_HID_REPORT, 
+                                pdev->host.Rx_Buffer,
+                                length);
+  
+  /* HID report descriptor is available in pdev->host.Rx_Buffer.
+  In case of USB Boot Mode devices for In report handling ,
+  HID report descriptor parsing is not required.
+  In case, for supporting Non-Boot Protocol devices and output reports,
+  user may parse the report descriptor*/
+  
+  
+  return status;
+}
+
+/**
+* @brief  USBH_Get_HID_Descriptor
+*         Issue HID Descriptor command to the device. Once the response 
+*         received, parse the report descriptor and update the status.
+* @param  pdev   : Selected device
+* @param  Length : HID Descriptor Length
+* @retval USBH_Status : Response for USB HID Get Report Descriptor Request
+*/
+static USBH_Status USBH_Get_HID_Descriptor (USB_OTG_CORE_HANDLE *pdev,
+                                            USBH_HOST *phost,
+                                            uint16_t length)
+{
+  
+  USBH_Status status;
+  
+  status = USBH_GetDescriptor(pdev, 
+                              phost,
+                              USB_REQ_RECIPIENT_INTERFACE
+                                | USB_REQ_TYPE_STANDARD,                                  
+                                USB_DESC_HID,
+                                pdev->host.Rx_Buffer,
+                                length);
+ 
+  return status;
+}
+
+/**
+* @brief  USBH_Set_Idle
+*         Set Idle State. 
+* @param  pdev: Selected device
+* @param  duration: Duration for HID Idle request
+* @param  reportID : Targetted report ID for Set Idle request
+* @retval USBH_Status : Response for USB Set Idle request
+*/
+static USBH_Status USBH_Set_Idle (USB_OTG_CORE_HANDLE *pdev,
+                                  USBH_HOST *phost,
+                                  uint8_t duration,
+                                  uint8_t reportId)
+{
+  
+  phost->Control.setup.b.bmRequestType = USB_H2D | USB_REQ_RECIPIENT_INTERFACE |\
+    USB_REQ_TYPE_CLASS;
+  
+  
+  phost->Control.setup.b.bRequest = USB_HID_SET_IDLE;
+  phost->Control.setup.b.wValue.w = (duration << 8 ) | reportId;
+  
+  phost->Control.setup.b.wIndex.w = 0;
+  phost->Control.setup.b.wLength.w = 0;
+  
+  return USBH_CtlReq(pdev, phost, 0 , 0 );
+}
+
+
+/**
+* @brief  USBH_Set_Report
+*         Issues Set Report 
+* @param  pdev: Selected device
+* @param  reportType  : Report type to be sent
+* @param  reportID    : Targetted report ID for Set Report request
+* @param  reportLen   : Length of data report to be send
+* @param  reportBuff  : Report Buffer
+* @retval USBH_Status : Response for USB Set Idle request
+*/
+USBH_Status USBH_Set_Report (USB_OTG_CORE_HANDLE *pdev, 
+                                 USBH_HOST *phost,
+                                    uint8_t reportType,
+                                    uint8_t reportId,
+                                    uint8_t reportLen,
+                                    uint8_t* reportBuff)
+{
+  
+  phost->Control.setup.b.bmRequestType = USB_H2D | USB_REQ_RECIPIENT_INTERFACE |\
+    USB_REQ_TYPE_CLASS;
+  
+  
+  phost->Control.setup.b.bRequest = USB_HID_SET_REPORT;
+  phost->Control.setup.b.wValue.w = (reportType << 8 ) | reportId;
+  
+  phost->Control.setup.b.wIndex.w = 0;
+  phost->Control.setup.b.wLength.w = reportLen;
+  
+  return USBH_CtlReq(pdev, phost, reportBuff , reportLen );
+}
+
+
+/**
+* @brief  USBH_Set_Protocol
+*         Set protocol State.
+* @param  pdev: Selected device
+* @param  protocol : Set Protocol for HID : boot/report protocol
+* @retval USBH_Status : Response for USB Set Protocol request
+*/
+static USBH_Status USBH_Set_Protocol(USB_OTG_CORE_HANDLE *pdev,
+                                     USBH_HOST *phost,
+                                     uint8_t protocol)
+{
+  
+  
+  phost->Control.setup.b.bmRequestType = USB_H2D | USB_REQ_RECIPIENT_INTERFACE |\
+    USB_REQ_TYPE_CLASS;
+  
+  
+  phost->Control.setup.b.bRequest = USB_HID_SET_PROTOCOL;
+  
+  if(protocol != 0)
+  {
+    /* Boot Protocol */
+    phost->Control.setup.b.wValue.w = 0;
+  }
+  else
+  {
+    /*Report Protocol*/
+    phost->Control.setup.b.wValue.w = 1;
+  }
+  
+  phost->Control.setup.b.wIndex.w = 0;
+  phost->Control.setup.b.wLength.w = 0;
+  
+  return USBH_CtlReq(pdev, phost, 0 , 0 );
+  
+}
+
+/**
+* @brief  USBH_ParseHIDDesc 
+*         This function Parse the HID descriptor
+* @param  buf: Buffer where the source descriptor is available
+* @retval None
+*/
+static void  USBH_ParseHIDDesc (USBH_HIDDesc_TypeDef *desc, uint8_t *buf)
+{
+  
+  desc->bLength                  = *(uint8_t  *) (buf + 0);
+  desc->bDescriptorType          = *(uint8_t  *) (buf + 1);
+  desc->bcdHID                   =  LE16  (buf + 2);
+  desc->bCountryCode             = *(uint8_t  *) (buf + 4);
+  desc->bNumDescriptors          = *(uint8_t  *) (buf + 5);
+  desc->bReportDescriptorType    = *(uint8_t  *) (buf + 6);
+  desc->wItemLength              =  LE16  (buf + 7);
+  
+} 
+/**
+* @}
+*/ 
+
+/**
+* @}
+*/ 
+
+/**
+* @}
+*/
+
+
+/**
+* @}
+*/
+
+
+/**
+* @}
+*/
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/src/lib/usbh_hid_core.h
+++ b/src/lib/usbh_hid_core.h
@@ -1,0 +1,204 @@
+/**
+  ******************************************************************************
+  * @file    usbh_hid_core.h
+  * @author  MCD Application Team
+  * @version V2.1.0
+  * @date    19-March-2012
+  * @brief   This file contains all the prototypes for the usbh_hid_core.c
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT 2012 STMicroelectronics</center></h2>
+  *
+  * Licensed under MCD-ST Liberty SW License Agreement V2, (the "License");
+  * You may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at:
+  *
+  *        http://www.st.com/software_license_agreement_liberty_v2
+  *
+  * Unless required by applicable law or agreed to in writing, software 
+  * distributed under the License is distributed on an "AS IS" BASIS, 
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  *
+  ******************************************************************************
+  */ 
+
+/* Define to prevent recursive  ----------------------------------------------*/
+#ifndef __USBH_HID_CORE_H
+#define __USBH_HID_CORE_H
+
+/* Includes ------------------------------------------------------------------*/
+#include "usbh_core.h"
+#include "usbh_stdreq.h"
+#include "usb_bsp.h"
+#include "usbh_ioreq.h"
+#include "usbh_hcs.h"
+ 
+/** @addtogroup USBH_LIB
+  * @{
+  */
+
+/** @addtogroup USBH_CLASS
+  * @{
+  */
+
+/** @addtogroup USBH_HID_CLASS
+  * @{
+  */
+  
+/** @defgroup USBH_HID_CORE
+  * @brief This file is the Header file for USBH_HID_CORE.c
+  * @{
+  */ 
+
+
+/** @defgroup USBH_HID_CORE_Exported_Types
+  * @{
+  */ 
+
+#define HID_MIN_POLL          10
+
+/* States for HID State Machine */
+typedef enum
+{
+  HID_IDLE= 0,
+  HID_SEND_DATA,
+  HID_BUSY,
+  HID_GET_DATA,   
+  HID_SYNC,     
+  HID_POLL,
+  HID_ERROR,
+}
+HID_State;
+
+typedef enum
+{
+  HID_REQ_IDLE = 0,
+  HID_REQ_GET_REPORT_DESC,
+  HID_REQ_GET_HID_DESC,
+  HID_REQ_SET_IDLE,
+  HID_REQ_SET_PROTOCOL,
+  HID_REQ_SET_REPORT,
+
+}
+HID_CtlState;
+
+typedef struct HID_cb
+{
+  int   (*Detect) (uint16_t, uint16_t);
+  void  (*Init)   (uint8_t, uint16_t, uint16_t);             
+  void  (*Decode) (uint8_t, uint8_t *data);       
+  
+} HID_cb_TypeDef;
+
+typedef  struct  _HID_Report 
+{
+    uint8_t   ReportID;    
+    uint8_t   ReportType;  
+    uint16_t  UsagePage;   
+    uint32_t  Usage[2]; 
+    uint32_t  NbrUsage;                      
+    uint32_t  UsageMin;                      
+    uint32_t  UsageMax;                      
+    int32_t   LogMin;                        
+    int32_t   LogMax;                        
+    int32_t   PhyMin;                        
+    int32_t   PhyMax;                        
+    int32_t   UnitExp;                       
+    uint32_t  Unit;                          
+    uint32_t  ReportSize;                    
+    uint32_t  ReportCnt;                     
+    uint32_t  Flag;                          
+    uint32_t  PhyUsage;                      
+    uint32_t  AppUsage;                      
+    uint32_t  LogUsage;   
+} 
+HID_Report_TypeDef;
+
+/* Structure for HID process */
+typedef struct _HID_Process
+{
+  uint8_t              buff[64];
+  uint8_t              hc_num_in; 
+  uint8_t              hc_num_out; 
+  HID_State            state; 
+  uint8_t              HIDIntOutEp;
+  uint8_t              HIDIntInEp;
+  HID_CtlState         ctl_state;
+  uint16_t             length;
+  uint8_t              ep_addr;
+  uint16_t             poll; 
+  __IO uint16_t        timer; 
+  HID_cb_TypeDef             *cb;
+}
+HID_Machine_TypeDef;
+
+/**
+  * @}
+  */ 
+
+/** @defgroup USBH_HID_CORE_Exported_Defines
+  * @{
+  */ 
+
+#define USB_HID_REQ_GET_REPORT       0x01
+#define USB_HID_GET_IDLE             0x02
+#define USB_HID_GET_PROTOCOL         0x03
+#define USB_HID_SET_REPORT           0x09
+#define USB_HID_SET_IDLE             0x0A
+#define USB_HID_SET_PROTOCOL         0x0B    
+/**
+  * @}
+  */ 
+
+/** @defgroup USBH_HID_CORE_Exported_Macros
+  * @{
+  */ 
+/**
+  * @}
+  */ 
+
+/** @defgroup USBH_HID_CORE_Exported_Variables
+  * @{
+  */ 
+extern USBH_Class_cb_TypeDef  HID_cb;
+/**
+  * @}
+  */ 
+
+/** @defgroup USBH_HID_CORE_Exported_FunctionsPrototype
+  * @{
+  */ 
+
+USBH_Status USBH_Set_Report (USB_OTG_CORE_HANDLE *pdev,
+                             USBH_HOST *phost,
+                                  uint8_t reportType,
+                                  uint8_t reportId,
+                                  uint8_t reportLen,
+                                  uint8_t* reportBuff);
+/**
+  * @}
+  */ 
+
+
+#endif /* __USBH_HID_CORE_H */
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
+

--- a/src/lib/usbh_hid_gamepad.c
+++ b/src/lib/usbh_hid_gamepad.c
@@ -1,0 +1,366 @@
+/**
+  ******************************************************************************
+  * @file    usbh_hid_gamepad.c 
+  * @author  MCD Application Team
+  * @version V2.1.0
+  * @date    19-March-2012
+  * @brief   This file is the application layer for USB Host HID Mouse Handling.                  
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT 2012 STMicroelectronics</center></h2>
+  *
+  * Licensed under MCD-ST Liberty SW License Agreement V2, (the "License");
+  * You may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at:
+  *
+  *        http://www.st.com/software_license_agreement_liberty_v2
+  *
+  * Unless required by applicable law or agreed to in writing, software 
+  * distributed under the License is distributed on an "AS IS" BASIS, 
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  *
+  ******************************************************************************
+  */ 
+
+/* Includes ------------------------------------------------------------------*/
+#include "usbh_hid_gamepad.h"
+
+
+
+/** @addtogroup USBH_LIB
+  * @{
+  */
+
+/** @addtogroup USBH_CLASS
+  * @{
+  */
+
+/** @addtogroup USBH_HID_CLASS
+  * @{
+  */
+  
+/** @defgroup USBH_HID_GAMEPAD 
+  * @brief    This file includes HID Layer Handlers for USB Host HID class.
+  * @{
+  */ 
+
+/** @defgroup USBH_HID_GAMEPAD_Private_TypesDefinitions
+  * @{
+  */
+
+typedef struct {
+	uint16_t vid, pid, pid2, pid3; // applicable vid & pid for the device. pid2,3 : alternate pids
+	// config
+
+	/* dpad type : 
+	 *   0 : None, use analog
+         *       1 : 7 value hat switch 0-7 0-270 degrees
+	 *	 2 : XY Gamepad (2x2bits)
+	 *	 3 : independant UDLR button
+	 *	 ...
+	 */
+	unsigned int dpad_type:3;
+
+	/* analog type : 
+	 *   0 : None, use dpad
+	 *	 1 : 2x8 bit axis, 0 default
+         *       2 : 2x8 bit axis, 127 default 
+	 */
+	unsigned int analog_type:2;
+        unsigned int max_button_index:3;  // 0-7, must have 1 button!
+        unsigned int reserved_config:8;  
+           
+        /* 
+        // IDEA, use 10 bits for location as max packet size is 128 (eg. it's 64)
+        // this would enable specifying individual U/D/L/R locations, + 2 extra 
+        uint32_t bitpos_2msb;
+        uint8_t analog_x;
+        uint8_t analog_y;
+        uint8_t dpad_bit[4];
+        uint8_t button_bit[8];
+        uint8_t reserved_bit[2];
+        */
+	uint16_t dpad_bit; // starting bit, len is taken from type
+	uint16_t analog_bit;
+
+	// button descriptor : button byte/bit offset
+	// order: B Y select start A X L R
+	uint16_t button_bit[8];  // starting bit from start of payload. Max = 65536/8=8k 
+
+        uint16_t reserved_data;   // 32 bytes is a nicely aligned data size
+} USB_Gamepad_descriptor;
+ 
+/**
+  * @}
+  */ 
+
+
+/** @defgroup USBH_HID_GAMEPAD_Private_Defines
+  * @{
+  */ 
+static const USB_Gamepad_descriptor device_table[] = {
+	// Thrustmaster Firestorm - no select/start button
+	{.vid=0x044f,.pid=0xb300,.pid2=0xb301,.pid3=0xb300,.dpad_type=1,.analog_type=0,.max_button_index=7,
+         .dpad_bit=40,.analog_bit=0,.button_bit={44,45,46,47,48,49,50,51}	
+	},
+        // Trust GXT 24 
+        {.vid=0x0079,.pid=0x0006,.pid2=0x0006,.pid3=0x0006,.dpad_type=1,.analog_type=0,.max_button_index=7,
+         .dpad_bit=40,.analog_bit=0,.button_bit={44,45,46,47,48,49,50,51}
+        },
+        // SNES Gamepad USB, Ebay
+        {.vid=0x0079,.pid=0x0011,.pid2=0x0011,.pid3=0x0011,.dpad_type=0,.analog_type=2,.max_button_index=7,
+         .dpad_bit=0,.analog_bit=0,.button_bit={44,45,46,47,48,49,50,51}
+        },	
+	{.vid=0} // terminator
+};
+/**
+  * @}
+  */ 
+
+
+/** @defgroup USBH_HID_GAMEPAD_Private_Macros
+  * @{
+  */ 
+// as reported by device interrupt data
+#define MAX_REPORT_SIZE 128
+
+/**
+  * @}
+  */ 
+
+/** @defgroup USBH_HID_GAMEPAD_Private_FunctionPrototypes
+  * @{
+  */ 
+static inline uint32_t extract(uint8_t *,uint16_t,uint8_t);
+static int   GAMEPAD_Detect(uint16_t,uint16_t);
+static void  GAMEPAD_Init (uint8_t, uint16_t,uint16_t);
+static void  GAMEPAD_Decode(uint8_t, uint8_t *data);
+/**
+  * @}
+  */ 
+
+
+/** @defgroup USBH_HID_GAMEPAD_Private_Variables
+  * @{
+  */
+#ifdef USB_OTG_HS_INTERNAL_DMA_ENABLED
+ #if defined   (__CC_ARM) /*!< ARM Compiler */
+  __align(4) 
+ #elif defined ( __ICCARM__ ) /*!< IAR Compiler */
+  #pragma data_alignment=4
+ #elif defined (__GNUC__) /*!< GNU Compiler */
+ #pragma pack(4) 
+ #elif defined  (__TASKING__) /*!< TASKING Compiler */                           
+  __align(4) 
+ #endif /* __CC_ARM */
+#endif
+ 
+    
+// VID = 0 : not configured
+const USB_Gamepad_descriptor *gamepad_descriptor[2]; // currently used gamepad table. ID=0 : not configured
+HID_GAMEPAD_Data_TypeDef HID_GAMEPAD_Data[2];
+
+// static char gamepad_report[2][MAX_REPORT_SIZE]; 
+ 
+HID_cb_TypeDef HID_GAMEPAD_cb = 
+{
+  GAMEPAD_Detect,
+  GAMEPAD_Init,
+  GAMEPAD_Decode,
+};
+/**
+  * @}
+  */ 
+
+
+/** @defgroup USBH_HID_GAMEPAD_Private_Functions
+  * @{
+  */ 
+
+static const USB_Gamepad_descriptor *GAMEPAD_FindDesc(uint16_t vid, uint16_t pid)
+{
+  int i = 0;
+
+  while (device_table[i].vid != 0) {
+    if (device_table[i].vid == vid && device_table[i].pid == pid) break;
+    i++;
+  }
+
+  return &device_table[i];
+}
+
+
+static int GAMEPAD_Detect (uint16_t vid, uint16_t pid)
+{
+  const USB_Gamepad_descriptor *gp = GAMEPAD_FindDesc(vid,pid);
+
+  if (gp->vid == 0) return 0;
+
+  return 1;
+}
+
+
+/**
+* @brief  GAMEPAD_Init
+*         Init Mouse State.
+* @param  None
+* @retval None
+*/
+static void  GAMEPAD_Init (uint8_t coreID, uint16_t vid, uint16_t pid)
+{
+ /* Call User Init*/
+ gamepad_descriptor[coreID] = GAMEPAD_FindDesc(vid,pid);
+
+ // USR_GAMEPAD_Init();
+}
+
+static inline uint32_t extract(uint8_t *data, uint16_t bitref, uint8_t nbits)
+// extracts the bitref-th bit from data, size wise
+// assumes does not cross a 32bit boundary !
+{
+	uint32_t x = ((uint32_t *)data)[bitref>>5] >> (bitref & 31);
+	uint32_t mask = (1<<nbits)-1;
+	return x & mask;
+}
+
+/**
+* @brief  GAMEPAD_Decode
+*         Decode Mouse data
+* @param  data : Pointer to Mouse HID data buffer
+* @retval None
+*/
+static void  GAMEPAD_Decode(uint8_t coreID, uint8_t *data)
+{
+        uint8_t device = coreID; 
+	// const data conversion from 0-270 degrees + -1 to x/y coordinates, -1 -> 7
+	// diagonals are sqrt(2)/2
+        const int8_t button_translate[8] = {gamepad_B,gamepad_Y,gamepad_select,gamepad_start,gamepad_A,gamepad_X,gamepad_L,gamepad_R};
+        // msb up/down/left/right lsb
+	const int8_t dig_to_analog[16][2] = {{0,0},{127,0},{-127,0},{0,0},{0,127},{89,89},{-89,89},{0,0},{0,-127},{89,-89},{-89,-89},{0,0},{0,0},{0,0},{0,0},{0,0}};
+	uint8_t val;
+
+	const USB_Gamepad_descriptor *gp = gamepad_descriptor[coreID]; // shortcut
+
+        if (!gp->vid) return; // not configured
+
+	HID_GAMEPAD_Data[device].button = 0;
+
+	// button
+	for (int button=0;button<=gp->max_button_index;button++)
+	{
+		if (extract(data,gp->button_bit[button],1))
+		{
+			HID_GAMEPAD_Data[device].button |= 1<<button_translate[button];
+		}
+	}
+
+	// Hat switch
+	switch(gp->dpad_type)
+	{
+		case 1 : // 0-7 hat switch + -1 as null value
+			val = extract(data, gp->dpad_bit, 4);
+                        switch (val) 
+			{
+                          case 0:
+			  HID_GAMEPAD_Data[device].button |= 1 << gamepad_up;
+			  break;
+                          case 1:
+			  HID_GAMEPAD_Data[device].button |= (1 << gamepad_up) | (1 << gamepad_right);
+			  break;
+                          case 2:
+			  HID_GAMEPAD_Data[device].button |= 1 << gamepad_right;
+			  break;
+			  case 3:
+			  HID_GAMEPAD_Data[device].button |= (1 << gamepad_down) | (1 << gamepad_right);
+			  break;
+			  case 4:
+			  HID_GAMEPAD_Data[device].button |= 1 << gamepad_down;
+			  break;
+			  case 5:
+			  HID_GAMEPAD_Data[device].button |= (1 << gamepad_down) | (1 << gamepad_left);
+			  break;
+			  case 6:
+			  HID_GAMEPAD_Data[device].button |= 1 << gamepad_left;
+			  break;
+			  case 7:
+			  HID_GAMEPAD_Data[device].button |= (1 << gamepad_up) | (1 << gamepad_left);
+			  break;
+                          case 15:
+                          default:
+                            // none pressed
+                            break;
+			}
+			break;
+		case 2 : // x/y 2 bits -1,0,1 as 11,00,01
+			val= extract(data, gp->dpad_bit, 2);
+			HID_GAMEPAD_Data[device].button |= (val&2)?(1<<gamepad_left):((val&1)?(1<<gamepad_right):0);
+			val= extract(data, gp->dpad_bit+2, 2);
+			HID_GAMEPAD_Data[device].button |= (val&2)?(1<<gamepad_down):((val&1)?(1<<gamepad_up):0);
+			break;
+		case 3 :
+			val= extract(data, gp->dpad_bit, 4);
+			HID_GAMEPAD_Data[device].button |= (val << gamepad_right);
+			break;
+
+	}
+
+	switch (gp->analog_type) 
+	{
+		case 1 :
+			HID_GAMEPAD_Data[device].x = (int8_t)extract(data, gp->analog_bit, 8);
+			HID_GAMEPAD_Data[device].y = (int8_t)extract(data, gp->analog_bit+8, 8);
+			break;
+       		case 2 :
+			HID_GAMEPAD_Data[device].x = (int16_t)extract(data, gp->analog_bit, 8) - 127;
+			HID_GAMEPAD_Data[device].y = (int16_t)extract(data, gp->analog_bit+8, 8) - 127;
+			break;
+		case 0 :
+		default:
+			val = (HID_GAMEPAD_Data[device].button >> gamepad_right) & 0x0F;
+			HID_GAMEPAD_Data[device].x = dig_to_analog[val][0];
+			HID_GAMEPAD_Data[device].y = dig_to_analog[val][1];
+			break;
+	}
+
+        if (gp->dpad_type == 0) {
+          if (HID_GAMEPAD_Data[device].x >= 63) {
+            HID_GAMEPAD_Data[device].button |= 1 << gamepad_right;
+          } else if (HID_GAMEPAD_Data[device].x <= -63) {
+            HID_GAMEPAD_Data[device].button |= 1 << gamepad_left;
+          }
+          
+          if (HID_GAMEPAD_Data[device].y >= 63) {
+            HID_GAMEPAD_Data[device].button |= 1 << gamepad_up;
+          } else if (HID_GAMEPAD_Data[device].y <= -63) {
+            HID_GAMEPAD_Data[device].button |= 1 << gamepad_down;
+          }     
+        }
+
+    // Comment this line to get accurate timing of the parser, this only lits leds:
+    // USR_GAMEPAD_ProcessData(&HID_GAMEPAD_Data[device]);
+
+}
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+
+/**
+  * @}
+  */
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/src/lib/usbh_hid_gamepad.h
+++ b/src/lib/usbh_hid_gamepad.h
@@ -1,0 +1,137 @@
+/**
+  ******************************************************************************
+  * @file    usbh_hid_gamepad.h 
+  * @author  MCD Application Team
+  * @version V2.1.0
+  * @date    19-March-2012
+  * @brief   This file contains all the prototypes for the usbh_hid_mouse.c
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT 2012 STMicroelectronics</center></h2>
+  *
+  * Licensed under MCD-ST Liberty SW License Agreement V2, (the "License");
+  * You may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at:
+  *
+  *        http://www.st.com/software_license_agreement_liberty_v2
+  *
+  * Unless required by applicable law or agreed to in writing, software 
+  * distributed under the License is distributed on an "AS IS" BASIS, 
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  *
+  ******************************************************************************
+  */ 
+
+
+/* Define to prevent recursive  ----------------------------------------------*/
+#ifndef __USBH_HID_GAMEPAD_H
+#define __USBH_HID_GAMEPAD_H
+
+/* Includes ------------------------------------------------------------------*/
+#include "usbh_hid_core.h"
+#include "gamepad.h"
+
+/** @addtogroup USBH_LIB
+  * @{
+  */
+
+/** @addtogroup USBH_CLASS
+  * @{
+  */
+
+/** @addtogroup USBH_HID_CLASS
+  * @{
+  */
+
+/** @defgroup USBH_HID_GAMEPAD
+  * @brief This file is the Header file for USBH_HID_GAMEPAD.c
+  * @{
+  */ 
+
+
+/** @defgroup USBH_HID_GAMEPAD_Exported_Types
+  * @{
+  */ 
+/*
+typedef enum {
+    gamepad_B=11,
+    gamepad_Y=10,
+    gamepad_select=9,
+    gamepad_start=8,
+    gamepad_up=7,
+    gamepad_down=6,
+    gamepad_left=5,
+    gamepad_right=4,
+    gamepad_A=3,
+    gamepad_X=2,
+    gamepad_L=1,
+    gamepad_R=0,
+    gamepad_MAX=12,
+} Gamepad;
+*/
+typedef struct _HID_GAMEPAD_Data
+{
+  uint8_t              x; 
+  uint8_t              y;
+  uint16_t             button; 
+}
+HID_GAMEPAD_Data_TypeDef;
+
+/**
+  * @}
+  */ 
+
+/** @defgroup USBH_HID_GAMEPAD_Exported_Defines
+  * @{
+  */ 
+/**
+  * @}
+  */ 
+
+/** @defgroup USBH_HID_GAMEPAD_Exported_Macros
+  * @{
+  */ 
+/**
+  * @}
+  */ 
+
+/** @defgroup USBH_HID_GAMEPAD_Exported_Variables
+  * @{
+  */ 
+
+extern HID_cb_TypeDef HID_GAMEPAD_cb;
+extern HID_GAMEPAD_Data_TypeDef	 HID_GAMEPAD_Data[];
+/**
+  * @}
+  */ 
+
+/** @defgroup USBH_HID_GAMEPAD_Exported_FunctionsPrototype
+  * @{
+  */ 
+void  USR_GAMEPAD_Init (void);
+void  USR_GAMEPAD_ProcessData (HID_GAMEPAD_Data_TypeDef *data);
+/**
+  * @}
+  */ 
+
+#endif /* __USBH_HID_GAMEPAD_H */
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/src/lib/usbh_hid_keybd.c
+++ b/src/lib/usbh_hid_keybd.c
@@ -1,0 +1,351 @@
+/**
+  ******************************************************************************
+  * @file    usbh_hid_keybd.c 
+  * @author  MCD Application Team
+  * @version V2.1.0
+  * @date    19-March-2012
+  * @brief   This file is the application layer for USB Host HID Keyboard handling
+  *          QWERTY and AZERTY Keyboard are supported as per the selection in 
+  *          usbh_hid_keybd.h              
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT 2012 STMicroelectronics</center></h2>
+  *
+  * Licensed under MCD-ST Liberty SW License Agreement V2, (the "License");
+  * You may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at:
+  *
+  *        http://www.st.com/software_license_agreement_liberty_v2
+  *
+  * Unless required by applicable law or agreed to in writing, software 
+  * distributed under the License is distributed on an "AS IS" BASIS, 
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  *
+  ******************************************************************************
+  */ 
+
+
+/* Includes ------------------------------------------------------------------*/
+#include "usbh_hid_keybd.h"
+
+/** @addtogroup USBH_LIB
+* @{
+*/
+
+/** @addtogroup USBH_CLASS
+* @{
+*/
+
+/** @addtogroup USBH_HID_CLASS
+* @{
+*/
+
+/** @defgroup USBH_HID_KEYBD 
+* @brief    This file includes HID Layer Handlers for USB Host HID class.
+* @{
+*/ 
+
+/** @defgroup USBH_HID_KEYBD_Private_TypesDefinitions
+* @{
+*/ 
+/**
+* @}
+*/ 
+
+
+/** @defgroup USBH_HID_KEYBD_Private_Defines
+* @{
+*/ 
+/**
+* @}
+*/ 
+
+
+/** @defgroup USBH_HID_KEYBD_Private_Macros
+* @{
+*/ 
+/**
+* @}
+*/ 
+
+/** @defgroup USBH_HID_KEYBD_Private_FunctionPrototypes
+* @{
+*/ 
+static int  KEYBRD_Detect (uint16_t,uint16_t);
+static void  KEYBRD_Init (uint8_t,uint16_t,uint16_t);
+static void  KEYBRD_Decode(uint8_t,uint8_t *data);
+
+/**
+* @}
+*/ 
+
+#ifdef USB_OTG_HS_INTERNAL_DMA_ENABLED
+ #if defined   (__CC_ARM) /*!< ARM Compiler */
+  __align(4) 
+ #elif defined ( __ICCARM__ ) /*!< IAR Compiler */
+  #pragma data_alignment=4
+ #elif defined (__GNUC__) /*!< GNU Compiler */
+ #pragma pack(4) 
+ #elif defined  (__TASKING__) /*!< TASKING Compiler */                           
+  __align(4) 
+ #endif /* __CC_ARM */
+#endif
+ 
+/** @defgroup USBH_HID_KEYBD_Private_Variables
+* @{
+*/
+HID_cb_TypeDef HID_KEYBRD_cb= 
+{
+  KEYBRD_Detect,
+  KEYBRD_Init,
+  KEYBRD_Decode
+};
+
+/*
+*******************************************************************************
+*                                             LOCAL CONSTANTS
+*******************************************************************************
+*/
+
+static  const  uint8_t  HID_KEYBRD_Codes[] = {
+  0,     0,    0,    0,   31,   50,   48,   33, 
+  19,   34,   35,   36,   24,   37,   38,   39,       /* 0x00 - 0x0F */
+  52,    51,   25,   26,   17,   20,   32,   21,
+  23,   49,   18,   47,   22,   46,    2,    3,       /* 0x10 - 0x1F */
+  4,    5,    6,    7,    8,    9,   10,   11, 
+  43,  110,   15,   16,   61,   12,   13,   27,       /* 0x20 - 0x2F */
+  28,   29,   42,   40,   41,    1,   53,   54,  
+  55,   30,  112,  113,  114,  115,  116,  117,       /* 0x30 - 0x3F */
+  118,  119,  120,  121,  122,  123,  124,  125,  
+  126,   75,   80,   85,   76,   81,   86,   89,       /* 0x40 - 0x4F */
+  79,   84,   83,   90,   95,  100,  105,  106,
+  108,   93,   98,  103,   92,   97,  102,   91,       /* 0x50 - 0x5F */
+  96,  101,   99,  104,   45,  129,    0,    0, 
+  0,    0,    0,    0,    0,    0,    0,    0,       /* 0x60 - 0x6F */
+  0,    0,    0,    0,    0,    0,    0,    0,
+  0,    0,    0,    0,    0,    0,    0,    0,       /* 0x70 - 0x7F */
+  0,    0,    0,    0,    0,  107,    0,   56,
+  0,    0,    0,    0,    0,    0,    0,    0,       /* 0x80 - 0x8F */
+  0,    0,    0,    0,    0,    0,    0,    0,
+  0,    0,    0,    0,    0,    0,    0,    0,       /* 0x90 - 0x9F */
+  0,    0,    0,    0,    0,    0,    0,    0,
+  0,    0,    0,    0,    0,    0,    0,    0,       /* 0xA0 - 0xAF */
+  0,    0,    0,    0,    0,    0,    0,    0, 
+  0,    0,    0,    0,    0,    0,    0,    0,       /* 0xB0 - 0xBF */
+  0,    0,    0,    0,    0,    0,    0,    0, 
+  0,    0,    0,    0,    0,    0,    0,    0,       /* 0xC0 - 0xCF */
+  0,    0,    0,    0,    0,    0,    0,    0, 
+  0,    0,    0,    0,    0,    0,    0,    0,       /* 0xD0 - 0xDF */
+  58,   44,   60,  127,   64,   57,   62,  128        /* 0xE0 - 0xE7 */
+};
+
+#ifdef QWERTY_KEYBOARD
+static  const  int8_t  HID_KEYBRD_Key[] = {
+  '\0',  '`',  '1',  '2',  '3',  '4',  '5',  '6',
+  '7',  '8',  '9',  '0',  '-',  '=',  '\0', '\r',
+  '\t',  'q',  'w',  'e',  'r',  't',  'y',  'u', 
+  'i',  'o',  'p',  '[',  ']',  '\\',
+  '\0',  'a',  's',  'd',  'f',  'g',  'h',  'j',  
+  'k',  'l',  ';',  '\'', '\0', '\n',
+  '\0',  '\0', 'z',  'x',  'c',  'v',  'b',  'n', 
+  'm',  ',',  '.',  '/',  '\0', '\0',
+  '\0',  '\0', '\0', ' ',  '\0', '\0', '\0', '\0', 
+  '\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0',
+  '\0',  '\0', '\0', '\0', '\0', '\r', '\0', '\0', 
+  '\0', '\0', '\0', '\0', '\0', '\0',
+  '\0',  '\0', '7',  '4',  '1',
+  '\0',  '/',  '8',  '5',  '2',
+  '0',   '*',  '9',  '6',  '3',
+  '.',   '-',  '+',  '\0', '\n', '\0', '\0', '\0', '\0', '\0', '\0',
+  '\0',  '\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0', 
+  '\0', '\0', '\0', '\0'
+};
+
+static  const  int8_t  HID_KEYBRD_ShiftKey[] = {
+  '\0', '~',  '!',  '@',  '#',  '$',  '%',  '^',  '&',  '*',  '(',  ')',
+  '_',  '+',  '\0', '\0', '\0', 'Q',  'W',  'E',  'R',  'T',  'Y',  'U', 
+  'I',  'O',  'P',  '{',  '}',  '|',  '\0', 'A',  'S',  'D',  'F',  'G', 
+  'H',  'J',  'K',  'L',  ':',  '"',  '\0', '\n', '\0', '\0', 'Z',  'X',  
+  'C',  'V',  'B',  'N',  'M',  '<',  '>',  '?',  '\0', '\0',  '\0', '\0',
+  '\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0', 
+  '\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0',
+  '\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0', 
+  '\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0',
+  '\0', '\0', '\0', '\0', '\0', '\0', '\0',    '\0', '\0', '\0', '\0', '\0',
+  '\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0'
+};
+
+#else
+
+static  const  int8_t  HID_KEYBRD_Key[] = {
+  '\0',  '`',  '1',  '2',  '3',  '4',  '5',  '6',  '7',  '8',  '9',  '0',
+  '-',  '=',  '\0', '\r', '\t',  'a',  'z',  'e',  'r',  't',  'y',  'u', 
+  'i',  'o',  'p',  '[',  ']', '\\', '\0',  'q',  's',  'd',  'f',  'g', 
+  'h',  'j',  'k',  'l',  'm',  '\0', '\0', '\n', '\0',  '\0', 'w',  'x', 
+  'c',  'v',  'b',  'n',  ',',  ';',  ':',  '!',  '\0', '\0', '\0',  '\0', 
+  '\0', ' ',  '\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0', 
+  '\0', '\0', '\0', '\0',  '\0', '\0', '\0', '\0', '\r', '\0', '\0', '\0', 
+  '\0', '\0', '\0', '\0', '\0', '\0',  '\0', '7',  '4',  '1','\0',  '/', 
+  '8',  '5',  '2', '0',   '*',  '9',  '6',  '3', '.',   '-',  '+',  '\0', 
+  '\n', '\0', '\0', '\0', '\0', '\0', '\0','\0',  '\0', '\0', '\0', '\0', '\0',
+  '\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0'
+};
+
+static  const  int8_t  HID_KEYBRD_ShiftKey[] = {
+  '\0', '~',  '!',  '@',  '#',  '$',  '%',  '^',  '&',  '*',  '(',  ')',  '_',
+  '+',  '\0', '\0', '\0', 'A',  'Z',  'E',  'R',  'T',  'Y',  'U',  'I',  'O',
+  'P',  '{',  '}',  '*', '\0', 'Q',  'S',  'D',  'F',  'G',  'H',  'J',  'K', 
+  'L',  'M',  '%',  '\0', '\n', '\0', '\0', 'W',  'X',  'C',  'V',  'B',  'N',
+  '?',  '.',  '/',  '\0',  '\0', '\0','\0', '\0', '\0', '\0', '\0', '\0', '\0', 
+  '\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0',
+  '\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0',
+  '\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0',
+  '\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0', 
+  '\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0'
+};
+#endif
+
+/**
+* @}
+*/ 
+
+
+/** @defgroup USBH_HID_KEYBD_Private_Functions
+* @{
+*/ 
+static int  KEYBRD_Detect (uint16_t vid, uint16_t pid)
+{
+  return 1;
+}
+
+/**
+* @brief  KEYBRD_Init.
+*         Initialize the keyboard function.
+* @param  None
+* @retval None
+*/
+static void  KEYBRD_Init (uint8_t coreID, uint16_t vid, uint16_t pid)
+{
+  /* Call User Init*/
+  // USR_KEYBRD_Init();
+}
+
+/**
+* @brief  KEYBRD_ProcessData.
+*         The function is to decode the pressed keys.
+* @param  pbuf : Pointer to the HID IN report data buffer
+* @retval None
+*/
+
+static void KEYBRD_Decode(uint8_t coreID, uint8_t *pbuf)
+{
+  static  uint8_t   shift;
+  static  uint8_t   keys[KBR_MAX_NBR_PRESSED];
+  static  uint8_t   keys_new[KBR_MAX_NBR_PRESSED];
+  static  uint8_t   keys_last[KBR_MAX_NBR_PRESSED];
+  static  uint8_t   key_newest;
+  static  uint8_t   nbr_keys;
+  static  uint8_t   nbr_keys_new;
+  static  uint8_t   nbr_keys_last;
+  uint8_t   ix;
+  uint8_t   jx;
+  uint8_t   error;
+  uint8_t   output;            
+  
+  // STM_EVAL_LEDToggle(LED_Orange);  // added by "STM32"
+  
+  nbr_keys      = 0;
+  nbr_keys_new  = 0;
+  nbr_keys_last = 0;
+  key_newest    = 0x00;
+  
+  
+  /* Check if Shift key is pressed */                                                                         
+  if ((pbuf[0] == KBD_LEFT_SHIFT) || (pbuf[0] == KBD_RIGHT_SHIFT)) {
+    shift = TRUE;
+  } else {
+    shift = FALSE;
+  }
+  
+  error = FALSE;
+  
+  /* Check for the value of pressed key */
+  for (ix = 2; ix < 2 + KBR_MAX_NBR_PRESSED; ix++) {                       
+    if ((pbuf[ix] == 0x01) ||
+        (pbuf[ix] == 0x02) ||
+          (pbuf[ix] == 0x03)) {
+            error = TRUE;
+          }
+  }
+  
+  if (error == TRUE) {
+    return;
+  }
+  
+  nbr_keys     = 0;
+  nbr_keys_new = 0;
+  for (ix = 2; ix < 2 + KBR_MAX_NBR_PRESSED; ix++) {
+    if (pbuf[ix] != 0) {
+      keys[nbr_keys] = pbuf[ix];                                       
+      nbr_keys++;
+      for (jx = 0; jx < nbr_keys_last; jx++) {                         
+        if (pbuf[ix] == keys_last[jx]) {
+          break;
+        }
+      }
+      
+      if (jx == nbr_keys_last) {
+        keys_new[nbr_keys_new] = pbuf[ix];
+        nbr_keys_new++;
+      }
+    }
+  }
+  
+  if (nbr_keys_new == 1) {
+    key_newest = keys_new[0];
+    
+    if (shift == TRUE) {
+      output =  HID_KEYBRD_ShiftKey[HID_KEYBRD_Codes[key_newest]];
+    } else {
+      output =  HID_KEYBRD_Key[HID_KEYBRD_Codes[key_newest]];
+    }
+    
+    /* call user process handle */
+    // USR_KEYBRD_ProcessData(output);
+  } else {
+    key_newest = 0x00;
+  }
+  
+  
+  nbr_keys_last  = nbr_keys;
+  for (ix = 0; ix < KBR_MAX_NBR_PRESSED; ix++) {
+    keys_last[ix] = keys[ix];
+  }
+}
+
+/**
+* @}
+*/ 
+
+/**
+* @}
+*/ 
+
+/**
+* @}
+*/
+
+/**
+* @}
+*/
+
+
+/**
+* @}
+*/
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
+

--- a/src/lib/usbh_hid_keybd.h
+++ b/src/lib/usbh_hid_keybd.h
@@ -1,0 +1,128 @@
+/**
+  ******************************************************************************
+  * @file    usbh_hid_keybd.h
+  * @author  MCD Application Team
+  * @version V2.1.0
+  * @date    19-March-2012
+  * @brief   This file contains all the prototypes for the usbh_hid_keybd.c
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT 2012 STMicroelectronics</center></h2>
+  *
+  * Licensed under MCD-ST Liberty SW License Agreement V2, (the "License");
+  * You may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at:
+  *
+  *        http://www.st.com/software_license_agreement_liberty_v2
+  *
+  * Unless required by applicable law or agreed to in writing, software 
+  * distributed under the License is distributed on an "AS IS" BASIS, 
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive -----------------------------------------------*/
+#ifndef __USBH_HID_KEYBD_H
+#define __USBH_HID_KEYBD_H
+
+/* Includes ------------------------------------------------------------------*/
+#include "usb_conf.h"
+#include "usbh_hid_core.h"
+
+/** @addtogroup USBH_LIB
+  * @{
+  */
+
+/** @addtogroup USBH_CLASS
+  * @{
+  */
+
+/** @addtogroup USBH_HID_CLASS
+  * @{
+  */
+  
+/** @defgroup USBH_HID_KEYBD
+  * @brief This file is the Header file for USBH_HID_KEYBD.c
+  * @{
+  */ 
+
+
+/** @defgroup USBH_HID_KEYBD_Exported_Types
+  * @{
+  */ 
+
+
+/**
+  * @}
+  */ 
+
+/** @defgroup USBH_HID_KEYBD_Exported_Defines
+  * @{
+  */ 
+//#define QWERTY_KEYBOARD
+#define AZERTY_KEYBOARD
+
+#define  KBD_LEFT_CTRL                                  0x01
+#define  KBD_LEFT_SHIFT                                 0x02
+#define  KBD_LEFT_ALT                                   0x04
+#define  KBD_LEFT_GUI                                   0x08
+#define  KBD_RIGHT_CTRL                                 0x10
+#define  KBD_RIGHT_SHIFT                                0x20
+#define  KBD_RIGHT_ALT                                  0x40
+#define  KBD_RIGHT_GUI                                  0x80
+
+#define  KBR_MAX_NBR_PRESSED                            6
+
+/**
+  * @}
+  */ 
+
+/** @defgroup USBH_HID_KEYBD_Exported_Macros
+  * @{
+  */ 
+/**
+  * @}
+  */ 
+
+/** @defgroup USBH_HID_KEYBD_Exported_Variables
+  * @{
+  */ 
+
+extern HID_cb_TypeDef HID_KEYBRD_cb;
+/**
+  * @}
+  */ 
+
+/** @defgroup USBH_HID_KEYBD_Exported_FunctionsPrototype
+  * @{
+  */ 
+void  USR_KEYBRD_Init (void);
+void  USR_KEYBRD_ProcessData (uint8_t pbuf);
+/**
+  * @}
+  */ 
+
+#endif /* __USBH_HID_KEYBD_H */
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
+

--- a/src/lib/usbh_hid_mouse.c
+++ b/src/lib/usbh_hid_mouse.c
@@ -1,0 +1,184 @@
+/**
+  ******************************************************************************
+  * @file    usbh_hid_mouse.c 
+  * @author  MCD Application Team
+  * @version V2.1.0
+  * @date    19-March-2012
+  * @brief   This file is the application layer for USB Host HID Mouse Handling.                  
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT 2012 STMicroelectronics</center></h2>
+  *
+  * Licensed under MCD-ST Liberty SW License Agreement V2, (the "License");
+  * You may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at:
+  *
+  *        http://www.st.com/software_license_agreement_liberty_v2
+  *
+  * Unless required by applicable law or agreed to in writing, software 
+  * distributed under the License is distributed on an "AS IS" BASIS, 
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  *
+  ******************************************************************************
+  */ 
+
+/* Includes ------------------------------------------------------------------*/
+#include "usbh_hid_mouse.h"
+
+
+/** @addtogroup USBH_LIB
+  * @{
+  */
+
+/** @addtogroup USBH_CLASS
+  * @{
+  */
+
+/** @addtogroup USBH_HID_CLASS
+  * @{
+  */
+  
+/** @defgroup USBH_HID_MOUSE 
+  * @brief    This file includes HID Layer Handlers for USB Host HID class.
+  * @{
+  */ 
+
+/** @defgroup USBH_HID_MOUSE_Private_TypesDefinitions
+  * @{
+  */ 
+/**
+  * @}
+  */ 
+
+
+/** @defgroup USBH_HID_MOUSE_Private_Defines
+  * @{
+  */ 
+/**
+  * @}
+  */ 
+
+
+/** @defgroup USBH_HID_MOUSE_Private_Macros
+  * @{
+  */ 
+/**
+  * @}
+  */ 
+
+/** @defgroup USBH_HID_MOUSE_Private_FunctionPrototypes
+  * @{
+  */ 
+static int MOUSE_Detect (uint16_t, uint16_t);
+static void  MOUSE_Init (uint8_t, uint16_t, uint16_t);
+static void  MOUSE_Decode(uint8_t, uint8_t *data);
+/**
+  * @}
+  */ 
+
+
+/** @defgroup USBH_HID_MOUSE_Private_Variables
+  * @{
+  */
+#ifdef USB_OTG_HS_INTERNAL_DMA_ENABLED
+ #if defined   (__CC_ARM) /*!< ARM Compiler */
+  __align(4) 
+ #elif defined ( __ICCARM__ ) /*!< IAR Compiler */
+  #pragma data_alignment=4
+ #elif defined (__GNUC__) /*!< GNU Compiler */
+ #pragma pack(4) 
+ #elif defined  (__TASKING__) /*!< TASKING Compiler */                           
+  __align(4) 
+ #endif /* __CC_ARM */
+#endif
+ 
+    
+/////////////////////////////////
+volatile uint8_t data_mouse_x = 0;
+volatile uint8_t  data_mouse_y = 0;
+volatile uint8_t  data_mouse_buttons = 0;
+/////////////////////////////////    
+ 
+HID_MOUSE_Data_TypeDef HID_MOUSE_Data;
+HID_cb_TypeDef HID_MOUSE_cb = 
+{
+  MOUSE_Detect,
+  MOUSE_Init,
+  MOUSE_Decode,
+};
+/**
+  * @}
+  */ 
+
+
+/** @defgroup USBH_HID_MOUSE_Private_Functions
+  * @{
+  */ 
+
+static int MOUSE_Detect (uint16_t vid,uint16_t pid)
+{
+ /* Call User Init*/
+ return 1;
+}
+/**
+* @brief  MOUSE_Init
+*         Init Mouse State.
+* @param  None
+* @retval None
+*/
+static void  MOUSE_Init (uint8_t coreID, uint16_t vid, uint16_t pid)
+{
+ /* Call User Init*/
+ // USR_MOUSE_Init();
+}
+            
+/**
+* @brief  MOUSE_Decode
+*         Decode Mouse data
+* @param  data : Pointer to Mouse HID data buffer
+* @retval None
+*/
+static void  MOUSE_Decode(uint8_t coreID, uint8_t *data)
+{
+  HID_MOUSE_Data.button = data[0];
+
+  HID_MOUSE_Data.x      = data[1];
+  HID_MOUSE_Data.y      = data[2];
+  
+//////////////////////////////////////////  added by "STM32"
+  data_mouse_x = HID_MOUSE_Data.y;
+  data_mouse_y = HID_MOUSE_Data.x;
+  
+  if(HID_MOUSE_Data.button != 0)
+  {
+    data_mouse_buttons = HID_MOUSE_Data.button;  
+  }
+////////////////////////////////
+  
+  // USR_MOUSE_ProcessData(&HID_MOUSE_Data);
+
+}
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+
+/**
+  * @}
+  */
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/src/lib/usbh_hid_mouse.h
+++ b/src/lib/usbh_hid_mouse.h
@@ -1,0 +1,120 @@
+/**
+  ******************************************************************************
+  * @file    usbh_hid_mouse.h 
+  * @author  MCD Application Team
+  * @version V2.1.0
+  * @date    19-March-2012
+  * @brief   This file contains all the prototypes for the usbh_hid_mouse.c
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT 2012 STMicroelectronics</center></h2>
+  *
+  * Licensed under MCD-ST Liberty SW License Agreement V2, (the "License");
+  * You may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at:
+  *
+  *        http://www.st.com/software_license_agreement_liberty_v2
+  *
+  * Unless required by applicable law or agreed to in writing, software 
+  * distributed under the License is distributed on an "AS IS" BASIS, 
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  *
+  ******************************************************************************
+  */ 
+
+
+/* Define to prevent recursive  ----------------------------------------------*/
+#ifndef __USBH_HID_MOUSE_H
+#define __USBH_HID_MOUSE_H
+
+/* Includes ------------------------------------------------------------------*/
+#include "usbh_hid_core.h"
+
+/** @addtogroup USBH_LIB
+  * @{
+  */
+
+/** @addtogroup USBH_CLASS
+  * @{
+  */
+
+/** @addtogroup USBH_HID_CLASS
+  * @{
+  */
+
+/** @defgroup USBH_HID_MOUSE
+  * @brief This file is the Header file for USBH_HID_MOUSE.c
+  * @{
+  */ 
+
+
+/** @defgroup USBH_HID_MOUSE_Exported_Types
+  * @{
+  */ 
+typedef struct _HID_MOUSE_Data
+{
+  uint8_t              x; 
+  uint8_t              y;
+  uint8_t              z;               /* Not Supported */ 
+  uint8_t              button; 
+}
+HID_MOUSE_Data_TypeDef;
+
+/**
+  * @}
+  */ 
+
+/** @defgroup USBH_HID_MOUSE_Exported_Defines
+  * @{
+  */ 
+/**
+  * @}
+  */ 
+
+/** @defgroup USBH_HID_MOUSE_Exported_Macros
+  * @{
+  */ 
+/**
+  * @}
+  */ 
+
+/** @defgroup USBH_HID_MOUSE_Exported_Variables
+  * @{
+  */ 
+
+extern HID_cb_TypeDef HID_MOUSE_cb;
+extern HID_MOUSE_Data_TypeDef	 HID_MOUSE_Data;
+/**
+  * @}
+  */ 
+
+/** @defgroup USBH_HID_MOUSE_Exported_FunctionsPrototype
+  * @{
+  */ 
+void  USR_MOUSE_Init (void);
+void  USR_MOUSE_ProcessData (HID_MOUSE_Data_TypeDef *data);
+/**
+  * @}
+  */ 
+
+#endif /* __USBH_HID_MOUSE_H */
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/src/lib/usbh_ioreq.c
+++ b/src/lib/usbh_ioreq.c
@@ -1,0 +1,474 @@
+/** 
+  ******************************************************************************
+  * @file    usbh_ioreq.c 
+  * @author  MCD Application Team
+  * @version V2.1.0
+  * @date    19-March-2012
+  * @brief   This file handles the issuing of the USB transactions
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT 2012 STMicroelectronics</center></h2>
+  *
+  * Licensed under MCD-ST Liberty SW License Agreement V2, (the "License");
+  * You may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at:
+  *
+  *        http://www.st.com/software_license_agreement_liberty_v2
+  *
+  * Unless required by applicable law or agreed to in writing, software 
+  * distributed under the License is distributed on an "AS IS" BASIS, 
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  *
+  ******************************************************************************
+  */ 
+/* Includes ------------------------------------------------------------------*/
+
+#include "usbh_ioreq.h"
+
+/** @addtogroup USBH_LIB
+  * @{
+  */
+
+/** @addtogroup USBH_LIB_CORE
+* @{
+*/
+  
+/** @defgroup USBH_IOREQ 
+  * @brief This file handles the standard protocol processing (USB v2.0)
+  * @{
+  */
+
+
+/** @defgroup USBH_IOREQ_Private_Defines
+  * @{
+  */ 
+/**
+  * @}
+  */ 
+ 
+
+/** @defgroup USBH_IOREQ_Private_TypesDefinitions
+  * @{
+  */ 
+/**
+  * @}
+  */ 
+
+
+
+/** @defgroup USBH_IOREQ_Private_Macros
+  * @{
+  */ 
+/**
+  * @}
+  */ 
+
+
+/** @defgroup USBH_IOREQ_Private_Variables
+  * @{
+  */ 
+/**
+  * @}
+  */ 
+
+
+/** @defgroup USBH_IOREQ_Private_FunctionPrototypes
+  * @{
+  */ 
+static USBH_Status USBH_SubmitSetupRequest(USBH_HOST *phost,
+                                           uint8_t* buff, 
+                                           uint16_t length);
+
+/**
+  * @}
+  */ 
+
+
+/** @defgroup USBH_IOREQ_Private_Functions
+  * @{
+  */ 
+
+
+/**
+  * @brief  USBH_CtlReq
+  *         USBH_CtlReq sends a control request and provide the status after 
+  *            completion of the request
+  * @param  pdev: Selected device
+  * @param  req: Setup Request Structure
+  * @param  buff: data buffer address to store the response
+  * @param  length: length of the response
+  * @retval Status
+  */
+USBH_Status USBH_CtlReq     (USB_OTG_CORE_HANDLE *pdev, 
+                             USBH_HOST           *phost, 
+                             uint8_t             *buff,
+                             uint16_t            length)
+{
+  USBH_Status status;
+  status = USBH_BUSY;
+  
+  switch (phost->RequestState)
+  {
+  case CMD_SEND:
+    /* Start a SETUP transfer */
+    USBH_SubmitSetupRequest(phost, buff, length);
+    phost->RequestState = CMD_WAIT;
+    status = USBH_BUSY;
+    break;
+    
+  case CMD_WAIT:
+     if (phost->Control.state == CTRL_COMPLETE ) 
+    {
+      /* Commands successfully sent and Response Received  */       
+      phost->RequestState = CMD_SEND;
+      phost->Control.state =CTRL_IDLE;  
+      status = USBH_OK;      
+    }
+    else if  (phost->Control.state == CTRL_ERROR)
+    {
+      /* Failure Mode */
+      phost->RequestState = CMD_SEND;
+      status = USBH_FAIL;
+    }   
+     else if  (phost->Control.state == CTRL_STALLED )
+    {
+      /* Commands successfully sent and Response Received  */       
+      phost->RequestState = CMD_SEND;
+      status = USBH_NOT_SUPPORTED;
+    }
+    break;
+    
+  default:
+    break; 
+  }
+  return status;
+}
+
+/**
+  * @brief  USBH_CtlSendSetup
+  *         Sends the Setup Packet to the Device
+  * @param  pdev: Selected device
+  * @param  buff: Buffer pointer from which the Data will be send to Device
+  * @param  hc_num: Host channel Number
+  * @retval Status
+  */
+USBH_Status USBH_CtlSendSetup ( USB_OTG_CORE_HANDLE *pdev, 
+                                uint8_t *buff, 
+                                uint8_t hc_num){
+  pdev->host.hc[hc_num].ep_is_in = 0;
+  pdev->host.hc[hc_num].data_pid = HC_PID_SETUP;   
+  pdev->host.hc[hc_num].xfer_buff = buff;
+  pdev->host.hc[hc_num].xfer_len = USBH_SETUP_PKT_SIZE;   
+
+  return (USBH_Status)HCD_SubmitRequest (pdev , hc_num);   
+}
+
+
+/**
+  * @brief  USBH_CtlSendData
+  *         Sends a data Packet to the Device
+  * @param  pdev: Selected device
+  * @param  buff: Buffer pointer from which the Data will be sent to Device
+  * @param  length: Length of the data to be sent
+  * @param  hc_num: Host channel Number
+  * @retval Status
+  */
+USBH_Status USBH_CtlSendData ( USB_OTG_CORE_HANDLE *pdev, 
+                                uint8_t *buff, 
+                                uint16_t length,
+                                uint8_t hc_num)
+{
+  pdev->host.hc[hc_num].ep_is_in = 0;
+  pdev->host.hc[hc_num].xfer_buff = buff;
+  pdev->host.hc[hc_num].xfer_len = length;
+ 
+  if ( length == 0 )
+  { /* For Status OUT stage, Length==0, Status Out PID = 1 */
+    pdev->host.hc[hc_num].toggle_out = 1;   
+  }
+ 
+ /* Set the Data Toggle bit as per the Flag */
+  if ( pdev->host.hc[hc_num].toggle_out == 0)
+  { /* Put the PID 0 */
+      pdev->host.hc[hc_num].data_pid = HC_PID_DATA0;    
+  }
+ else
+ { /* Put the PID 1 */
+      pdev->host.hc[hc_num].data_pid = HC_PID_DATA1 ;
+ }
+
+  HCD_SubmitRequest (pdev , hc_num);   
+   
+  return USBH_OK;
+}
+
+
+/**
+  * @brief  USBH_CtlReceiveData
+  *         Receives the Device Response to the Setup Packet
+  * @param  pdev: Selected device
+  * @param  buff: Buffer pointer in which the response needs to be copied
+  * @param  length: Length of the data to be received
+  * @param  hc_num: Host channel Number
+  * @retval Status. 
+  */
+USBH_Status USBH_CtlReceiveData(USB_OTG_CORE_HANDLE *pdev, 
+                                uint8_t* buff, 
+                                uint16_t length,
+                                uint8_t hc_num)
+{
+
+  pdev->host.hc[hc_num].ep_is_in = 1;
+  pdev->host.hc[hc_num].data_pid = HC_PID_DATA1;
+  pdev->host.hc[hc_num].xfer_buff = buff;
+  pdev->host.hc[hc_num].xfer_len = length;  
+
+  HCD_SubmitRequest (pdev , hc_num);   
+  
+  return USBH_OK;
+  
+}
+
+
+/**
+  * @brief  USBH_BulkSendData
+  *         Sends the Bulk Packet to the device
+  * @param  pdev: Selected device
+  * @param  buff: Buffer pointer from which the Data will be sent to Device
+  * @param  length: Length of the data to be sent
+  * @param  hc_num: Host channel Number
+  * @retval Status
+  */
+USBH_Status USBH_BulkSendData ( USB_OTG_CORE_HANDLE *pdev, 
+                                uint8_t *buff, 
+                                uint16_t length,
+                                uint8_t hc_num)
+{ 
+  pdev->host.hc[hc_num].ep_is_in = 0;
+  pdev->host.hc[hc_num].xfer_buff = buff;
+  pdev->host.hc[hc_num].xfer_len = length;  
+
+ /* Set the Data Toggle bit as per the Flag */
+  if ( pdev->host.hc[hc_num].toggle_out == 0)
+  { /* Put the PID 0 */
+      pdev->host.hc[hc_num].data_pid = HC_PID_DATA0;    
+  }
+ else
+ { /* Put the PID 1 */
+      pdev->host.hc[hc_num].data_pid = HC_PID_DATA1 ;
+ }
+
+  HCD_SubmitRequest (pdev , hc_num);   
+  return USBH_OK;
+}
+
+
+/**
+  * @brief  USBH_BulkReceiveData
+  *         Receives IN bulk packet from device
+  * @param  pdev: Selected device
+  * @param  buff: Buffer pointer in which the received data packet to be copied
+  * @param  length: Length of the data to be received
+  * @param  hc_num: Host channel Number
+  * @retval Status. 
+  */
+USBH_Status USBH_BulkReceiveData( USB_OTG_CORE_HANDLE *pdev, 
+                                uint8_t *buff, 
+                                uint16_t length,
+                                uint8_t hc_num)
+{
+  pdev->host.hc[hc_num].ep_is_in = 1;   
+  pdev->host.hc[hc_num].xfer_buff = buff;
+  pdev->host.hc[hc_num].xfer_len = length;
+  
+
+  if( pdev->host.hc[hc_num].toggle_in == 0)
+  {
+    pdev->host.hc[hc_num].data_pid = HC_PID_DATA0;
+  }
+  else
+  {
+    pdev->host.hc[hc_num].data_pid = HC_PID_DATA1;
+  }
+
+  HCD_SubmitRequest (pdev , hc_num);  
+  return USBH_OK;
+}
+
+
+/**
+  * @brief  USBH_InterruptReceiveData
+  *         Receives the Device Response to the Interrupt IN token
+  * @param  pdev: Selected device
+  * @param  buff: Buffer pointer in which the response needs to be copied
+  * @param  length: Length of the data to be received
+  * @param  hc_num: Host channel Number
+  * @retval Status. 
+  */
+USBH_Status USBH_InterruptReceiveData( USB_OTG_CORE_HANDLE *pdev, 
+                                uint8_t *buff, 
+                                uint8_t length,
+                                uint8_t hc_num)
+{
+
+  pdev->host.hc[hc_num].ep_is_in = 1;  
+  pdev->host.hc[hc_num].xfer_buff = buff;
+  pdev->host.hc[hc_num].xfer_len = length;
+  
+
+  
+  if(pdev->host.hc[hc_num].toggle_in == 0)
+  {
+    pdev->host.hc[hc_num].data_pid = HC_PID_DATA0;
+  }
+  else
+  {
+    pdev->host.hc[hc_num].data_pid = HC_PID_DATA1;
+  }
+
+  /* toggle DATA PID */
+  pdev->host.hc[hc_num].toggle_in ^= 1;  
+  
+  HCD_SubmitRequest (pdev , hc_num);  
+  
+  return USBH_OK;
+}
+
+/**
+  * @brief  USBH_InterruptSendData
+  *         Sends the data on Interrupt OUT Endpoint
+  * @param  pdev: Selected device
+  * @param  buff: Buffer pointer from where the data needs to be copied
+  * @param  length: Length of the data to be sent
+  * @param  hc_num: Host channel Number
+  * @retval Status. 
+  */
+USBH_Status USBH_InterruptSendData( USB_OTG_CORE_HANDLE *pdev, 
+                                uint8_t *buff, 
+                                uint8_t length,
+                                uint8_t hc_num)
+{
+
+  pdev->host.hc[hc_num].ep_is_in = 0;  
+  pdev->host.hc[hc_num].xfer_buff = buff;
+  pdev->host.hc[hc_num].xfer_len = length;
+  
+  if(pdev->host.hc[hc_num].toggle_in == 0)
+  {
+    pdev->host.hc[hc_num].data_pid = HC_PID_DATA0;
+  }
+  else
+  {
+    pdev->host.hc[hc_num].data_pid = HC_PID_DATA1;
+  }
+
+  pdev->host.hc[hc_num].toggle_in ^= 1;  
+  
+  HCD_SubmitRequest (pdev , hc_num);  
+  
+  return USBH_OK;
+}
+
+
+/**
+  * @brief  USBH_SubmitSetupRequest
+  *         Start a setup transfer by changing the state-machine and 
+  *         initializing  the required variables needed for the Control Transfer
+  * @param  pdev: Selected device
+  * @param  setup: Setup Request Structure
+  * @param  buff: Buffer used for setup request
+  * @param  length: Length of the data
+  * @retval Status. 
+*/
+static USBH_Status USBH_SubmitSetupRequest(USBH_HOST *phost,
+                                           uint8_t* buff, 
+                                           uint16_t length)
+{
+  
+  /* Save Global State */
+  phost->gStateBkp =   phost->gState; 
+  
+  /* Prepare the Transactions */
+  phost->gState = HOST_CTRL_XFER;
+  phost->Control.buff = buff; 
+  phost->Control.length = length;
+  phost->Control.state = CTRL_SETUP;  
+
+  return USBH_OK;  
+}
+
+
+/**
+  * @brief  USBH_IsocReceiveData
+  *         Receives the Device Response to the Isochronous IN token
+  * @param  pdev: Selected device
+  * @param  buff: Buffer pointer in which the response needs to be copied
+  * @param  length: Length of the data to be received
+  * @param  hc_num: Host channel Number
+  * @retval Status. 
+  */
+USBH_Status USBH_IsocReceiveData( USB_OTG_CORE_HANDLE *pdev, 
+                                uint8_t *buff, 
+                                uint32_t length,
+                                uint8_t hc_num)
+{    
+  
+  pdev->host.hc[hc_num].ep_is_in = 1;  
+  pdev->host.hc[hc_num].xfer_buff = buff;
+  pdev->host.hc[hc_num].xfer_len = length;
+  pdev->host.hc[hc_num].data_pid = HC_PID_DATA0;
+  
+
+  HCD_SubmitRequest (pdev , hc_num);  
+  
+  return USBH_OK;
+}
+
+/**
+  * @brief  USBH_IsocSendData
+  *         Sends the data on Isochronous OUT Endpoint
+  * @param  pdev: Selected device
+  * @param  buff: Buffer pointer from where the data needs to be copied
+  * @param  length: Length of the data to be sent
+  * @param  hc_num: Host channel Number
+  * @retval Status. 
+  */
+USBH_Status USBH_IsocSendData( USB_OTG_CORE_HANDLE *pdev, 
+                                uint8_t *buff, 
+                                uint32_t length,
+                                uint8_t hc_num)
+{
+  
+  pdev->host.hc[hc_num].ep_is_in = 0;  
+  pdev->host.hc[hc_num].xfer_buff = buff;
+  pdev->host.hc[hc_num].xfer_len = length;
+  pdev->host.hc[hc_num].data_pid = HC_PID_DATA0;
+  
+  HCD_SubmitRequest (pdev , hc_num);  
+  
+  return USBH_OK;
+}
+
+/**
+* @}
+*/ 
+
+/**
+* @}
+*/ 
+
+/**
+* @}
+*/
+
+/**
+* @}
+*/ 
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
+
+
+

--- a/src/lib/usbh_ioreq.h
+++ b/src/lib/usbh_ioreq.h
@@ -1,0 +1,156 @@
+/**
+  ******************************************************************************
+  * @file    usbh_ioreq.h
+  * @author  MCD Application Team
+  * @version V2.1.0
+  * @date    19-March-2012
+  * @brief   Header file for usbh_ioreq.c
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT 2012 STMicroelectronics</center></h2>
+  *
+  * Licensed under MCD-ST Liberty SW License Agreement V2, (the "License");
+  * You may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at:
+  *
+  *        http://www.st.com/software_license_agreement_liberty_v2
+  *
+  * Unless required by applicable law or agreed to in writing, software 
+  * distributed under the License is distributed on an "AS IS" BASIS, 
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  *
+  ******************************************************************************
+  */ 
+
+/* Define to prevent recursive  ----------------------------------------------*/
+#ifndef __USBH_IOREQ_H
+#define __USBH_IOREQ_H
+
+/* Includes ------------------------------------------------------------------*/
+#include "usb_conf.h"
+#include "usbh_core.h"
+#include "usbh_def.h"
+
+/** @addtogroup USBH_LIB
+  * @{
+  */
+
+/** @addtogroup USBH_LIB_CORE
+* @{
+*/
+  
+/** @defgroup USBH_IOREQ
+  * @brief This file is the header file for usbh_ioreq.c
+  * @{
+  */ 
+
+
+/** @defgroup USBH_IOREQ_Exported_Defines
+  * @{
+  */
+#define USBH_SETUP_PKT_SIZE   8
+#define USBH_EP0_EP_NUM       0
+#define USBH_MAX_PACKET_SIZE  0x40
+/**
+  * @}
+  */ 
+
+
+/** @defgroup USBH_IOREQ_Exported_Types
+  * @{
+  */ 
+/**
+  * @}
+  */ 
+
+
+/** @defgroup USBH_IOREQ_Exported_Macros
+  * @{
+  */ 
+/**
+  * @}
+  */ 
+
+/** @defgroup USBH_IOREQ_Exported_Variables
+  * @{
+  */ 
+/**
+  * @}
+  */ 
+
+/** @defgroup USBH_IOREQ_Exported_FunctionsPrototype
+  * @{
+  */
+USBH_Status USBH_CtlSendSetup ( USB_OTG_CORE_HANDLE *pdev, 
+                                uint8_t *buff, 
+                                uint8_t hc_num);
+
+USBH_Status USBH_CtlSendData ( USB_OTG_CORE_HANDLE *pdev, 
+                                uint8_t *buff, 
+                                uint16_t length,
+                                uint8_t hc_num);
+
+USBH_Status USBH_CtlReceiveData( USB_OTG_CORE_HANDLE *pdev, 
+                                uint8_t *buff, 
+                                uint16_t length,
+                                uint8_t hc_num);
+
+USBH_Status USBH_BulkReceiveData( USB_OTG_CORE_HANDLE *pdev, 
+                                uint8_t *buff, 
+                                uint16_t length,
+                                uint8_t hc_num);
+
+USBH_Status USBH_BulkSendData ( USB_OTG_CORE_HANDLE *pdev, 
+                                uint8_t *buff, 
+                                uint16_t length,
+                                uint8_t hc_num);
+
+USBH_Status USBH_InterruptReceiveData( USB_OTG_CORE_HANDLE *pdev, 
+                                       uint8_t             *buff, 
+                                       uint8_t             length,
+                                       uint8_t             hc_num);
+
+USBH_Status USBH_InterruptSendData( USB_OTG_CORE_HANDLE *pdev, 
+                                    uint8_t *buff, 
+                                    uint8_t length,
+                                    uint8_t hc_num);
+
+USBH_Status USBH_CtlReq (USB_OTG_CORE_HANDLE *pdev,
+                         USBH_HOST *phost, 
+                         uint8_t             *buff,
+                         uint16_t            length);
+
+USBH_Status USBH_IsocReceiveData( USB_OTG_CORE_HANDLE *pdev, 
+                                uint8_t *buff, 
+                                uint32_t length,
+                                uint8_t hc_num);
+
+
+USBH_Status USBH_IsocSendData( USB_OTG_CORE_HANDLE *pdev, 
+                                uint8_t *buff, 
+                                uint32_t length,
+                                uint8_t hc_num);
+/**
+  * @}
+  */ 
+
+#endif /* __USBH_IOREQ_H */
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */
+
+/**
+* @}
+*/ 
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
+
+

--- a/src/lib/usbh_stdreq.c
+++ b/src/lib/usbh_stdreq.c
@@ -1,0 +1,607 @@
+/**
+  ******************************************************************************
+  * @file    usbh_stdreq.c 
+  * @author  MCD Application Team
+  * @version V2.1.0
+  * @date    19-March-2012
+  * @brief   This file implements the standard requests for device enumeration
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT 2012 STMicroelectronics</center></h2>
+  *
+  * Licensed under MCD-ST Liberty SW License Agreement V2, (the "License");
+  * You may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at:
+  *
+  *        http://www.st.com/software_license_agreement_liberty_v2
+  *
+  * Unless required by applicable law or agreed to in writing, software 
+  * distributed under the License is distributed on an "AS IS" BASIS, 
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  *
+  ******************************************************************************
+  */ 
+/* Includes ------------------------------------------------------------------*/
+
+#include "usbh_ioreq.h"
+#include "usbh_stdreq.h"
+
+/** @addtogroup USBH_LIB
+* @{
+*/
+
+/** @addtogroup USBH_LIB_CORE
+* @{
+*/
+
+/** @defgroup USBH_STDREQ 
+* @brief This file implements the standard requests for device enumeration
+* @{
+*/
+
+
+/** @defgroup USBH_STDREQ_Private_Defines
+* @{
+*/ 
+/**
+* @}
+*/ 
+
+
+/** @defgroup USBH_STDREQ_Private_TypesDefinitions
+* @{
+*/ 
+/**
+* @}
+*/ 
+
+
+
+/** @defgroup USBH_STDREQ_Private_Macros
+* @{
+*/ 
+/**
+* @}
+*/ 
+
+
+/** @defgroup USBH_STDREQ_Private_Variables
+* @{
+*/
+/**
+* @}
+*/ 
+#ifdef USB_OTG_HS_INTERNAL_DMA_ENABLED
+  #if defined ( __ICCARM__ ) /*!< IAR Compiler */
+    #pragma data_alignment=4   
+  #endif
+#endif /* USB_OTG_HS_INTERNAL_DMA_ENABLED */
+__ALIGN_BEGIN uint8_t          USBH_CfgDesc[512] __ALIGN_END ;
+
+
+/** @defgroup USBH_STDREQ_Private_FunctionPrototypes
+* @{
+*/
+static void USBH_ParseDevDesc (USBH_DevDesc_TypeDef* , uint8_t *buf, uint16_t length);
+
+static void USBH_ParseCfgDesc (USBH_CfgDesc_TypeDef* cfg_desc,
+                               USBH_InterfaceDesc_TypeDef* itf_desc,
+                               USBH_EpDesc_TypeDef  ep_desc[][USBH_MAX_NUM_ENDPOINTS],                                                           
+                               uint8_t *buf, 
+                               uint16_t length);
+
+
+static void USBH_ParseInterfaceDesc (USBH_InterfaceDesc_TypeDef  *if_descriptor, uint8_t *buf);
+static void USBH_ParseEPDesc (USBH_EpDesc_TypeDef  *ep_descriptor, uint8_t *buf);
+
+static void USBH_ParseStringDesc (uint8_t* psrc, uint8_t* pdest, uint16_t length);
+/**
+* @}
+*/ 
+
+
+/** @defgroup USBH_STDREQ_Private_Functions
+* @{
+*/ 
+
+
+/**
+* @brief  USBH_Get_DevDesc
+*         Issue Get Device Descriptor command to the device. Once the response 
+*         received, it parses the device descriptor and updates the status.
+* @param  pdev: Selected device
+* @param  dev_desc: Device Descriptor buffer address
+* @param  pdev->host.Rx_Buffer: Receive Buffer address
+* @param  length: Length of the descriptor
+* @retval Status
+*/
+USBH_Status USBH_Get_DevDesc(USB_OTG_CORE_HANDLE *pdev,
+                             USBH_HOST *phost,
+                             uint8_t length)
+{
+  
+  USBH_Status status;
+  
+  if((status = USBH_GetDescriptor(pdev, 
+                                  phost,
+                                  USB_REQ_RECIPIENT_DEVICE | USB_REQ_TYPE_STANDARD,                          
+                                  USB_DESC_DEVICE, 
+                                  pdev->host.Rx_Buffer,
+                                  length)) == USBH_OK)
+  {
+    /* Commands successfully sent and Response Received */       
+    USBH_ParseDevDesc(&phost->device_prop.Dev_Desc, pdev->host.Rx_Buffer, length);
+  }
+  return status;      
+}
+
+/**
+* @brief  USBH_Get_CfgDesc
+*         Issues Configuration Descriptor to the device. Once the response 
+*         received, it parses the configuartion descriptor and updates the 
+*         status.
+* @param  pdev: Selected device
+* @param  cfg_desc: Configuration Descriptor address
+* @param  itf_desc: Interface Descriptor address
+* @param  ep_desc: Endpoint Descriptor address
+* @param  length: Length of the descriptor
+* @retval Status
+*/
+USBH_Status USBH_Get_CfgDesc(USB_OTG_CORE_HANDLE *pdev, 
+                             USBH_HOST           *phost,                      
+                             uint16_t length)
+
+{
+  USBH_Status status;
+  uint16_t index = 0;
+  
+  if((status = USBH_GetDescriptor(pdev,
+                                  phost,
+                                  USB_REQ_RECIPIENT_DEVICE | USB_REQ_TYPE_STANDARD,                          
+                                  USB_DESC_CONFIGURATION, 
+                                  pdev->host.Rx_Buffer,
+                                  length)) == USBH_OK)
+  {
+    /*save Cfg descriptor for class parsing usage */
+    for( ; index < length ; index ++)
+    {
+      USBH_CfgDesc[index] = pdev->host.Rx_Buffer[index];
+    }
+    
+    /* Commands successfully sent and Response Received  */       
+    USBH_ParseCfgDesc (&phost->device_prop.Cfg_Desc,
+                       phost->device_prop.Itf_Desc,
+                       phost->device_prop.Ep_Desc, 
+                       pdev->host.Rx_Buffer,
+                       length); 
+    
+  }
+  return status;
+}
+
+
+/**
+* @brief  USBH_Get_StringDesc
+*         Issues string Descriptor command to the device. Once the response 
+*         received, it parses the string descriptor and updates the status.
+* @param  pdev: Selected device
+* @param  string_index: String index for the descriptor
+* @param  buff: Buffer address for the descriptor
+* @param  length: Length of the descriptor
+* @retval Status
+*/
+USBH_Status USBH_Get_StringDesc(USB_OTG_CORE_HANDLE *pdev,
+                                USBH_HOST *phost,
+                                uint8_t string_index, 
+                                uint8_t *buff, 
+                                uint16_t length)
+{
+  USBH_Status status;
+  
+  if((status = USBH_GetDescriptor(pdev,
+                                  phost,
+                                  USB_REQ_RECIPIENT_DEVICE | USB_REQ_TYPE_STANDARD,                                    
+                                  USB_DESC_STRING | string_index, 
+                                  pdev->host.Rx_Buffer,
+                                  length)) == USBH_OK)
+  {
+    /* Commands successfully sent and Response Received  */       
+    USBH_ParseStringDesc(pdev->host.Rx_Buffer,buff, length);    
+  }
+  return status;
+}
+
+/**
+* @brief  USBH_GetDescriptor
+*         Issues Descriptor command to the device. Once the response received,
+*         it parses the descriptor and updates the status.
+* @param  pdev: Selected device
+* @param  req_type: Descriptor type
+* @param  value_idx: wValue for the GetDescriptr request
+* @param  buff: Buffer to store the descriptor
+* @param  length: Length of the descriptor
+* @retval Status
+*/
+USBH_Status USBH_GetDescriptor(USB_OTG_CORE_HANDLE *pdev,
+                               USBH_HOST           *phost,                                
+                               uint8_t  req_type,
+                               uint16_t value_idx, 
+                               uint8_t* buff, 
+                               uint16_t length )
+{ 
+  phost->Control.setup.b.bmRequestType = USB_D2H | req_type;
+  phost->Control.setup.b.bRequest = USB_REQ_GET_DESCRIPTOR;
+  phost->Control.setup.b.wValue.w = value_idx;
+  
+  if ((value_idx & 0xff00) == USB_DESC_STRING)
+  {
+    phost->Control.setup.b.wIndex.w = 0x0409;
+  }
+  else
+  {
+    phost->Control.setup.b.wIndex.w = 0;
+  }
+  phost->Control.setup.b.wLength.w = length;           
+  return USBH_CtlReq(pdev, phost, buff , length );     
+}
+
+/**
+* @brief  USBH_SetAddress
+*         This command sets the address to the connected device
+* @param  pdev: Selected device
+* @param  DeviceAddress: Device address to assign
+* @retval Status
+*/
+USBH_Status USBH_SetAddress(USB_OTG_CORE_HANDLE *pdev, 
+                            USBH_HOST *phost,
+                            uint8_t DeviceAddress)
+{
+  phost->Control.setup.b.bmRequestType = USB_H2D | USB_REQ_RECIPIENT_DEVICE | \
+    USB_REQ_TYPE_STANDARD;
+  
+  phost->Control.setup.b.bRequest = USB_REQ_SET_ADDRESS;
+  
+  phost->Control.setup.b.wValue.w = (uint16_t)DeviceAddress;
+  phost->Control.setup.b.wIndex.w = 0;
+  phost->Control.setup.b.wLength.w = 0;
+  
+  return USBH_CtlReq(pdev, phost, 0 , 0 );
+}
+
+/**
+* @brief  USBH_SetCfg
+*         The command sets the configuration value to the connected device
+* @param  pdev: Selected device
+* @param  cfg_idx: Configuration value
+* @retval Status
+*/
+USBH_Status USBH_SetCfg(USB_OTG_CORE_HANDLE *pdev, 
+                        USBH_HOST *phost,
+                        uint16_t cfg_idx)
+{
+  
+  phost->Control.setup.b.bmRequestType = USB_H2D | USB_REQ_RECIPIENT_DEVICE |\
+    USB_REQ_TYPE_STANDARD;
+  phost->Control.setup.b.bRequest = USB_REQ_SET_CONFIGURATION;
+  phost->Control.setup.b.wValue.w = cfg_idx;
+  phost->Control.setup.b.wIndex.w = 0;
+  phost->Control.setup.b.wLength.w = 0;           
+  
+  return USBH_CtlReq(pdev, phost, 0 , 0 );      
+}
+
+/**
+* @brief  USBH_SetInterface
+*         The command sets the Interface value to the connected device
+* @param  pdev: Selected device
+* @param  itf_idx: Interface value
+* @retval Status
+*/
+USBH_Status USBH_SetInterface(USB_OTG_CORE_HANDLE *pdev, 
+                        USBH_HOST *phost,
+                        uint8_t ep_num, uint8_t altSetting)
+{
+  
+  
+  phost->Control.setup.b.bmRequestType = USB_H2D | USB_REQ_RECIPIENT_INTERFACE | \
+    USB_REQ_TYPE_STANDARD;
+  
+  phost->Control.setup.b.bRequest = USB_REQ_SET_INTERFACE;
+  phost->Control.setup.b.wValue.w = altSetting;
+  phost->Control.setup.b.wIndex.w = ep_num;
+  phost->Control.setup.b.wLength.w = 0;           
+ 
+  return USBH_CtlReq(pdev, phost, 0 , 0 );     
+}
+/**
+* @brief  USBH_ClrFeature
+*         This request is used to clear or disable a specific feature.
+
+* @param  pdev: Selected device
+* @param  ep_num: endpoint number 
+* @param  hc_num: Host channel number 
+* @retval Status
+*/
+USBH_Status USBH_ClrFeature(USB_OTG_CORE_HANDLE *pdev,
+                            USBH_HOST *phost,
+                            uint8_t ep_num, 
+                            uint8_t hc_num) 
+{
+  
+  phost->Control.setup.b.bmRequestType = USB_H2D | 
+                                         USB_REQ_RECIPIENT_ENDPOINT |
+                                         USB_REQ_TYPE_STANDARD;
+  
+  phost->Control.setup.b.bRequest = USB_REQ_CLEAR_FEATURE;
+  phost->Control.setup.b.wValue.w = FEATURE_SELECTOR_ENDPOINT;
+  phost->Control.setup.b.wIndex.w = ep_num;
+  phost->Control.setup.b.wLength.w = 0;           
+  
+  if ((ep_num & USB_REQ_DIR_MASK ) == USB_D2H)
+  { /* EP Type is IN */
+    pdev->host.hc[hc_num].toggle_in = 0; 
+  }
+  else
+  {/* EP Type is OUT */
+    pdev->host.hc[hc_num].toggle_out = 0; 
+  }
+  
+  return USBH_CtlReq(pdev, phost, 0 , 0 );   
+}
+
+/**
+* @brief  USBH_ParseDevDesc 
+*         This function Parses the device descriptor
+* @param  dev_desc: device_descriptor destinaton address 
+* @param  buf: Buffer where the source descriptor is available
+* @param  length: Length of the descriptor
+* @retval None
+*/
+static void  USBH_ParseDevDesc (USBH_DevDesc_TypeDef* dev_desc,
+                                uint8_t *buf, 
+                                uint16_t length)
+{
+  dev_desc->bLength            = *(uint8_t  *) (buf +  0);
+  dev_desc->bDescriptorType    = *(uint8_t  *) (buf +  1);
+  dev_desc->bcdUSB             = LE16 (buf +  2);
+  dev_desc->bDeviceClass       = *(uint8_t  *) (buf +  4);
+  dev_desc->bDeviceSubClass    = *(uint8_t  *) (buf +  5);
+  dev_desc->bDeviceProtocol    = *(uint8_t  *) (buf +  6);
+  dev_desc->bMaxPacketSize     = *(uint8_t  *) (buf +  7);
+  
+  if (length > 8)
+  { /* For 1st time after device connection, Host may issue only 8 bytes for 
+    Device Descriptor Length  */
+    dev_desc->idVendor           = LE16 (buf +  8);
+    dev_desc->idProduct          = LE16 (buf + 10);
+    dev_desc->bcdDevice          = LE16 (buf + 12);
+    dev_desc->iManufacturer      = *(uint8_t  *) (buf + 14);
+    dev_desc->iProduct           = *(uint8_t  *) (buf + 15);
+    dev_desc->iSerialNumber      = *(uint8_t  *) (buf + 16);
+    dev_desc->bNumConfigurations = *(uint8_t  *) (buf + 17);
+  }
+}
+
+/**
+* @brief  USBH_ParseCfgDesc 
+*         This function Parses the configuration descriptor
+* @param  cfg_desc: Configuration Descriptor address
+* @param  itf_desc: Interface Descriptor address
+* @param  ep_desc: Endpoint Descriptor address
+* @param  buf: Buffer where the source descriptor is available
+* @param  length: Length of the descriptor
+* @retval None
+*/
+static void  USBH_ParseCfgDesc (USBH_CfgDesc_TypeDef* cfg_desc,
+                                USBH_InterfaceDesc_TypeDef* itf_desc,
+                                USBH_EpDesc_TypeDef   ep_desc[][USBH_MAX_NUM_ENDPOINTS], 
+                                uint8_t *buf, 
+                                uint16_t length)
+{  
+  USBH_InterfaceDesc_TypeDef    *pif ;
+  USBH_InterfaceDesc_TypeDef    temp_pif ;  
+  USBH_EpDesc_TypeDef           *pep;  
+  USBH_DescHeader_t             *pdesc = (USBH_DescHeader_t *)buf;
+  uint16_t                      ptr;
+  int8_t                        if_ix = 0;
+  int8_t                        ep_ix = 0;  
+  static uint16_t               prev_ep_size = 0;
+  static uint8_t                prev_itf = 0;  
+  
+  
+  pdesc   = (USBH_DescHeader_t *)buf;
+  
+  /* Parse configuration descriptor */
+  cfg_desc->bLength             = *(uint8_t  *) (buf + 0);
+  cfg_desc->bDescriptorType     = *(uint8_t  *) (buf + 1);
+  cfg_desc->wTotalLength        = LE16 (buf + 2);
+  cfg_desc->bNumInterfaces      = *(uint8_t  *) (buf + 4);
+  cfg_desc->bConfigurationValue = *(uint8_t  *) (buf + 5);
+  cfg_desc->iConfiguration      = *(uint8_t  *) (buf + 6);
+  cfg_desc->bmAttributes        = *(uint8_t  *) (buf + 7);
+  cfg_desc->bMaxPower           = *(uint8_t  *) (buf + 8);    
+  
+  
+  if (length > USB_CONFIGURATION_DESC_SIZE)
+  {
+    ptr = USB_LEN_CFG_DESC;
+    
+    if ( cfg_desc->bNumInterfaces <= USBH_MAX_NUM_INTERFACES) 
+    {
+      pif = (USBH_InterfaceDesc_TypeDef *)0;
+      
+      while (ptr < cfg_desc->wTotalLength ) 
+      {
+        pdesc = USBH_GetNextDesc((uint8_t *)pdesc, &ptr);
+        if (pdesc->bDescriptorType   == USB_DESC_TYPE_INTERFACE) 
+        {
+          if_ix             = *(((uint8_t *)pdesc ) + 2);
+          pif               = &itf_desc[if_ix];
+          
+          if((*((uint8_t *)pdesc + 3)) < 3)
+          {
+          USBH_ParseInterfaceDesc (&temp_pif, (uint8_t *)pdesc);            
+          ep_ix = 0;
+          
+          /* Parse Ep descriptors relative to the current interface */
+          if(temp_pif.bNumEndpoints <= USBH_MAX_NUM_ENDPOINTS)
+          {          
+            while (ep_ix < temp_pif.bNumEndpoints) 
+            {
+              pdesc = USBH_GetNextDesc((void* )pdesc, &ptr);
+              if (pdesc->bDescriptorType   == USB_DESC_TYPE_ENDPOINT) 
+              {  
+                pep               = &ep_desc[if_ix][ep_ix];
+                
+                if(prev_itf != if_ix)
+                {
+                  prev_itf = if_ix;
+                  USBH_ParseInterfaceDesc (pif, (uint8_t *)&temp_pif); 
+                }
+                else
+                {
+                  if(prev_ep_size > LE16((uint8_t *)pdesc + 4))
+                  {
+                    break;
+                  }
+                  else
+                  {
+                    USBH_ParseInterfaceDesc (pif, (uint8_t *)&temp_pif);    
+                  }
+                }
+                USBH_ParseEPDesc (pep, (uint8_t *)pdesc);
+                prev_ep_size = LE16((uint8_t *)pdesc + 4);
+                ep_ix++;
+              }
+            }
+          }
+         }
+        }
+      }
+    }
+    prev_ep_size = 0;
+    prev_itf = 0; 
+  }  
+}
+
+
+/**
+* @brief  USBH_ParseInterfaceDesc 
+*         This function Parses the interface descriptor
+* @param  if_descriptor : Interface descriptor destination
+* @param  buf: Buffer where the descriptor data is available
+* @retval None
+*/
+static void  USBH_ParseInterfaceDesc (USBH_InterfaceDesc_TypeDef *if_descriptor, 
+                                      uint8_t *buf)
+{
+  if_descriptor->bLength            = *(uint8_t  *) (buf + 0);
+  if_descriptor->bDescriptorType    = *(uint8_t  *) (buf + 1);
+  if_descriptor->bInterfaceNumber   = *(uint8_t  *) (buf + 2);
+  if_descriptor->bAlternateSetting  = *(uint8_t  *) (buf + 3);
+  if_descriptor->bNumEndpoints      = *(uint8_t  *) (buf + 4);
+  if_descriptor->bInterfaceClass    = *(uint8_t  *) (buf + 5);
+  if_descriptor->bInterfaceSubClass = *(uint8_t  *) (buf + 6);
+  if_descriptor->bInterfaceProtocol = *(uint8_t  *) (buf + 7);
+  if_descriptor->iInterface         = *(uint8_t  *) (buf + 8);
+}
+
+/**
+* @brief  USBH_ParseEPDesc 
+*         This function Parses the endpoint descriptor
+* @param  ep_descriptor: Endpoint descriptor destination address
+* @param  buf: Buffer where the parsed descriptor stored
+* @retval None
+*/
+static void  USBH_ParseEPDesc (USBH_EpDesc_TypeDef  *ep_descriptor, 
+                               uint8_t *buf)
+{
+  
+  ep_descriptor->bLength          = *(uint8_t  *) (buf + 0);
+  ep_descriptor->bDescriptorType  = *(uint8_t  *) (buf + 1);
+  ep_descriptor->bEndpointAddress = *(uint8_t  *) (buf + 2);
+  ep_descriptor->bmAttributes     = *(uint8_t  *) (buf + 3);
+  ep_descriptor->wMaxPacketSize   = LE16 (buf + 4);
+  ep_descriptor->bInterval        = *(uint8_t  *) (buf + 6);
+}
+
+/**
+* @brief  USBH_ParseStringDesc 
+*         This function Parses the string descriptor
+* @param  psrc: Source pointer containing the descriptor data
+* @param  pdest: Destination address pointer
+* @param  length: Length of the descriptor
+* @retval None
+*/
+static void USBH_ParseStringDesc (uint8_t* psrc, 
+                                  uint8_t* pdest, 
+                                  uint16_t length)
+{
+  uint16_t strlength;
+  uint16_t idx;
+  
+  /* The UNICODE string descriptor is not NULL-terminated. The string length is
+  computed by substracting two from the value of the first byte of the descriptor.
+  */
+  
+  /* Check which is lower size, the Size of string or the length of bytes read 
+  from the device */
+  
+  if ( psrc[1] == USB_DESC_TYPE_STRING)
+  { /* Make sure the Descriptor is String Type */
+    
+    /* psrc[0] contains Size of Descriptor, subtract 2 to get the length of string */      
+    strlength = ( ( (psrc[0]-2) <= length) ? (psrc[0]-2) :length); 
+    psrc += 2; /* Adjust the offset ignoring the String Len and Descriptor type */
+    
+    for (idx = 0; idx < strlength; idx+=2 )
+    {/* Copy Only the string and ignore the UNICODE ID, hence add the src */
+      *pdest =  psrc[idx];
+      pdest++;
+    }  
+    *pdest = 0; /* mark end of string */  
+  }
+}
+
+/**
+* @brief  USBH_GetNextDesc 
+*         This function return the next descriptor header
+* @param  buf: Buffer where the cfg descriptor is available
+* @param  ptr: data popinter inside the cfg descriptor
+* @retval next header
+*/
+USBH_DescHeader_t  *USBH_GetNextDesc (uint8_t   *pbuf, uint16_t  *ptr)
+{
+  USBH_DescHeader_t  *pnext;
+ 
+  *ptr += ((USBH_DescHeader_t *)pbuf)->bLength;  
+  pnext = (USBH_DescHeader_t *)((uint8_t *)pbuf + \
+         ((USBH_DescHeader_t *)pbuf)->bLength);
+ 
+  return(pnext);
+}
+
+/**
+* @}
+*/ 
+
+/**
+* @}
+*/ 
+
+/**
+* @}
+*/
+
+/**
+* @}
+*/ 
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
+
+
+
+

--- a/src/lib/usbh_stdreq.h
+++ b/src/lib/usbh_stdreq.h
@@ -1,0 +1,161 @@
+/**
+  ******************************************************************************
+  * @file    usbh_stdreq.h
+  * @author  MCD Application Team
+  * @version V2.1.0
+  * @date    19-March-2012
+  * @brief   Header file for usbh_stdreq.c
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT 2012 STMicroelectronics</center></h2>
+  *
+  * Licensed under MCD-ST Liberty SW License Agreement V2, (the "License");
+  * You may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at:
+  *
+  *        http://www.st.com/software_license_agreement_liberty_v2
+  *
+  * Unless required by applicable law or agreed to in writing, software 
+  * distributed under the License is distributed on an "AS IS" BASIS, 
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  *
+  ******************************************************************************
+  */ 
+
+/* Define to prevent recursive  ----------------------------------------------*/
+#ifndef __USBH_STDREQ_H
+#define __USBH_STDREQ_H
+
+/* Includes ------------------------------------------------------------------*/
+#include "usb_conf.h"
+#include "usb_hcd.h"
+#include "usbh_core.h"
+#include "usbh_def.h"
+
+/** @addtogroup USBH_LIB
+  * @{
+  */
+
+/** @addtogroup USBH_LIB_CORE
+* @{
+*/
+  
+/** @defgroup USBH_STDREQ
+  * @brief This file is the 
+  * @{
+  */ 
+
+
+/** @defgroup USBH_STDREQ_Exported_Defines
+  * @{
+  */
+/*Standard Feature Selector for clear feature command*/
+#define FEATURE_SELECTOR_ENDPOINT         0X00
+#define FEATURE_SELECTOR_DEVICE           0X01
+
+
+#define INTERFACE_DESC_TYPE               0x04
+#define ENDPOINT_DESC_TYPE                0x05
+#define INTERFACE_DESC_SIZE               0x09
+
+
+#define USBH_HID_CLASS                    0x03
+
+/**
+  * @}
+  */ 
+
+
+/** @defgroup USBH_STDREQ_Exported_Types
+  * @{
+  */ 
+/**
+  * @}
+  */ 
+
+
+/** @defgroup USBH_STDREQ_Exported_Macros
+  * @{
+  */ 
+/**
+  * @}
+  */ 
+
+/** @defgroup USBH_STDREQ_Exported_Variables
+  * @{
+  */ 
+extern uint8_t USBH_CfgDesc[512];
+/**
+  * @}
+  */ 
+
+/** @defgroup USBH_STDREQ_Exported_FunctionsPrototype
+  * @{
+  */
+USBH_Status USBH_GetDescriptor(USB_OTG_CORE_HANDLE *pdev, 
+                               USBH_HOST           *phost,                                
+                               uint8_t  req_type,
+                               uint16_t value_idx, 
+                               uint8_t* buff, 
+                               uint16_t length );
+
+USBH_Status USBH_Get_DevDesc(USB_OTG_CORE_HANDLE *pdev,
+                             USBH_HOST *phost,
+                             uint8_t length);
+
+USBH_Status USBH_Get_StringDesc(USB_OTG_CORE_HANDLE *pdev, 
+                                USBH_HOST           *phost,                                 
+                                uint8_t string_index, 
+                                uint8_t *buff, 
+                                uint16_t length);
+
+USBH_Status USBH_SetCfg(USB_OTG_CORE_HANDLE *pdev, 
+                        USBH_HOST *phost,
+                        uint16_t configuration_value);
+
+USBH_Status USBH_Get_CfgDesc(USB_OTG_CORE_HANDLE *pdev,
+                             USBH_HOST           *phost,                                 
+                             uint16_t length);
+
+USBH_Status USBH_SetAddress(USB_OTG_CORE_HANDLE *pdev, 
+                            USBH_HOST           *phost,                             
+                            uint8_t DeviceAddress);
+
+USBH_Status USBH_ClrFeature(USB_OTG_CORE_HANDLE *pdev,
+                            USBH_HOST           *phost,                             
+                            uint8_t ep_num, uint8_t hc_num); 
+
+USBH_Status USBH_SetInterface(USB_OTG_CORE_HANDLE *pdev, 
+                        USBH_HOST *phost,
+                        uint8_t ep_num, uint8_t altSetting);
+
+USBH_Status USBH_Issue_ClrFeature(USB_OTG_CORE_HANDLE *pdev, 
+                                  USBH_HOST           *phost, 
+                                  uint8_t ep_num);
+
+USBH_DescHeader_t      *USBH_GetNextDesc (uint8_t   *pbuf, 
+                                                  uint16_t  *ptr);
+/**
+  * @}
+  */ 
+
+#endif /* __USBH_STDREQ_H */
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+
+/**
+* @}
+*/ 
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
+
+

--- a/src/lib/usbh_usr.c
+++ b/src/lib/usbh_usr.c
@@ -1,0 +1,527 @@
+/**
+  ******************************************************************************
+  * @file    usbh_usr.c
+  * @author  MCD Application Team
+  * @version V2.1.0
+  * @date    19-March-2012
+  * @brief   This file includes the user application layer
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT 2012 STMicroelectronics</center></h2>
+  *
+  * Licensed under MCD-ST Liberty SW License Agreement V2, (the "License");
+  * You may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at:
+  *
+  *        http://www.st.com/software_license_agreement_liberty_v2
+  *
+  * Unless required by applicable law or agreed to in writing, software 
+  * distributed under the License is distributed on an "AS IS" BASIS, 
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  *
+  ******************************************************************************
+  */ 
+
+/* Includes ------------------------------------------------------------------*/
+//#include "lcd_log.h"
+#include "usbh_usr.h"
+#include "usbh_hid_mouse.h"
+#include "usbh_hid_gamepad.h"
+#include "usbh_hid_keybd.h"
+#include "stm32f4xx_gpio.h"
+
+/** @addtogroup USBH_USER
+* @{
+*/
+
+/** @addtogroup USBH_HID_DEMO_USER_CALLBACKS
+* @{
+*/
+
+/** @defgroup USBH_USR
+* @brief This file is the Header file for usbh_usr.c
+* @{
+*/ 
+
+
+/** @defgroup USBH_CORE_Exported_TypesDefinitions
+* @{
+*/ 
+#define KYBRD_FIRST_COLUMN               (uint16_t)319
+#define KYBRD_LAST_COLUMN                (uint16_t)7
+#define KYBRD_FIRST_LINE                 (uint8_t)120
+#define KYBRD_LAST_LINE                  (uint8_t)200
+
+////////////////////////////////////////////////
+volatile uint8_t  data_X = 0;
+volatile uint8_t  data_Y = 0;
+volatile uint8_t  data_Button = 0;  
+uint8_t  data_from_keyboard[50];
+volatile uint8_t keyboard_idx=0;
+///////////////////////////////////////////////
+
+__IO uint8_t USBH_Usr_InputDone = 0;
+
+/**
+* @}
+*/ 
+uint8_t  KeybrdCharXpos           = 0;
+uint16_t KeybrdCharYpos           = 0;
+extern  int16_t  x_loc, y_loc; 
+extern __IO int16_t  prev_x, prev_y;
+
+/** @addtogroup USER
+* @{
+*/
+
+/** @defgroup USBH_USR 
+* @brief    This file includes the user application layer
+* @{
+*/ 
+
+/** @defgroup USBH_CORE_Exported_Types
+* @{
+*/ 
+
+
+
+/** @defgroup USBH_USR_Private_Defines
+* @{
+*/ 
+/**
+* @}
+*/ 
+
+
+/** @defgroup USBH_USR_Private_Macros
+* @{
+*/ 
+/**
+* @}
+*/ 
+
+/** @defgroup USBH_USR_Private_Variables
+* @{
+*/
+//extern USB_OTG_CORE_HANDLE           USB_OTG_Core_dev;
+/*  Points to the DEVICE_PROP structure of current device */
+/*  The purpose of this register is to speed up the execution */
+
+USBH_Usr_cb_TypeDef USR_Callbacks =
+{
+  USBH_USR_Init,
+  USBH_USR_DeInit,
+  USBH_USR_DeviceAttached,
+  USBH_USR_ResetDevice,
+  USBH_USR_DeviceDisconnected,
+  USBH_USR_OverCurrentDetected,
+  USBH_USR_DeviceSpeedDetected,
+  USBH_USR_Device_DescAvailable,
+  USBH_USR_DeviceAddressAssigned,
+  USBH_USR_Configuration_DescAvailable,
+  USBH_USR_Manufacturer_String,
+  USBH_USR_Product_String,
+  USBH_USR_SerialNum_String,
+  USBH_USR_EnumerationDone,
+  USBH_USR_UserInput,
+  NULL,
+  USBH_USR_DeviceNotSupported,
+  USBH_USR_UnrecoveredError
+};
+
+/**
+* @}
+*/
+
+/** @defgroup USBH_USR_Private_Constants
+* @{
+*/ 
+/*--------------- LCD Messages ---------------*/
+//const uint8_t MSG_HOST_INIT[]          = "> Host Library Initialized\n";
+//const uint8_t MSG_DEV_ATTACHED[]       = "> Device Attached\n";
+//const uint8_t MSG_DEV_DISCONNECTED[]   = "> Device Disconnected\n";
+//const uint8_t MSG_DEV_ENUMERATED[]     = "> Enumeration completed\n";
+//const uint8_t MSG_DEV_HIGHSPEED[]      = "> High speed device detected\n";
+//const uint8_t MSG_DEV_FULLSPEED[]      = "> Full speed device detected\n";
+//const uint8_t MSG_DEV_LOWSPEED[]       = "> Low speed device detected\n";
+//const uint8_t MSG_DEV_ERROR[]          = "> Device fault \n";
+//
+//const uint8_t MSG_MSC_CLASS[]          = "> Mass storage device connected\n";
+//const uint8_t MSG_HID_CLASS[]          = "> HID device connected\n";
+//
+//const uint8_t USB_HID_MouseStatus[]    = "> HID Demo Device : Mouse\n";
+//const uint8_t USB_HID_KeybrdStatus[]   = "> HID Demo Device : Keyboard\n";
+//const uint8_t MSG_UNREC_ERROR[]        = "> UNRECOVERED ERROR STATE\n";
+/**
+* @}
+*/
+
+
+
+/** @defgroup USBH_USR_Private_FunctionPrototypes
+* @{
+*/ 
+/**
+* @}
+*/ 
+
+
+/** @defgroup USBH_USR_Private_Functions
+* @{
+*/ 
+
+
+
+
+
+/**
+* @brief  USBH_USR_Init 
+*         Displays the message on LCD for host lib initialization
+* @param  None
+* @retval None
+*/
+void USBH_USR_Init(void)
+{
+  static uint8_t startup = 0;  
+    GPIO_InitTypeDef  GPIO_InitStructure;
+  
+  if(startup == 0 )
+  {
+    startup = 1;
+    USBH_Usr_InputDone = 0;
+  /* Enable the GPIO_LED Clock */
+  RCC_AHB1PeriphClockCmd(RCC_AHB1Periph_GPIOD, ENABLE);
+
+  /* Configure the GPIO_LED pin */
+  GPIO_InitStructure.GPIO_Pin = GPIO_Pin_15;
+  GPIO_InitStructure.GPIO_Mode = GPIO_Mode_OUT;
+  GPIO_InitStructure.GPIO_OType = GPIO_OType_PP;
+  GPIO_InitStructure.GPIO_PuPd = GPIO_PuPd_UP;
+  GPIO_InitStructure.GPIO_Speed = GPIO_Speed_50MHz;
+  GPIO_Init(GPIOD, &GPIO_InitStructure);
+    
+
+    /* Configure the LEDs */
+/*
+    STM_EVAL_LEDInit(LED_Green);
+    STM_EVAL_LEDInit(LED_Orange);
+    STM_EVAL_LEDInit(LED_Red); 
+    STM_EVAL_LEDInit(LED_Blue); 
+    
+    STM_EVAL_LEDOn(LED_Green);
+    STM_EVAL_LEDOn(LED_Orange);
+    STM_EVAL_LEDOn(LED_Red);
+    STM_EVAL_LEDOn(LED_Blue);
+    
+    STM_EVAL_PBInit(BUTTON_USER, BUTTON_MODE_GPIO);
+*/
+/*    
+#if defined (USE_STM322xG_EVAL)
+  STM322xG_LCD_Init();
+#elif defined(USE_STM324xG_EVAL)
+  STM324xG_LCD_Init();
+#elif defined (USE_STM3210C_EVAL)
+  STM3210C_LCD_Init();
+#else
+ #error "Missing define: Evaluation board (ie. USE_STM322xG_EVAL)"
+#endif
+
+    LCD_LOG_Init();
+
+#ifdef USE_USB_OTG_HS 
+    LCD_LOG_SetHeader(" USB OTG HS HID Host");
+#else
+    LCD_LOG_SetHeader(" USB OTG FS HID Host");
+#endif
+    LCD_UsrLog("> USB Host library started.\n"); 
+    LCD_LOG_SetFooter ("     USB Host Library v2.1.0" );
+*/    
+  }
+}
+
+/**
+* @brief  USBH_USR_DeviceAttached 
+*         Displays the message on LCD on device attached
+* @param  None
+* @retval None
+*/
+void USBH_USR_DeviceAttached(void)
+{  
+  //LCD_UsrLog ((void*)MSG_DEV_ATTACHED);
+}
+
+/**
+* @brief  USBH_USR_UnrecoveredError
+* @param  None
+* @retval None
+*/
+void USBH_USR_UnrecoveredError (void)
+{
+  //LCD_ErrLog((void*)MSG_UNREC_ERROR);
+}
+
+/**
+* @brief  USBH_DisconnectEvent
+*         Device disconnect event
+* @param  None
+* @retval None
+*/
+void USBH_USR_DeviceDisconnected (void)
+{
+  
+  //LCD_SetBackColor(Black); 
+  //LCD_SetTextColor(Black);   
+  
+  //LCD_LOG_ClearTextZone();
+
+  //LCD_DrawRect(MOUSE_WINDOW_X,
+  //             MOUSE_WINDOW_Y, 
+  //             MOUSE_WINDOW_HEIGHT,
+  //             MOUSE_WINDOW_WIDTH);
+  //LCD_SetTextColor(White);    
+  
+  //LCD_DisplayStringLine( LCD_PIXEL_HEIGHT - 42, "                                   ");
+  //LCD_DisplayStringLine( LCD_PIXEL_HEIGHT - 30, "                                   ");  
+  
+  //LCD_ErrLog((void *)MSG_DEV_DISCONNECTED);
+}
+
+/**
+* @brief  USBH_USR_ResetUSBDevice 
+*         Reset USB Device
+* @param  None
+* @retval None
+*/
+void USBH_USR_ResetDevice(void)
+{
+  /* Users can do their application actions here for the USB-Reset */
+}
+
+
+/**
+* @brief  USBH_USR_DeviceSpeedDetected 
+*         Displays the message on LCD for device speed
+* @param  Devicespeed : Device Speed
+* @retval None
+*/
+void USBH_USR_DeviceSpeedDetected(uint8_t DeviceSpeed)
+{
+//  if(DeviceSpeed == HPRT0_PRTSPD_HIGH_SPEED)
+//  {
+////   LCD_UsrLog((void *)MSG_DEV_HIGHSPEED);
+//  }
+//  else if(DeviceSpeed == HPRT0_PRTSPD_FULL_SPEED)
+//  {
+////LCD_UsrLog((void *)MSG_DEV_FULLSPEED);
+//  }
+//  else if(DeviceSpeed == HPRT0_PRTSPD_LOW_SPEED)
+//  {
+////    LCD_UsrLog((void *)MSG_DEV_LOWSPEED);
+//  }
+//  else
+//  {
+////    LCD_UsrLog((void *)MSG_DEV_ERROR);
+//  }
+}
+
+/**
+* @brief  USBH_USR_Device_DescAvailable 
+*         Displays the message on LCD for device descriptor
+* @param  DeviceDesc : device descriptor
+* @retval None
+*/
+void USBH_USR_Device_DescAvailable(void *DeviceDesc)
+{
+//  uint8_t temp[50];
+//  USBH_DevDesc_TypeDef *hs;
+//  hs = DeviceDesc;
+//
+//
+//  sprintf((char *)temp , "VID : %04Xh\n" , (uint32_t)(*hs).idVendor); /
+//  //LCD_UsrLog((void *)temp);
+//
+//
+//  sprintf((char *)temp , "PID : %04Xh\n" , (uint32_t)(*hs).idProduct);
+//  //LCD_UsrLog((void *)temp);
+}
+
+/**
+* @brief  USBH_USR_DeviceAddressAssigned 
+*         USB device is successfully assigned the Address 
+* @param  None
+* @retval None
+*/
+void USBH_USR_DeviceAddressAssigned(void)
+{
+  
+}
+
+
+/**
+* @brief  USBH_USR_Conf_Desc 
+*         Displays the message on LCD for configuration descriptor
+* @param  ConfDesc : Configuration descriptor
+* @retval None
+*/
+void USBH_USR_Configuration_DescAvailable(USBH_CfgDesc_TypeDef * cfgDesc,
+                                          USBH_InterfaceDesc_TypeDef *itfDesc,
+                                          USBH_EpDesc_TypeDef *epDesc)
+{
+//  USBH_InterfaceDesc_TypeDef *id;
+//
+//  id = itfDesc;
+//
+//  if((*id).bInterfaceClass  == 0x08)
+//  {
+////    LCD_UsrLog((void *)MSG_MSC_CLASS);
+//  }
+//  else if((*id).bInterfaceClass  == 0x03)
+//  {
+////    LCD_UsrLog((void *)MSG_HID_CLASS);
+//  }
+}
+
+/**
+* @brief  USBH_USR_Manufacturer_String 
+*         Displays the message on LCD for Manufacturer String 
+* @param  ManufacturerString : Manufacturer String of Device
+* @retval None
+*/
+void USBH_USR_Manufacturer_String(void *ManufacturerString)
+{
+//  char temp[100];
+//  sprintf(temp, "Manufacturer : %s\n", (char *)ManufacturerString);
+////  LCD_UsrLog((void *)temp);
+  
+}
+
+/**
+* @brief  USBH_USR_Product_String 
+*         Displays the message on LCD for Product String
+* @param  ProductString : Product String of Device
+* @retval None
+*/
+void USBH_USR_Product_String(void *ProductString)
+{
+//  char temp[100];
+//  sprintf((char *)temp, "Product : %s\n", (char *)ProductString);
+////  LCD_UsrLog((void *)temp);
+  
+}
+
+/**
+* @brief  USBH_USR_SerialNum_String 
+*         Displays the message on LCD for SerialNum_String 
+* @param  SerialNumString : SerialNum_String of device
+* @retval None
+*/
+void USBH_USR_SerialNum_String(void *SerialNumString)
+{
+//  uint8_t temp[100];
+//  sprintf((char *)temp, "Serial Number : %s\n", (char *)SerialNumString);
+////  LCD_UsrLog((void *)temp);
+} 
+
+/**
+* @brief  EnumerationDone 
+*         User response request is displayed to ask for
+*         application jump to class
+* @param  None
+* @retval None
+*/
+void USBH_USR_EnumerationDone(void)
+{
+  /* Enumeration complete */
+  //LCD_UsrLog((void *)MSG_DEV_ENUMERATED);
+  //LCD_SetTextColor(Green);
+  //LCD_DisplayStringLine( LCD_PIXEL_HEIGHT - 42, "To start the HID class operations: " );
+  //LCD_DisplayStringLine( LCD_PIXEL_HEIGHT - 30, "Press Key...                       ");
+  //LCD_SetTextColor(LCD_LOG_DEFAULT_COLOR);   
+} 
+
+/**
+* @brief  USBH_USR_DeviceNotSupported
+*         Device is not supported
+* @param  None
+* @retval None
+*/
+void USBH_USR_DeviceNotSupported(void)
+{
+//  LCD_UsrLog ("> Device not supported.\n");              
+  
+}  
+
+
+/**
+* @brief  USBH_USR_UserInput
+*         User Action for application state entry
+* @param  None
+* @retval USBH_USR_Status : User response for key button
+*/
+USBH_USR_Status USBH_USR_UserInput(void)
+{
+  
+  USBH_USR_Status usbh_usr_status;
+  
+  usbh_usr_status = USBH_USR_NO_RESP;  
+
+  GPIOD->BSRRL = GPIO_Pin_15;
+//  STM_EVAL_LEDOn(LED_Blue); // added by "STM32"
+  
+  // commented by "STM32"
+//  /*Key B3 is in polling mode to detect user action */
+//  if(STM_EVAL_PBGetState(Button_WAKEUP) == SET) 
+//  {
+
+  USBH_Usr_InputDone = 1;    
+    usbh_usr_status = USBH_USR_RESP_OK;
+    
+//  }
+  
+  
+  return usbh_usr_status;
+  
+} 
+
+/**
+* @brief  USBH_USR_OverCurrentDetected
+*         Device Overcurrent detection event
+* @param  None
+* @retval None
+*/
+void USBH_USR_OverCurrentDetected (void)
+{
+//   LCD_ErrLog ("Overcurrent detected.\n");
+  
+}
+
+/**
+* @brief  USBH_USR_DeInit
+*         Deint User state and associated variables
+* @param  None
+* @retval None
+*/
+void USBH_USR_DeInit(void)
+{
+}
+
+/**
+* @}
+*/ 
+
+/**
+* @}
+*/ 
+
+/**
+* @}
+*/
+
+/**
+* @}
+*/
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
+

--- a/src/lib/usbh_usr.h
+++ b/src/lib/usbh_usr.h
@@ -1,0 +1,107 @@
+/**
+  ******************************************************************************
+  * @file    usbh_usr.h
+  * @author  MCD Application Team
+  * @version V2.1.0
+  * @date    19-March-2012
+  * @brief   This file is the header file for usb usr file
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT 2012 STMicroelectronics</center></h2>
+  *
+  * Licensed under MCD-ST Liberty SW License Agreement V2, (the "License");
+  * You may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at:
+  *
+  *        http://www.st.com/software_license_agreement_liberty_v2
+  *
+  * Unless required by applicable law or agreed to in writing, software 
+  * distributed under the License is distributed on an "AS IS" BASIS, 
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  *
+  ******************************************************************************
+  */ 
+
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __USH_USR_H__
+#define __USH_USR_H__
+
+
+/* Includes ------------------------------------------------------------------*/
+#include "usbh_core.h"
+#include "usb_conf.h"
+#include <stdio.h>
+
+/** @addtogroup USBH_USER
+* @{
+*/
+
+/** @addtogroup USBH_HID_DEMO_USER_CALLBACKS
+* @{
+*/
+  
+/** @defgroup USBH_USR 
+  * @brief This file is the header file for user action
+  * @{
+  */ 
+
+
+/** @defgroup USBH_CORE_Exported_Variables
+  * @{
+  */ 
+
+
+extern  USBH_Usr_cb_TypeDef USR_Callbacks;
+extern  __IO uint8_t USBH_Usr_InputDone;
+
+/**
+  * @}
+  */ 
+
+
+/** @defgroup USBH_CORE_Exported_FunctionsPrototype
+  * @{
+  */ 
+
+void USBH_USR_ApplicationSelected(void);
+void USBH_USR_Init(void);
+void USBH_USR_DeInit(void);
+void USBH_USR_DeviceAttached(void);
+void USBH_USR_ResetDevice(void);
+void USBH_USR_DeviceDisconnected (void);
+void USBH_USR_OverCurrentDetected (void);
+void USBH_USR_DeviceSpeedDetected(uint8_t DeviceSpeed); 
+void USBH_USR_Device_DescAvailable(void *);
+void USBH_USR_DeviceAddressAssigned(void);
+void USBH_USR_Configuration_DescAvailable(USBH_CfgDesc_TypeDef * cfgDesc,
+                                          USBH_InterfaceDesc_TypeDef *itfDesc,
+                                          USBH_EpDesc_TypeDef *epDesc);
+void USBH_USR_Manufacturer_String(void *);
+void USBH_USR_Product_String(void *);
+void USBH_USR_SerialNum_String(void *);
+void USBH_USR_EnumerationDone(void);
+USBH_USR_Status USBH_USR_UserInput(void);
+void USBH_USR_DeInit(void);
+void USBH_USR_DeviceNotSupported(void);
+void USBH_USR_UnrecoveredError(void);
+/**
+  * @}
+  */ 
+
+#endif /* __USBH_USR_H */
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/src/test_kernel/.gdbinit
+++ b/src/test_kernel/.gdbinit
@@ -1,0 +1,8 @@
+define reload
+kill
+monitor jtag_reset
+load
+end
+
+target extended localhost:4242
+load

--- a/src/test_kernel/main.c
+++ b/src/test_kernel/main.c
@@ -8,10 +8,12 @@ void game_init() {}
 
 void game_frame()
 {
+
     if (PRESSED(up) && y>-240) y--;
     if (PRESSED(down) && y<240) y++;
     if (PRESSED(left) && x>-320) x--;
     if (PRESSED(right) && x<320) x++;
+
 } 
 
 void game_line()
@@ -38,10 +40,21 @@ void game_line()
 		draw_buffer[640-line-i] = (i/4)<<8;
 
 	// display gamepad state as an inverse video point
-	if (line==200+y)
+       
+        if (line == 200) {
+        for (int i=0; i<16; i++)
+          if (gamepad1 & (1 << i)) draw_buffer[320+i]^=0xfff;
+        }
+        	
+        if (line==200+y)
 	{
 		draw_buffer[320+x]^=0xfff;
 	}
+        
+        // if (line == 0) {
+        //  for (int i=0;i<640;i++)
+        //        draw_buffer[i]=0xf0f;
+        // }
 }
 
 void game_sample() {}


### PR DESCRIPTION
Ok, so the bitbox "alive led" interfered with the discovery setup. On the other hand the discovery boards blue led is setup when usb init routine as the code calls USBH_Usr_Init() in usbh_usr.c, an lit by USBH_USR_UserInput() at the end of the device init phase.

I'm also in favor of separating the ST code from bitbox specifics.
