### PR TITLE
Added missing implementation of 'graph_line8'

### DIFF
--- a/test_kernel/main.c
+++ b/test_kernel/main.c
@@ -26,6 +26,7 @@ void game_frame()
     }
 } 
 
+void graph_line8(){}
 void graph_frame(){}
 void graph_line()
 // called from VGA kernel


### PR DESCRIPTION
The example would not compile without an implementation of the 'graph_line8' function.