### PR TITLE
Added -dead_strip option for OS X builds (Clang version of -gc-sections)

### DIFF
--- a/lib/bitbox.mk
+++ b/lib/bitbox.mk
@@ -63,7 +63,7 @@ C_OPTS = -std=c99 -g -Wall -ffast-math -fsingle-precision-constant -ffunction-se
 ifneq ($(HOST), Darwin)
   LD_FLAGS = -Wl,--gc-sections
 else
-  LD_FLAGS = 
+  LD_FLAGS = -dead_strip
   $(BITBOX_TGT): LD_FLAGS = -Wl,--gc-sections
 endif
 


### PR DESCRIPTION
This allows all examples to compile out of the box on OS X