### PR TITLE
new features for the new chiptune engine, plus a bug fix for linux

### DIFF
--- a/lib/StdPeriph/stm32f4xx_gpio.h
+++ b/lib/StdPeriph/stm32f4xx_gpio.h
@@ -35,8 +35,8 @@
 #endif
 
 /* Includes ------------------------------------------------------------------*/
-//#include "stm32f4xx.h"
-#include "../CMSIS/Include/stm32f4xx.h" // XXX Mak absolute path
+#include "stm32f4xx.h"
+//#include "../cmsis/stm32f4xx.h" // XXX Mak absolute path
 
 /** @addtogroup STM32F4xx_StdPeriph_Driver
   * @{

--- a/lib/StdPeriph/stm32f4xx_rcc.h
+++ b/lib/StdPeriph/stm32f4xx_rcc.h
@@ -34,7 +34,8 @@
 #endif
 
 /* Includes ------------------------------------------------------------------*/
-#include "../CMSIS/Include/stm32f4xx.h" // XXX Mak absolute path
+#include "stm32f4xx.h" // requires -I$(BITBOX)/lib/cmsis as in bitbox.mk
+//#include "../cmsis/stm32f4xx.h" // XXX Mak absolute path
 
 /** @addtogroup STM32F4xx_StdPeriph_Driver
   * @{

--- a/lib/chiptune.c
+++ b/lib/chiptune.c
@@ -199,7 +199,7 @@ void chip_note(uint8_t ch, uint8_t note, uint8_t instrument)
 	channel[ch].vdepth = 0;
 }
 
-static void song_update()
+static void chip_song_update()
 // this shall be called each 1/60 sec. 
 // one buffer is 512 samples @32kHz, which is ~ 62.5 Hz,
 // calling each song frame should be OK
@@ -260,7 +260,7 @@ static void song_update()
 	}
 }
 
-static void osc_update()
+static void chip_osc_update()
 {
 	int nchan = current_song->numchannels; // number of channels
 	for(int ch = 0; ch < nchan; ch++) {
@@ -387,9 +387,9 @@ static inline uint16_t gen_sample()
 void game_snd_buffer(uint16_t* buffer, int len) {
 	if (current_song) {
 		if (playsong)
-			song_update();
+			chip_song_update();
 			// even if there's no song, update oscillators in case a "chip_note" gets called.
-		osc_update(); 
+		chip_osc_update(); 
 	}
 	// Just generate enough samples to fill the buffer.
 	for (int i = 0; i < len; i++) {
@@ -397,7 +397,7 @@ void game_snd_buffer(uint16_t* buffer, int len) {
 	}
 }
 
-int chip_over()
+int chip_song_finished()
 {
     return (playsong == 0);
 }

--- a/lib/chiptune.c
+++ b/lib/chiptune.c
@@ -169,6 +169,7 @@ static void runcmd(uint8_t ch, uint8_t cmd, uint8_t param, uint8_t context) {
 void chip_play(const struct ChipSong *song) {
 	current_song = (struct ChipSong*) song;
 	if (!song) { // if given NULL, just stop it now
+		songwait = 0;
 		playsong=0;
 		return;
 	}
@@ -390,3 +391,7 @@ void game_snd_buffer(uint16_t* buffer, int len) {
 	}
 }
 
+int chip_over()
+{
+    return (playsong == 0) && (songwait == 0);
+}

--- a/lib/chiptune.c
+++ b/lib/chiptune.c
@@ -79,8 +79,8 @@ enum {
 	WF_NOI // noise !*@?
 };
 
-// This is the definition of our oscillators. There are 4 of these (2 for left,
-// 2 for right).
+// This is the definition of our oscillators. There are 8 of these (4 for left,
+// 4 for right).
 struct oscillator {
 	uint16_t	freq; // frequency (except for noise, unused)
 	uint16_t	phase; // phase (except for noise, unused)
@@ -169,7 +169,6 @@ static void runcmd(uint8_t ch, uint8_t cmd, uint8_t param, uint8_t context) {
 void chip_play(const struct ChipSong *song) {
 	current_song = (struct ChipSong*) song;
 	if (!song) { // if given NULL, just stop it now
-		songwait = 0;
 		playsong=0;
 		return;
 	}
@@ -180,7 +179,7 @@ void chip_play(const struct ChipSong *song) {
 	songpos = 0;
 	songspeed=4; // default speed
 
-	for (int i=0;i<4;i++) {
+	for (int i=0;i<MAX_CHANNELS;i++) {
 		osc[i].volume = 0;
 		channel[i].inum = 0;
 		osc[i].bitcrush = 5;
@@ -200,7 +199,7 @@ void chip_note(uint8_t ch, uint8_t note, uint8_t instrument)
 	channel[ch].vdepth = 0;
 }
 
-static void chip_update()
+static void song_update()
 // this shall be called each 1/60 sec. 
 // one buffer is 512 samples @32kHz, which is ~ 62.5 Hz,
 // calling each song frame should be OK
@@ -259,7 +258,11 @@ static void chip_update()
 				trackpos = 0;
 		}
 	}
+}
 
+static void osc_update()
+{
+	int nchan = current_song->numchannels; // number of channels
 	for(int ch = 0; ch < nchan; ch++) {
 		int16_t vol;
 		uint16_t duty;
@@ -309,14 +312,11 @@ static void chip_update()
 		osc[ch].duty = duty;
 
 		channel[ch].vpos += channel[ch].vrate;
-
 	}
-
 }
 
 
-
-// This function generates one audio sample for all 4 oscillators. The returned
+// This function generates one audio sample for all 8 oscillators. The returned
 // value is a 2*8bit stereo audio sample ready for putting in the audio buffer.
 static inline uint16_t gen_sample()
 {
@@ -338,7 +338,7 @@ static inline uint16_t gen_sample()
 	acc[0] = 0;
 	acc[1] = 0;
 	// Now compute the value of each oscillator and mix them
-	for(int i = 0; i < 4; i++) {
+	for(int i=0; i<MAX_CHANNELS; i++) {
 		int8_t value; // [-32,31]
 
 		switch(osc[i].waveform) {
@@ -380,11 +380,17 @@ static inline uint16_t gen_sample()
 	}
 	// Now put the two channels together in the output word
 	// acc [-32640,31620] > ret 2*[1,251]
-	return (128 + (acc[0] >> 7)) | ((128 + (acc[1] >> 7)) << 8);	// [1,251]
+	return (128 + (acc[0] >> 8)) | ((128 + (acc[1] >> 8)) << 8);	// [1,251]
+    // was (acc[i] >> 7) for 4 channels, but was clipping for 8 channels.
 }
 
 void game_snd_buffer(uint16_t* buffer, int len) {
-	chip_update();
+	if (current_song) {
+		if (playsong)
+			song_update();
+			// even if there's no song, update oscillators in case a "chip_note" gets called.
+		osc_update(); 
+	}
 	// Just generate enough samples to fill the buffer.
 	for (int i = 0; i < len; i++) {
 		buffer[i] = gen_sample();
@@ -393,5 +399,5 @@ void game_snd_buffer(uint16_t* buffer, int len) {
 
 int chip_over()
 {
-    return (playsong == 0) && (songwait == 0);
+    return (playsong == 0);
 }

--- a/lib/chiptune.h
+++ b/lib/chiptune.h
@@ -59,4 +59,4 @@ void chip_play(const struct ChipSong *song);
 // play a note of this instrument now - useful for FX ! 
 void chip_note(uint8_t ch, uint8_t note, uint8_t instrument);
 
-int chip_song_finished();
+int chip_song_playing();

--- a/lib/chiptune.h
+++ b/lib/chiptune.h
@@ -9,7 +9,7 @@
  * Copyright 2014, Adrien Destugues <pulkomandy@pulkomandy.tk>
  * Copyright 2007, Linus Akesson
  * Based on the "Hardware Chiptune" project */
-
+#pragma once
 #include <stdint.h>
 
 /*
@@ -58,3 +58,5 @@ void chip_play(const struct ChipSong *song);
 
 // play a note of this instrument now - useful for FX ! 
 void chip_note(uint8_t ch, uint8_t note, uint8_t instrument);
+
+int chip_over();

--- a/lib/chiptune.h
+++ b/lib/chiptune.h
@@ -59,4 +59,4 @@ void chip_play(const struct ChipSong *song);
 // play a note of this instrument now - useful for FX ! 
 void chip_note(uint8_t ch, uint8_t note, uint8_t instrument);
 
-int chip_over();
+int chip_song_finished();

--- a/lib/usbh_hid_gamepad.c
+++ b/lib/usbh_hid_gamepad.c
@@ -38,13 +38,14 @@ static const USB_Gamepad_descriptor device_table[] = {
         .button_bit={44,45,46,47,48,49,50,51}
     },
 
-    // SNES Gamepad USB, Ebay
+/*    // SNES Gamepad USB, Ebay
     {
         .vid=0x0079,.pid=0x0011,.pid2=0x0011,.pid3=0x0011,
         .dpad_type=0,.analog_type=2,.max_button_index=7,
         .dpad_bit=0,
         .button_bit={44,45,46,47,48,49,50,51}
     },     
+*/
 
     // PS3 dualshock 3 (info from http://eleccelerator.com/wiki/index.php?title=DualShock_3)
     {


### PR DESCRIPTION
now we can check if the song is still playing (chip_song_playing()), and the header (chiptune.h) has "header guards" (pragma once).  this should allow bbgunner to compile, and i figured out what was weird with the music.

also a bug fix:  since we use a -I$(BITBOX)/lib/cmsis in the bitbox.mk, we don't need to include the relative or absolute path in the include lines in the lib/StdPeriph/stm32f4xx_gpio.h and lib/StdPeriph/stm32f4xx_rcc.h files.

(also, i rebased out the debug stuff, so it's not there.  i've also removed the SNES controller definition which borks things for me.)