### PR TITLE
print_at: return number of printed chars

### DIFF
--- a/lib/bitbox.h
+++ b/lib/bitbox.h
@@ -139,10 +139,16 @@ enum gamepad_buttons_enum {
 #define GAMEPAD_PRESSED(id , key) (gamepad_buttons[id] & (gamepad_##key))
 enum keycodes{
 	KEY_ERR = 0xff,
-	KEY_RIGHT = 128,
-	KEY_LEFT = 129,
-	KEY_DOWN = 130,
-	KEY_UP = 131
+	KEY_INSER = 128,
+	KEY_HOME = 129,
+	KEY_PAGEUP = 130,
+	KEY_DEL = 131,
+	KEY_END = 132,
+	KEY_PAGEDOWN = 133,
+	KEY_RIGHT = 134,
+	KEY_LEFT = 135,
+	KEY_DOWN = 136,
+	KEY_UP = 137
 };
 
 struct event { //should be coded in 32bits

--- a/lib/bitbox_main.c
+++ b/lib/bitbox_main.c
@@ -5,7 +5,6 @@ __attribute__((weak)) int main(void)
 	game_init();
 
 	while (1) {
-		game_frame();
 
 		// wait next frame.
 		#ifndef NO_VGA
@@ -13,6 +12,7 @@ __attribute__((weak)) int main(void)
 		while (oframe==vga_frame);
 		#endif
 
-		set_led(button_state());
+		game_frame();
+		//set_led(button_state());
 	}
 }

--- a/lib/evt_queue.c
+++ b/lib/evt_queue.c
@@ -121,19 +121,22 @@ static const char keyb_en[3][83] = { // normal, shift, ctrl
         'o','p','q','r','s','t','u','v','w','x','y','z','1','2','3','4','5','6',
         '7','8','9','0','\n',0x1B,'\b','\t',' ','-','=','[',']','\\','#',';','\'','`',
         ',','.','/',
-        [79]=KEY_RIGHT,KEY_LEFT,KEY_DOWN,KEY_UP
+        [73]=KEY_INSER,KEY_HOME,KEY_PAGEUP,KEY_DEL,KEY_END,KEY_PAGEDOWN,
+             KEY_RIGHT,KEY_LEFT,KEY_DOWN,KEY_UP
     },{
         ERR,ERR,ERR,ERR,'A','B','C','D','E','F','G','H','I','J','K','L','M','N',
         'O','P','Q','R','S','T','U','V','W','X','Y','Z','!','@','#','$','%','^',
         '&','*','(',')','\n',0x1B,'\b','\t',' ','_','+','{','}','|','#',':','"','~',
         '<','>','?',
-        [79]=KEY_RIGHT,KEY_LEFT,KEY_DOWN,KEY_UP,
+        [73]=KEY_INSER,KEY_HOME,KEY_PAGEUP,KEY_DEL,KEY_END,KEY_PAGEDOWN,
+             KEY_RIGHT,KEY_LEFT,KEY_DOWN,KEY_UP
     },{
         ERR,ERR,ERR,ERR, 1 , 2 , 3 , 4 , 5 , 6 , 7 , 8 , 9 , 10, 11, 12, 13, 14,
          15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26,'1','2','3','4','5','6',
         '7','8','9','0','\n',0x1B,'\b','\t',' ','-','=','[',']','\\',ERR,';','\'','`',
         ',','.','/',
-        [79]=KEY_RIGHT,KEY_LEFT,KEY_DOWN,KEY_UP,
+        [73]=KEY_INSER,KEY_HOME,KEY_PAGEUP,KEY_DEL,KEY_END,KEY_PAGEDOWN,
+             KEY_RIGHT,KEY_LEFT,KEY_DOWN,KEY_UP
     }
 };
 
@@ -143,19 +146,22 @@ static const char keyb_fr[3][83] = { // normal, shift, ctrl - TODO : add right_a
         'o','p','a','r','s','t','u','v','z','x','y','w','&',0xe9,'\"','\'','(','-',
         0xe8,'_',0xe7,0xe0,'\n',0x1B,'\b','\t',' ',')','=','^','$','\\','#','m',0xF9,'~',
         ';',':','!',
-        [79]=KEY_RIGHT,KEY_LEFT,KEY_DOWN,KEY_UP
+        [73]=KEY_INSER,KEY_HOME,KEY_PAGEUP,KEY_DEL,KEY_END,KEY_PAGEDOWN,
+             KEY_RIGHT,KEY_LEFT,KEY_DOWN,KEY_UP
     },{
         ERR,ERR,ERR,ERR,'Q','B','C','D','E','F','G','H','I','J','K','L','?','N',
         'O','P','A','R','S','T','U','V','Z','X','Y','W','1','2','3','4','5','6',
         '7','8','9','0','\n',0x1B,'\b','\t',' ',0xB0,'+',0xa8,0xa3,'*','#','M','%',0xB5,
         '.','/',0xA7,
-        [79]=KEY_RIGHT,KEY_LEFT,KEY_DOWN,KEY_UP,
+        [73]=KEY_INSER,KEY_HOME,KEY_PAGEUP,KEY_DEL,KEY_END,KEY_PAGEDOWN,
+             KEY_RIGHT,KEY_LEFT,KEY_DOWN,KEY_UP
     },{
         ERR,ERR,ERR,ERR, 17, 2 , 3 , 4 , 5 , 6 , 7 , 8 , 9 , 10, 11, 12,',', 14,
          15, 16, 1 , 18, 19, 20, 21, 22, 26, 24, 25, 23,'1','2','3','4','5','6',
         '7','8','9','0','\n',0x1B,'\b','\t',' ','-','=','[',']','\\',ERR,';','\'','`',
          13,'.','/',
-        [79]=KEY_RIGHT,KEY_LEFT,KEY_DOWN,KEY_UP,
+        [73]=KEY_INSER,KEY_HOME,KEY_PAGEUP,KEY_DEL,KEY_END,KEY_PAGEDOWN,
+             KEY_RIGHT,KEY_LEFT,KEY_DOWN,KEY_UP
     }
 };
 

--- a/lib/simple.c
+++ b/lib/simple.c
@@ -483,14 +483,16 @@ void clear()
    #endif
 }
 
-void print_at(int column, int line, const char *msg)
+int print_at(int column, int line, const char *msg)
 {
-	for(int k = 0; msg[k] && (k+column+line*SCREEN_W<SCREEN_H*SCREEN_W); k++) {
+	int k;
+	for(k = 0; msg[k] && (k+column+line*SCREEN_W<SCREEN_H*SCREEN_W); k++) {
 		vram[line][column + k] = msg[k];
 		#ifdef COLOR_TEXT
 		vram_attr[line][column + k] = text_color;
 		#endif
   	}
+	return k;
 }
 
 // draws an empty window at this position, asserts x1<x2 && y1<y2

--- a/lib/simple.h
+++ b/lib/simple.h
@@ -127,7 +127,8 @@ extern uint32_t palette[];
 extern uint8_t text_color;
 #endif
 
-void print_at(int column, int line, const char *msg);
+// Print a string. Returns the number of char actually printed.
+int print_at(int column, int line, const char *msg);
 
 // draws an empty window at this position, asserts x1<x2 && y1<y2
 void window (int x1, int y1, int x2, int y2);


### PR DESCRIPTION
print_at knows the number of printed char, and this can save a call to
strlen. Part of my work to optimize screen redraw in the chiptracker.